### PR TITLE
Make first launch visible: seed toggle position, start expanded

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,14 +64,32 @@ cd pelmet
 swift run
 ```
 
-The toggle and divider appear in your menu bar immediately. Launch-at-login is
-the one feature that needs a real .app bundle:
+The terminal prints a startup banner, the ‹/› toggle appears **next to the
+clock**, and the ╱ divider starts at the left end of your icons. Nothing
+showed up? See [Troubleshooting](#troubleshooting). Launch-at-login is the
+one feature that needs a real .app bundle:
 
 ```bash
 brew install xcodegen
 xcodegen generate
 open Pelmet.xcodeproj   # then build & run with ⌘R
 ```
+
+### Troubleshooting
+
+- **Nothing appeared in the menu bar.** On notched MacBooks, macOS silently
+  hides menu bar items that don't fit — the very problem Pelmet exists to
+  solve — and brand-new items are the first to be swallowed. Quit another
+  menu bar app to free some space, then relaunch Pelmet.
+- **Is it even running?** `swift run` prints a banner once the app is up, and
+  pressing ⌥⌘B flips the chevron between ‹ and ›. No Dock icon or window is
+  normal — Pelmet is a menu-bar-only app.
+- **It quit when I closed the terminal.** Under `swift run` the app belongs to
+  your terminal session; Ctrl-C (or closing the tab) quits it. Build the .app
+  bundle above for a standalone install.
+- **Don't run two copies at once.** Two instances fight over the same status
+  items and saved positions. Quit the first one (right-click the chevron →
+  Quit Pelmet, or Ctrl-C in its terminal).
 
 ## Roadmap
 

--- a/Sources/Pelmet/AppDelegate.swift
+++ b/Sources/Pelmet/AppDelegate.swift
@@ -12,10 +12,40 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         HotkeyManager.shared.onToggle = {
             MenuBarManager.shared.toggle()
         }
-        HotkeyManager.shared.register()
+        let hotkeyRegistered = HotkeyManager.shared.register()
+
+        printStartupBanner(hotkeyRegistered: hotkeyRegistered)
     }
 
     func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
         true
+    }
+
+    /// Terminal feedback for `swift run` users — the only way to tell an
+    /// invisible menu-bar app is alive. A bundled .app has no visible stdout,
+    /// and os.Logger goes to the unified log, not the terminal, so print is
+    /// the right channel for this audience.
+    private func printStartupBanner(hotkeyRegistered: Bool) {
+        var lines = [
+            "Pelmet is running as a menu-bar-only app (no Dock icon, no window).",
+            "  Look for the ‹/› chevron toggle next to the clock; the ╱ divider",
+            "  sits at the left end of your menu bar icons.",
+            hotkeyRegistered
+                ? "  • Click the chevron or press ⌥⌘B to hide/show items."
+                : "  • Click the chevron to hide/show items. (⌥⌘B is unavailable — another app claimed it.)",
+            "  • ⌘-drag icons to the LEFT of ╱ to let Pelmet manage them.",
+        ]
+        if Preferences.autoRehide {
+            lines.append("  • Revealed items re-hide after \(Int(Preferences.rehideDelay)) s (right-click the chevron → Settings).")
+        }
+        lines.append(contentsOf: [
+            "  • Nothing visible? A full menu bar or the notch hides items that don't fit —",
+            "    quit another menu bar app to free space, then relaunch Pelmet.",
+            "  • Ctrl-C here (or closing this terminal) quits Pelmet.",
+        ])
+        print(lines.joined(separator: "\n"))
+        // stdout is block-buffered when redirected (pipe/file); flush so the
+        // banner isn't held back until the app exits.
+        fflush(stdout)
     }
 }

--- a/Sources/Pelmet/HotkeyManager.swift
+++ b/Sources/Pelmet/HotkeyManager.swift
@@ -15,7 +15,9 @@ final class HotkeyManager {
     private let logger = Logger(subsystem: "com.ismatbabirli.Pelmet", category: "HotkeyManager")
 
     /// Registers ⌥⌘B as the global toggle shortcut.
-    func register() {
+    /// - Returns: `true` if the hotkey is live; `false` if installation or
+    ///   registration failed (usually another app already claimed ⌥⌘B).
+    func register() -> Bool {
         var eventType = EventTypeSpec(
             eventClass: OSType(kEventClassKeyboard),
             eventKind: UInt32(kEventHotKeyPressed)
@@ -36,7 +38,7 @@ final class HotkeyManager {
         )
         guard handlerStatus == noErr else {
             logger.error("Failed to install hotkey event handler (OSStatus \(handlerStatus))")
-            return
+            return false
         }
 
         let hotKeyID = EventHotKeyID(signature: fourCharCode("PLMT"), id: 1)
@@ -51,7 +53,9 @@ final class HotkeyManager {
         if hotKeyStatus != noErr {
             // Usually means another app already claimed ⌥⌘B.
             logger.error("Failed to register ⌥⌘B global hotkey (OSStatus \(hotKeyStatus))")
+            return false
         }
+        return true
     }
 
     func unregister() {

--- a/Sources/Pelmet/MenuBarManager.swift
+++ b/Sources/Pelmet/MenuBarManager.swift
@@ -21,6 +21,9 @@ final class MenuBarManager: NSObject {
     /// Large enough to push items past the left screen edge on any display.
     private let collapsedSeparatorLength: CGFloat = 10_000
 
+    private let toggleAutosaveName = "Pelmet_Toggle"
+    private let separatorAutosaveName = "Pelmet_Separator"
+
     // MARK: - State
 
     private(set) var isCollapsed = false
@@ -32,14 +35,20 @@ final class MenuBarManager: NSObject {
     // MARK: - Setup
 
     func setUp() {
+        seedFirstLaunchPositionIfNeeded()
+
         // Creation order matters only for the very first launch;
         // autosaveName persists whatever arrangement the user ⌘-drags into.
         toggleItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
-        toggleItem.autosaveName = "Pelmet_Toggle"
+        toggleItem.autosaveName = toggleAutosaveName
         toggleItem.behavior = []
+        // Assigning autosaveName adopts persisted state, so un-hide AFTER it —
+        // recovers an item ⌘-dragged out of the bar by an earlier build.
+        toggleItem.isVisible = true
 
         separatorItem = NSStatusBar.system.statusItem(withLength: expandedSeparatorLength)
-        separatorItem.autosaveName = "Pelmet_Separator"
+        separatorItem.autosaveName = separatorAutosaveName
+        separatorItem.isVisible = true
 
         if let button = toggleItem.button {
             button.target = self
@@ -54,8 +63,27 @@ final class MenuBarManager: NSObject {
             button.toolTip = "⌘-drag icons to the LEFT of this divider to let Pelmet manage them"
         }
 
-        // Start collapsed so the effect is visible immediately.
-        collapse()
+        // Restore the last collapse state. First launch starts EXPANDED:
+        // collapsing would hide nothing (no icons are managed yet) while
+        // turning the ╱ divider into an invisible 10,000 pt spacer.
+        Preferences.isCollapsed ? collapse() : expand()
+    }
+
+    /// macOS stores each status item's position in UserDefaults under
+    /// "NSStatusItem Preferred Position <autosaveName>" — the distance in
+    /// points from the RIGHT screen edge (larger = further left). Undocumented
+    /// but stable since 10.12; Hidden Bar and Ice rely on it. Without a seed,
+    /// a brand-new item is inserted at the LEFT end of the item area — on
+    /// notched MacBooks exactly the region macOS silently swallows when the
+    /// bar is full, which can make a first launch completely invisible.
+    /// Seeding the toggle next to the clock sidesteps that. The separator is
+    /// deliberately NOT seeded: it must start left of every existing icon so
+    /// that nothing is "managed" (hidden on collapse) until the user opts in
+    /// by ⌘-dragging icons across it.
+    private func seedFirstLaunchPositionIfNeeded() {
+        let key = "NSStatusItem Preferred Position \(toggleAutosaveName)"
+        guard UserDefaults.standard.object(forKey: key) == nil else { return }
+        UserDefaults.standard.set(0, forKey: key)
     }
 
     // MARK: - Public actions
@@ -66,6 +94,7 @@ final class MenuBarManager: NSObject {
 
     func expand() {
         isCollapsed = false
+        Preferences.isCollapsed = false
         separatorItem.length = expandedSeparatorLength
         separatorItem.button?.image = separatorImage()
         updateToggleIcon()
@@ -74,6 +103,7 @@ final class MenuBarManager: NSObject {
 
     func collapse() {
         isCollapsed = true
+        Preferences.isCollapsed = true
         rehideTimer?.invalidate()
         separatorItem.length = collapsedSeparatorLength
         // Hide the divider glyph while it's a giant invisible spacer.

--- a/Sources/Pelmet/Preferences.swift
+++ b/Sources/Pelmet/Preferences.swift
@@ -8,6 +8,14 @@ enum Preferences {
     enum Keys {
         static let autoRehide = "autoRehide"
         static let rehideDelay = "rehideDelay"
+        static let isCollapsed = "isCollapsed"
+    }
+
+    /// Last collapse state, restored at launch. Defaults to expanded so a
+    /// first-time user actually sees the ╱ divider they drag icons against.
+    static var isCollapsed: Bool {
+        get { UserDefaults.standard.bool(forKey: Keys.isCollapsed) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.isCollapsed) }
     }
 
     static var autoRehide: Bool {


### PR DESCRIPTION
## What & why

Running `swift run` produced no visible toggle: macOS inserts brand-new status items at the left end of the menu bar — the notch kill zone on notched MacBooks — and silently hides whatever doesn't fit, even though the app, both items, and the ⌥⌘B hotkey were all working. First launch now seeds the toggle's autosave position next to the clock (separator deliberately unseeded so nothing is "managed" until the user opts in), starts expanded with the collapse state persisted across restarts, defensively un-hides both items, prints a startup banner to the terminal (including whether ⌥⌘B actually registered), and the README replaces the "appears immediately" claim with a Troubleshooting section.

## How I tested it

`swift build` clean; ran the binary from a fresh defaults domain — banner prints, `defaults read Pelmet` shows the seeded `NSStatusItem Preferred Position Pelmet_Toggle` and `isCollapsed`; verified the ‹ chevron appears next to the clock on a notched MacBook Pro 14" and ⌥⌘B/click toggling works.