### PR TITLE
Notch-aware core: detect swallowed icons, seed the divider, bound the spacer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,8 @@ deliberately lightweight — no forms, no committees.
 
 ## Dev setup
 
-You need macOS 13+ and Xcode 15+ (Swift 5.9).
+You need a Swift 6 toolchain — Xcode 16+ or recent Command Line Tools (the
+app itself runs on macOS 13+).
 
 ```bash
 git clone https://github.com/ismatBabirli/pelmet.git
@@ -32,17 +33,22 @@ open Pelmet.xcodeproj   # then build & run with ⌘R
 
 ## Map of the code
 
-Everything lives in `Sources/Pelmet/` — about 350 lines total.
+The app lives in `Sources/Pelmet/`; the pure, unit-tested notch/overflow
+geometry lives in `Sources/PelmetCore/`.
 
 | File | What it does |
 |---|---|
 | `main.swift` | AppKit lifecycle entry point |
 | `AppDelegate.swift` | Boot: accessory policy, manager, hotkey |
-| `MenuBarManager.swift` | Core hide/show logic — the expanding-spacer trick |
+| `MenuBarManager.swift` | Core hide/show logic — the expanding-spacer trick, toggle states, menu |
+| `NotchLayoutMonitor.swift` | Event-driven measurement: when to look at the menu bar layout |
+| `WindowListSource.swift` | The only window-server touchpoint (permission-free metadata) |
+| `StatusItemRescuer.swift` | Safe recreate-at-position for Pelmet's own items |
 | `HotkeyManager.swift` | Carbon global hotkey (⌥⌘B), permission-free |
 | `Preferences.swift` | UserDefaults keys shared between AppKit and SwiftUI |
 | `Settings/SettingsView.swift` | SwiftUI settings form |
 | `Settings/SettingsWindowController.swift` | Hosts the settings window from an accessory app |
+| `../PelmetCore/MenuBarLayoutClassifier.swift` | Pure geometry: which icons is macOS hiding at the notch |
 
 Two ground rules:
 
@@ -62,14 +68,32 @@ No linter is configured — just match the surrounding style:
 
 ## Testing
 
-There's no test suite yet — most of the code is AppKit plumbing that's hard to
-unit test. CI checks that every PR compiles. Before sending a PR, please run
-the manual smoke test:
+The notch/overflow classifier in `PelmetCore` has a Swift Testing suite:
+
+```bash
+swift test
+```
+
+On a machine with only Command Line Tools (no Xcode), the Testing framework
+isn't on the default search path — use:
+
+```bash
+FW=/Library/Developer/CommandLineTools/Library/Developer/Frameworks
+LIB=/Library/Developer/CommandLineTools/Library/Developer/usr/lib
+swift test -Xswiftc -F$FW -Xlinker -F$FW \
+  -Xlinker -rpath -Xlinker $FW -Xlinker -rpath -Xlinker $LIB
+```
+
+The AppKit plumbing is still verified manually. Before sending a PR, please
+run the smoke test:
 
 1. `swift run`
 2. Toggle with a click on ‹ / › and with ⌥⌘B
 3. Open Settings (right-click the toggle), flip the options, relaunch, and
    confirm they persisted
+4. On a notched MacBook with a crowded bar: confirm the +N count appears when
+   expanded icons don't fit, and that right-click → Reset Divider Position
+   brings the ╱ divider back next to the chevron
 
-If your change adds genuinely testable logic, a small XCTest target is very
-welcome.
+If your change adds genuinely testable logic, put it in `PelmetCore` with
+tests alongside.

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:6.0
 import PackageDescription
 
 let package = Package(
@@ -7,9 +7,24 @@ let package = Package(
         .macOS(.v13)
     ],
     targets: [
+        // Pure geometry/classification — no window-server or UI calls,
+        // so the notch-overflow logic stays unit-testable.
+        .target(
+            name: "PelmetCore",
+            path: "Sources/PelmetCore"
+        ),
         .executableTarget(
             name: "Pelmet",
+            dependencies: ["PelmetCore"],
             path: "Sources/Pelmet"
-        )
-    ]
+        ),
+        .testTarget(
+            name: "PelmetCoreTests",
+            dependencies: ["PelmetCore"],
+            path: "Tests/PelmetCoreTests"
+        ),
+    ],
+    // Tools 6.0 is needed for Swift Testing; the app itself stays in the
+    // Swift 5 language mode (no strict-concurrency migration yet).
+    swiftLanguageModes: [.v5]
 )

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ This one hides your menu bar clutter, so nothing disappears behind the MacBook n
 [![CI](https://img.shields.io/github/actions/workflow/status/ismatBabirli/pelmet/ci.yml?branch=main&label=CI)](https://github.com/ismatBabirli/pelmet/actions/workflows/ci.yml)
 -->
 ![macOS 13+](https://img.shields.io/badge/macOS-13%2B-black?logo=apple)
-![Swift 5.9](https://img.shields.io/badge/Swift-5.9-F05138?logo=swift&logoColor=white)
+![Swift 6](https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
 
 <!-- TODO(screenshot): add a short GIF of collapse/expand here once recorded, e.g. docs/demo.gif -->
@@ -29,7 +29,10 @@ This one hides your menu bar clutter, so nothing disappears behind the MacBook n
 On notched MacBooks, macOS silently hides menu bar items that don't fit next to
 the camera housing — no overflow indicator, the icons are just *gone*. Pelmet
 gives you back control: park rarely-used icons behind a divider and summon them
-when you need them.
+when you need them. And when icons *still* don't fit, Pelmet is the only tool
+that tells you — a small **+3** appears next to its chevron, with tips one
+right-click away. No other utility detects this, and Pelmet does it with zero
+permissions.
 
 ## How it works — no private APIs, no permissions
 
@@ -41,18 +44,27 @@ Pelmet places two items in your menu bar:
              separator                    toggle
 ```
 
-- **⌘-drag** any menu bar icon to the **left** of the ╱ separator.
-- When collapsed, Pelmet inflates the separator's width to ~10,000 pt, pushing
-  everything left of it past the screen edge. Expand and they slide back.
+- Pelmet hides everything to the **left** of the ╱ separator — **⌘-drag** the
+  icons you always want visible to its **right**, next to the clock.
+- When collapsed, Pelmet inflates the separator's width (bounded at ~4,000 pt —
+  macOS caps status-item windows near 5,000 pt), pushing everything left of it
+  past the screen edge. Expand and they slide back.
 - This is the same battle-tested technique used by Hidden Bar and Dozer. It
   needs **no** Screen Recording or Accessibility permission.
+- If the expanded icons don't all fit beside the notch, the toggle shows a
+  count (e.g. **› +3**) instead of letting them vanish without a trace.
+  Right-click it for ways to make room. Detection uses only public
+  window-geometry metadata — nothing that prompts for permissions or lights
+  the screen-recording indicator.
 
 ## Usage
 
 | Action | How |
 |---|---|
 | Show/hide managed icons | Click the ‹ / › toggle, or press **⌥⌘B** |
-| Choose which icons are managed | ⌘-drag them left of the ╱ divider |
+| Keep an icon always visible | ⌘-drag it to the **right** of the ╱ divider |
+| See why icons are missing | Hover or right-click the toggle when it shows **+N** |
+| Lost the divider? | Right-click the toggle → Reset Divider Position |
 | Settings (auto-rehide, launch at login) | Right-click the toggle → Settings… |
 | Quit | Right-click the toggle → Quit Pelmet |
 
@@ -66,10 +78,11 @@ cd pelmet
 swift run
 ```
 
-The terminal prints a startup banner, the ‹/› toggle appears **next to the
-clock**, and the ╱ divider starts at the left end of your icons. Nothing
-showed up? See [Troubleshooting](#troubleshooting). Launch-at-login is the
-one feature that needs a real .app bundle:
+The terminal prints a startup banner, and both the ‹/› toggle and the ╱
+divider appear **next to the clock** — always visible, never behind the
+notch. Building needs a Swift 6 toolchain (Xcode 16+ or recent Command Line
+Tools); the app itself runs on macOS 13+. Launch-at-login is the one feature
+that needs a real .app bundle:
 
 ```bash
 brew install xcodegen
@@ -79,10 +92,16 @@ open Pelmet.xcodeproj   # then build & run with ⌘R
 
 ### Troubleshooting
 
-- **Nothing appeared in the menu bar.** On notched MacBooks, macOS silently
-  hides menu bar items that don't fit — the very problem Pelmet exists to
-  solve — and brand-new items are the first to be swallowed. Quit another
-  menu bar app to free some space, then relaunch Pelmet.
+- **Nothing appeared in the menu bar.** Pelmet's toggle and divider are
+  seeded right next to the clock, the last spot macOS swallows, so this
+  should be rare. If your bar is packed edge to edge, quit another menu bar
+  app to free some space, then relaunch Pelmet.
+- **A number like +3 sits next to the chevron.** That many icons don't fit
+  beside the notch, so macOS is hiding them (it never says so itself).
+  Right-click the chevron for tips: ⌘-drag important icons toward the clock,
+  hide expendable ones behind ╱, or quit unused menu bar apps.
+- **I can't find the ╱ divider.** Right-click the chevron → Reset Divider
+  Position brings it back next to the toggle.
 - **Is it even running?** `swift run` prints a banner once the app is up, and
   pressing ⌥⌘B flips the chevron between ‹ and ›. No Dock icon or window is
   normal — Pelmet is a menu-bar-only app.
@@ -107,7 +126,7 @@ The full vision and phased plan live in [PROJECT.md](PROJECT.md).
 
 Pelmet stands on the shoulders of some excellent open-source projects:
 
-- [Ice](https://github.com/jordanbaird/Ice) (MIT) — the most advanced open-source option; its "Ice Bar" panel is the reference for our notch panel
+- [Ice](https://github.com/jordanbaird/Ice) (GPL-3.0) — the most advanced open-source option; its "Ice Bar" panel is the behavior reference for our notch panel (GPL — we reference behavior, never code)
 - [Hidden Bar](https://github.com/dwarvesf/hidden) (MIT) — origin of the expanding-spacer trick
 - [Dozer](https://github.com/Mortennn/Dozer) (MIT)
 

--- a/Sources/Pelmet/AppDelegate.swift
+++ b/Sources/Pelmet/AppDelegate.swift
@@ -58,18 +58,19 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         var lines = [
             "Pelmet is running as a menu-bar-only app (no Dock icon, no window).",
             "  Look for the ‹/› chevron toggle next to the clock; the ╱ divider",
-            "  sits at the left end of your menu bar icons.",
+            "  sits just left of the chevron.",
             hotkeyRegistered
-                ? "  • Click the chevron or press ⌥⌘B to hide/show items."
-                : "  • Click the chevron to hide/show items. (⌥⌘B is unavailable — another app claimed it.)",
-            "  • ⌘-drag icons to the LEFT of ╱ to let Pelmet manage them.",
+                ? "  • Click the chevron or press ⌥⌘B to hide/show icons."
+                : "  • Click the chevron to hide/show icons. (⌥⌘B is unavailable — another app claimed it.)",
+            "  • Pelmet hides everything LEFT of ╱ — ⌘-drag icons you always",
+            "    want visible to its RIGHT, next to the clock.",
         ]
         if Preferences.autoRehide {
-            lines.append("  • Revealed items re-hide after \(Int(Preferences.rehideDelay)) s (right-click the chevron → Settings).")
+            lines.append("  • Revealed icons re-hide after \(Int(Preferences.rehideDelay)) s (right-click the chevron → Settings).")
         }
         lines.append(contentsOf: [
-            "  • Nothing visible? A full menu bar or the notch hides items that don't fit —",
-            "    quit another menu bar app to free space, then relaunch Pelmet.",
+            "  • A number next to the chevron (like +3) means that many icons don't fit",
+            "    beside the notch — right-click the chevron for tips.",
             "  • Ctrl-C here (or closing this terminal) quits Pelmet.",
         ])
         print(lines.joined(separator: "\n"))

--- a/Sources/Pelmet/MenuBarManager.swift
+++ b/Sources/Pelmet/MenuBarManager.swift
@@ -1,4 +1,5 @@
 import AppKit
+import PelmetCore
 
 /// Manages two NSStatusItems:
 ///
@@ -6,11 +7,16 @@ import AppKit
 ///  │  [hidden icons...]  |separator|  [always-visible icons...] [toggle]  clock │
 ///  └───────────────────────────────────────────────────────────────┘
 ///
-/// Anything the user ⌘-drags to the LEFT of the separator is controlled
-/// by Pelmet. When collapsed, the separator's length is inflated to a
-/// huge value, pushing everything left of it off the screen edge —
-/// the same technique used by Hidden Bar / Dozer. No private APIs,
-/// no Screen Recording or Accessibility permission required.
+/// Anything to the LEFT of the separator is controlled by Pelmet. When
+/// collapsed, the separator's length is inflated to push everything left of
+/// it off the screen edge — the same technique used by Hidden Bar / Dozer.
+/// No private APIs, no Screen Recording or Accessibility permission required.
+///
+/// On notched MacBooks, macOS silently refuses to draw status items that
+/// don't fit beside the notch. Pelmet can't force them on screen (nobody
+/// can, without heavy permissions) — but it detects the situation via
+/// NotchLayoutMonitor and says so on the toggle, so an expand that can't
+/// show everything doesn't just look broken.
 final class MenuBarManager: NSObject {
 
     static let shared = MenuBarManager()
@@ -18,8 +24,16 @@ final class MenuBarManager: NSObject {
     // MARK: - Configuration
 
     private let expandedSeparatorLength: CGFloat = 10
-    /// Large enough to push items past the left screen edge on any display.
-    private let collapsedSeparatorLength: CGFloat = 10_000
+
+    /// Collapse works by inflating the separator so items left of it are
+    /// pushed past the screen edge. Bounded because huge lengths misbehave:
+    /// macOS 26.5 silently caps a status item window near 5,000pt (measured
+    /// — a 10,000pt request displaces neighbors by only ~5,000), and Hidden
+    /// Bar saw pathological layout behavior with unbounded values.
+    private var collapsedSeparatorLength: CGFloat {
+        let widestScreen = NSScreen.screens.map(\.frame.width).max() ?? 2_000
+        return max(500, min(widestScreen + 200, 4_000))
+    }
 
     private let toggleAutosaveName = "Pelmet_Toggle"
     private let separatorAutosaveName = "Pelmet_Separator"
@@ -32,64 +46,108 @@ final class MenuBarManager: NSObject {
     private var toggleItem: NSStatusItem!
     private var separatorItem: NSStatusItem!
 
+    /// Latest confirmed layout facts from NotchLayoutMonitor.
+    private var swallowedCount = 0
+    private var separatorSwallowed = false
+
+    private var toggleRescueAttempts = 0
+    private var lastToggleRescue = Date.distantPast
+
     // MARK: - Setup
 
     func setUp() {
-        seedFirstLaunchPositionIfNeeded()
+        seedFirstLaunchPositionsIfNeeded()
 
-        // Creation order matters only for the very first launch;
-        // autosaveName persists whatever arrangement the user ⌘-drags into.
-        toggleItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.squareLength)
+        // variableLength so the "+N" overflow count fits next to the chevron;
+        // with an empty title the width matches the old square item.
+        toggleItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
         toggleItem.autosaveName = toggleAutosaveName
         toggleItem.behavior = []
         // Assigning autosaveName adopts persisted state, so un-hide AFTER it —
         // recovers an item ⌘-dragged out of the bar by an earlier build.
         toggleItem.isVisible = true
+        configureToggleButton(toggleItem)
 
         separatorItem = NSStatusBar.system.statusItem(withLength: expandedSeparatorLength)
         separatorItem.autosaveName = separatorAutosaveName
         separatorItem.isVisible = true
+        configureSeparatorButton(separatorItem)
 
-        if let button = toggleItem.button {
-            button.target = self
-            button.action = #selector(toggleButtonClicked(_:))
-            button.sendAction(on: [.leftMouseUp, .rightMouseUp])
-            button.toolTip = "Pelmet — click to show/hide menu bar items (⌥⌘B)"
+        NotchLayoutMonitor.shared.attach(
+            separator: separatorItem,
+            toggle: toggleItem,
+            isCollapsed: { [weak self] in self?.isCollapsed ?? false }
+        )
+        NotchLayoutMonitor.shared.onConfirmedChange = { [weak self] classification in
+            self?.apply(classification)
         }
 
-        if let button = separatorItem.button {
-            button.image = separatorImage()
-            button.appearsDisabled = true
-            button.toolTip = "⌘-drag icons to the LEFT of this divider to let Pelmet manage them"
+        // Recompute the bounded collapse length when displays change.
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.didChangeScreenParametersNotification,
+            object: nil, queue: .main
+        ) { [weak self] _ in
+            guard let self, self.isCollapsed else { return }
+            self.separatorItem.length = self.collapsedSeparatorLength
         }
 
         // Restore the last collapse state. First launch starts EXPANDED and
-        // STAYS expanded — collapsing would hide nothing (no icons are managed
-        // yet) while turning the ╱ divider into an invisible 10,000 pt spacer.
-        // Auto-rehide follows a user-initiated reveal, NOT this launch restore,
-        // so pass scheduleRehide: false to avoid the app collapsing itself.
+        // STAYS expanded — nothing hides until the user acts. Auto-rehide
+        // follows a user-initiated reveal, NOT this launch restore.
         if Preferences.isCollapsed {
             collapse()
         } else {
             expand(scheduleRehide: false)
         }
+
+        NotchLayoutMonitor.shared.requestMeasurement(reason: .launch)
     }
 
     /// macOS stores each status item's position in UserDefaults under
-    /// "NSStatusItem Preferred Position <autosaveName>" — the distance in
-    /// points from the RIGHT screen edge (larger = further left). Undocumented
-    /// but stable since 10.12; Hidden Bar and Ice rely on it. Without a seed,
-    /// a brand-new item is inserted at the LEFT end of the item area — on
-    /// notched MacBooks exactly the region macOS silently swallows when the
-    /// bar is full, which can make a first launch completely invisible.
-    /// Seeding the toggle next to the clock sidesteps that. The separator is
-    /// deliberately NOT seeded: it must start left of every existing icon so
-    /// that nothing is "managed" (hidden on collapse) until the user opts in
-    /// by ⌘-dragging icons across it.
-    private func seedFirstLaunchPositionIfNeeded() {
-        let key = "NSStatusItem Preferred Position \(toggleAutosaveName)"
-        guard UserDefaults.standard.object(forKey: key) == nil else { return }
-        UserDefaults.standard.set(0, forKey: key)
+    /// "NSStatusItem Preferred Position <autosaveName>" — an order hint where
+    /// smaller = closer to the RIGHT screen edge. Undocumented but stable;
+    /// Hidden Bar and Ice rely on it, and Ice seeds exactly these values.
+    ///
+    /// Without a seed, a brand-new item is inserted at the LEFT end of the
+    /// item area — on notched MacBooks exactly the region macOS silently
+    /// swallows when the bar is full, which made the ╱ divider invisible on
+    /// crowded bars (and a first launch look completely dead). Seeding the
+    /// toggle at 0 and the divider at 1 places both next to the clock, where
+    /// they are always visible. The divider starts with every icon on its
+    /// managed (left) side: nothing hides until the user collapses, and the
+    /// icons to keep visible are ⌘-dragged to the RIGHT of ╱.
+    ///
+    /// Per-key guards make this self-healing: an existing install whose
+    /// divider was never ⌘-dragged (because it was born invisible) has no
+    /// separator key, so the seed applies on the next launch.
+    private func seedFirstLaunchPositionsIfNeeded() {
+        let seeds: [(name: String, position: CGFloat)] = [
+            (toggleAutosaveName, 0),
+            (separatorAutosaveName, 1),
+        ]
+        for seed in seeds {
+            let key = "NSStatusItem Preferred Position \(seed.name)"
+            if UserDefaults.standard.object(forKey: key) == nil {
+                UserDefaults.standard.set(seed.position, forKey: key)
+            }
+        }
+    }
+
+    private func configureToggleButton(_ item: NSStatusItem) {
+        guard let button = item.button else { return }
+        button.target = self
+        button.action = #selector(toggleButtonClicked(_:))
+        button.sendAction(on: [.leftMouseUp, .rightMouseUp])
+        button.imagePosition = .imageLeading
+        button.setAccessibilityLabel("Pelmet")
+    }
+
+    private func configureSeparatorButton(_ item: NSStatusItem) {
+        guard let button = item.button else { return }
+        button.image = separatorImage()
+        button.appearsDisabled = true
+        button.toolTip = "Pelmet hides everything left of this divider — ⌘-drag icons you always want visible to its right."
+        button.setAccessibilityLabel("Pelmet divider")
     }
 
     // MARK: - Public actions
@@ -105,6 +163,7 @@ final class MenuBarManager: NSObject {
         separatorItem.button?.image = separatorImage()
         updateToggleIcon()
         if scheduleRehide { scheduleRehideIfNeeded() }
+        NotchLayoutMonitor.shared.requestMeasurement(reason: .expandSettled)
     }
 
     func collapse() {
@@ -114,7 +173,201 @@ final class MenuBarManager: NSObject {
         separatorItem.length = collapsedSeparatorLength
         // Hide the divider glyph while it's a giant invisible spacer.
         separatorItem.button?.image = nil
+        // A count would now include the icons we intentionally hid — clear
+        // immediately rather than waiting for the next measurement.
+        swallowedCount = 0
+        separatorSwallowed = false
         updateToggleIcon()
+        NotchLayoutMonitor.shared.requestMeasurement(reason: .collapseSettled)
+    }
+
+    // MARK: - Layout monitoring
+
+    private func apply(_ classification: LayoutClassification) {
+        swallowedCount = classification.swallowedCount
+        separatorSwallowed = !isCollapsed && classification.separatorHealth == .swallowed
+        updateToggleIcon()
+
+        if !classification.toggleVisible {
+            rescueToggleIfNeeded()
+        }
+    }
+
+    /// The toggle is the escape hatch — if it ever gets swallowed the user
+    /// has no way back, so it alone is rescued automatically (rate-limited).
+    private func rescueToggleIfNeeded() {
+        guard toggleRescueAttempts < 2,
+              Date().timeIntervalSince(lastToggleRescue) > 60 else { return }
+        toggleRescueAttempts += 1
+        lastToggleRescue = Date()
+
+        if isCollapsed {
+            // Collapsed with an unreachable toggle means locked out: reveal
+            // first so the rescued toggle has somewhere visible to land.
+            expand(scheduleRehide: false)
+        }
+        toggleItem = StatusItemRescuer.recreate(
+            toggleItem,
+            autosaveName: toggleAutosaveName,
+            length: NSStatusItem.variableLength,
+            preferredPosition: 0,
+            configure: { [weak self] item in self?.configureToggleButton(item) }
+        )
+        updateToggleIcon()
+        NotchLayoutMonitor.shared.reattach(separator: separatorItem, toggle: toggleItem)
+    }
+
+    // MARK: - UI plumbing
+
+    @objc private func toggleButtonClicked(_ sender: NSStatusBarButton) {
+        if NSApp.currentEvent?.type == .rightMouseUp {
+            showContextMenu()
+        } else {
+            toggle()
+        }
+    }
+
+    /// State is conveyed by the chevron glyph and a plain-text count ONLY —
+    /// never a colored dot. Small colored dots in the menu bar are macOS
+    /// privacy vocabulary (green = camera, orange = mic, purple = screen
+    /// capture) and a badge in that grammar reads as a recording alarm.
+    private func updateToggleIcon() {
+        guard let button = toggleItem.button else { return }
+
+        let symbol = isCollapsed ? "chevron.left" : "chevron.right"
+        button.image = NSImage(
+            systemSymbolName: symbol,
+            accessibilityDescription: isCollapsed ? "Show hidden icons" : "Hide icons"
+        )
+
+        let showCount = !isCollapsed && swallowedCount > 0
+        if showCount {
+            button.attributedTitle = NSAttributedString(
+                string: "+\(swallowedCount)",
+                attributes: [.font: NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .medium)]
+            )
+        } else {
+            button.attributedTitle = NSAttributedString(string: "")
+        }
+
+        let tooltip: String
+        let accessibilityValue: String
+        if isCollapsed {
+            tooltip = "Pelmet — show hidden icons (⌥⌘B)"
+            accessibilityValue = "Icons hidden"
+        } else if separatorSwallowed {
+            tooltip = "The menu bar is full — Pelmet's divider is hidden by the notch. Right-click for options."
+            accessibilityValue = "Icons shown. The divider is hidden — the menu bar is full."
+        } else if swallowedCount > 0 {
+            tooltip = "\(countPhrase(swallowedCount)) by the notch. Right-click for ways to make room."
+            accessibilityValue = "Icons shown. \(countPhrase(swallowedCount)) by the notch."
+        } else {
+            tooltip = "Pelmet — hide icons (⌥⌘B)"
+            accessibilityValue = "Icons shown"
+        }
+        button.toolTip = tooltip
+        button.setAccessibilityValue(accessibilityValue)
+    }
+
+    private func countPhrase(_ count: Int) -> String {
+        count == 1
+            ? "1 icon doesn't fit and is hidden"
+            : "\(count) icons don't fit and are hidden"
+    }
+
+    private func separatorImage() -> NSImage? {
+        NSImage(systemSymbolName: "line.diagonal", accessibilityDescription: "Pelmet divider")
+    }
+
+    private func showContextMenu() {
+        let menu = NSMenu()
+        menu.autoenablesItems = false
+
+        // Status section — present only when there is something to say
+        // (disabled informational rows, the Wi-Fi-menu pattern).
+        var statusLines: [String] = []
+        if separatorSwallowed {
+            statusLines.append("Pelmet's divider is hidden — the menu bar is full")
+        }
+        if swallowedCount > 0 {
+            let fitPhrase = swallowedCount == 1 ? "1 icon doesn't fit" : "\(swallowedCount) icons don't fit"
+            statusLines.append(
+                isCollapsed
+                    ? "\(fitPhrase) even while collapsed"
+                    : "\(fitPhrase) — hidden by the notch"
+            )
+        }
+        if !statusLines.isEmpty {
+            for line in statusLines {
+                let info = NSMenuItem(title: line, action: nil, keyEquivalent: "")
+                info.isEnabled = false
+                menu.addItem(info)
+            }
+            let hint = NSMenuItem(title: "", action: nil, keyEquivalent: "")
+            hint.isEnabled = false
+            hint.attributedTitle = NSAttributedString(
+                string: "⌘-drag important icons toward the clock,\nor quit unused menu bar apps.",
+                attributes: [
+                    .font: NSFont.systemFont(ofSize: NSFont.smallSystemFontSize),
+                    .foregroundColor: NSColor.secondaryLabelColor,
+                ]
+            )
+            menu.addItem(hint)
+            menu.addItem(.separator())
+        }
+
+        let toggleTitle = isCollapsed ? "Show Hidden Icons" : "Hide Icons"
+        let toggleEntry = NSMenuItem(title: toggleTitle, action: #selector(menuToggle), keyEquivalent: "b")
+        toggleEntry.keyEquivalentModifierMask = [.command, .option]
+        toggleEntry.target = self
+        menu.addItem(toggleEntry)
+
+        menu.addItem(.separator())
+
+        let resetEntry = NSMenuItem(
+            title: "Reset Divider Position",
+            action: #selector(resetDividerPosition),
+            keyEquivalent: ""
+        )
+        resetEntry.target = self
+        menu.addItem(resetEntry)
+
+        let settingsEntry = NSMenuItem(title: "Settings…", action: #selector(openSettings), keyEquivalent: ",")
+        settingsEntry.target = self
+        menu.addItem(settingsEntry)
+
+        menu.addItem(.separator())
+
+        let quitEntry = NSMenuItem(title: "Quit Pelmet", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
+        menu.addItem(quitEntry)
+
+        NotchLayoutMonitor.shared.requestMeasurement(reason: .menuOpened)
+
+        // Standard trick: temporarily attach the menu, click, detach —
+        // keeps left-click free for the toggle action.
+        toggleItem.menu = menu
+        toggleItem.button?.performClick(nil)
+        toggleItem.menu = nil
+    }
+
+    @objc private func menuToggle() { toggle() }
+
+    /// Escape hatch for a divider ⌘-dragged somewhere invisible (under the
+    /// notch, or off among icons the user can't find): recreate it in the
+    /// seeded spot next to the toggle.
+    @objc private func resetDividerPosition() {
+        let wasCollapsed = isCollapsed
+        separatorItem = StatusItemRescuer.recreate(
+            separatorItem,
+            autosaveName: separatorAutosaveName,
+            length: wasCollapsed ? collapsedSeparatorLength : expandedSeparatorLength,
+            preferredPosition: 1,
+            configure: { [weak self] item in self?.configureSeparatorButton(item) }
+        )
+        if wasCollapsed {
+            separatorItem.button?.image = nil
+        }
+        NotchLayoutMonitor.shared.reattach(separator: separatorItem, toggle: toggleItem)
     }
 
     // MARK: - Auto-rehide
@@ -129,57 +382,6 @@ final class MenuBarManager: NSObject {
             self?.collapse()
         }
     }
-
-    // MARK: - UI plumbing
-
-    @objc private func toggleButtonClicked(_ sender: NSStatusBarButton) {
-        if NSApp.currentEvent?.type == .rightMouseUp {
-            showContextMenu()
-        } else {
-            toggle()
-        }
-    }
-
-    private func updateToggleIcon() {
-        let symbol = isCollapsed ? "chevron.left" : "chevron.right"
-        toggleItem.button?.image = NSImage(
-            systemSymbolName: symbol,
-            accessibilityDescription: isCollapsed ? "Show hidden items" : "Hide items"
-        )
-    }
-
-    private func separatorImage() -> NSImage? {
-        NSImage(systemSymbolName: "line.diagonal", accessibilityDescription: "Pelmet divider")
-    }
-
-    private func showContextMenu() {
-        let menu = NSMenu()
-
-        let toggleTitle = isCollapsed ? "Show Hidden Items" : "Hide Items"
-        let toggleEntry = NSMenuItem(title: toggleTitle, action: #selector(menuToggle), keyEquivalent: "b")
-        toggleEntry.keyEquivalentModifierMask = [.command, .option]
-        toggleEntry.target = self
-        menu.addItem(toggleEntry)
-
-        menu.addItem(.separator())
-
-        let settingsEntry = NSMenuItem(title: "Settings…", action: #selector(openSettings), keyEquivalent: ",")
-        settingsEntry.target = self
-        menu.addItem(settingsEntry)
-
-        menu.addItem(.separator())
-
-        let quitEntry = NSMenuItem(title: "Quit Pelmet", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
-        menu.addItem(quitEntry)
-
-        // Standard trick: temporarily attach the menu, click, detach —
-        // keeps left-click free for the toggle action.
-        toggleItem.menu = menu
-        toggleItem.button?.performClick(nil)
-        toggleItem.menu = nil
-    }
-
-    @objc private func menuToggle() { toggle() }
 
     @objc private func openSettings() {
         SettingsWindowController.shared.show()

--- a/Sources/Pelmet/NotchLayoutMonitor.swift
+++ b/Sources/Pelmet/NotchLayoutMonitor.swift
@@ -1,0 +1,184 @@
+import AppKit
+import PelmetCore
+
+/// Watches menu bar layout and reports, with zero permissions, how many
+/// icons macOS is silently hiding at the notch — plus whether Pelmet's own
+/// divider and toggle are visible.
+///
+/// Event-driven only (no polling): measurements run after expand/collapse
+/// settles, on screen-parameter changes, and on workspace events that can
+/// reflow the bar. A classification must repeat in two consecutive
+/// measurements before it is published — single snapshots can be garbage
+/// mid-animation, mid-⌘-drag, or during display transitions.
+///
+/// Occlusion state is deliberately unused: on macOS 26 it reports "occluded"
+/// even for plainly visible status items (verified empirically).
+///
+/// Main-thread only, like the rest of the app: timers and observers are
+/// scheduled on the main run loop.
+final class NotchLayoutMonitor {
+
+    static let shared = NotchLayoutMonitor()
+
+    // MARK: - Published state
+
+    private(set) var confirmed: LayoutClassification?
+    var onConfirmedChange: ((LayoutClassification) -> Void)?
+
+    // MARK: - Wiring
+
+    private weak var separatorItem: NSStatusItem?
+    private weak var toggleItem: NSStatusItem?
+    private var isCollapsed: () -> Bool = { false }
+
+    private var pendingMeasurement: Timer?
+    private var candidate: LayoutClassification.Digest?
+    private var deferredRetries = 0
+    private var observers: [NSObjectProtocol] = []
+
+    enum MeasurementReason {
+        case launch, expandSettled, collapseSettled, screenChanged, workspaceChanged, menuOpened, itemRecreated
+
+        var settleDelay: TimeInterval {
+            switch self {
+            case .launch: return 1.5
+            case .expandSettled, .collapseSettled: return 0.35
+            case .screenChanged: return 1.0
+            case .workspaceChanged: return 1.0
+            case .menuOpened: return 0
+            case .itemRecreated: return 0.5
+            }
+        }
+    }
+
+    func attach(separator: NSStatusItem, toggle: NSStatusItem, isCollapsed: @escaping () -> Bool) {
+        separatorItem = separator
+        toggleItem = toggle
+        self.isCollapsed = isCollapsed
+
+        guard observers.isEmpty else { return }
+        let observe: (NotificationCenter, Notification.Name, MeasurementReason) -> NSObjectProtocol = { center, name, reason in
+            center.addObserver(forName: name, object: nil, queue: .main) { [weak self] _ in
+                self?.requestMeasurement(reason: reason)
+            }
+        }
+        observers = [
+            observe(.default, NSApplication.didChangeScreenParametersNotification, .screenChanged),
+            observe(NSWorkspace.shared.notificationCenter, NSWorkspace.activeSpaceDidChangeNotification, .workspaceChanged),
+            observe(NSWorkspace.shared.notificationCenter, NSWorkspace.didWakeNotification, .workspaceChanged),
+            observe(NSWorkspace.shared.notificationCenter, NSWorkspace.didTerminateApplicationNotification, .workspaceChanged),
+        ]
+    }
+
+    /// Call after a status item is removed and recreated (divider reset):
+    /// the old weak reference dies with the old item.
+    func reattach(separator: NSStatusItem, toggle: NSStatusItem) {
+        separatorItem = separator
+        toggleItem = toggle
+        requestMeasurement(reason: .itemRecreated)
+    }
+
+    // MARK: - Measurement
+
+    func requestMeasurement(reason: MeasurementReason) {
+        // Coalesce: the soonest requested measurement wins.
+        let delay = reason.settleDelay
+        if let pending = pendingMeasurement, pending.isValid,
+           pending.fireDate.timeIntervalSinceNow < delay { return }
+        pendingMeasurement?.invalidate()
+        deferredRetries = 0
+        pendingMeasurement = Timer.scheduledTimer(withTimeInterval: max(delay, 0.01), repeats: false) { [weak self] _ in
+            self?.measureNow()
+        }
+    }
+
+    private func measureNow() {
+        pendingMeasurement = nil
+
+        // Mid-drag (⌘-drag of a status item) layouts are transient garbage.
+        if NSEvent.pressedMouseButtons != 0, deferredRetries < 6 {
+            deferredRetries += 1
+            pendingMeasurement = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) { [weak self] _ in
+                self?.measureNow()
+            }
+            return
+        }
+
+        guard let geometry = currentGeometry() else { return }
+        let rawFrames = WindowListSource.statusItemWindowFrames()
+        guard !rawFrames.isEmpty else { return } // degraded read; keep prior state
+
+        let classification = MenuBarLayoutClassifier.classify(
+            rawItemFrames: rawFrames,
+            ownSeparatorFrame: separatorItem?.button?.window?.frame,
+            ownToggleFrame: toggleItem?.button?.window?.frame,
+            isCollapsed: isCollapsed(),
+            geometry: geometry
+        )
+
+        publish(classification)
+    }
+
+    private func publish(_ classification: LayoutClassification) {
+        let digest = classification.digest
+        if digest == confirmed?.digest {
+            candidate = nil
+            return
+        }
+        if digest == candidate {
+            candidate = nil
+            confirmed = classification
+            if let flag = ProcessInfo.processInfo.environment["PELMET_DEBUG_LAYOUT"] {
+                print("Pelmet layout: swallowed=\(classification.swallowedCount) offscreenLeft=\(classification.offscreenLeftCount) separator=\(classification.separatorHealth) toggleVisible=\(classification.toggleVisible)")
+                if flag == "verbose" {
+                    let sep = separatorItem?.button?.window?.frame ?? .zero
+                    let tog = toggleItem?.button?.window?.frame ?? .zero
+                    print("  own separator=[\(Int(sep.minX)),\(Int(sep.maxX))] toggle=[\(Int(tog.minX)),\(Int(tog.maxX))]")
+                    for item in classification.items where item.visibility != .visible {
+                        print("  \(item.visibility): x=[\(Int(item.frame.minX)),\(Int(item.frame.maxX))] w=\(Int(item.frame.width))")
+                    }
+                }
+                fflush(stdout)
+            }
+            onConfirmedChange?(classification)
+        } else {
+            // New reading — require one confirming measurement before the UI moves.
+            candidate = digest
+            pendingMeasurement?.invalidate()
+            pendingMeasurement = Timer.scheduledTimer(withTimeInterval: 1.0, repeats: false) { [weak self] _ in
+                self?.measureNow()
+            }
+        }
+    }
+
+    private func currentGeometry() -> MenuBarGeometry? {
+        // Warn only about the notched (built-in) display; on every other
+        // display the full bar fits and there is nothing to say. Fall back
+        // to the toggle's screen so collapse bookkeeping still works.
+        let screen = NSScreen.screens.first { $0.safeAreaInsets.top > 0 }
+            ?? toggleItem?.button?.window?.screen
+            ?? NSScreen.main
+        guard let screen else { return nil }
+
+        var notchRect: CGRect?
+        if screen.safeAreaInsets.top > 0,
+           let topLeft = screen.auxiliaryTopLeftArea,
+           let topRight = screen.auxiliaryTopRightArea {
+            notchRect = CGRect(
+                x: topLeft.maxX,
+                y: screen.frame.maxY - screen.safeAreaInsets.top,
+                width: topRight.minX - topLeft.maxX,
+                height: screen.safeAreaInsets.top
+            )
+        }
+
+        let menuBarHeight = toggleItem?.button?.window?.frame.height
+            ?? max(NSStatusBar.system.thickness, screen.safeAreaInsets.top)
+
+        return MenuBarGeometry(
+            screenFrame: screen.frame,
+            notchRect: notchRect,
+            menuBarHeight: menuBarHeight
+        )
+    }
+}

--- a/Sources/Pelmet/Settings/SettingsView.swift
+++ b/Sources/Pelmet/Settings/SettingsView.swift
@@ -12,7 +12,7 @@ struct SettingsView: View {
         Form {
             Section {
                 Label {
-                    Text("⌘-drag menu bar icons to the **left** of the ╱ divider. Pelmet will hide and reveal everything on that side.")
+                    Text("Pelmet hides everything to the **left** of the ╱ divider. ⌘-drag icons you want always visible to its **right**, next to the clock.")
                 } icon: {
                     Image(systemName: "hand.draw")
                         .foregroundStyle(.tint)

--- a/Sources/Pelmet/StatusItemRescuer.swift
+++ b/Sources/Pelmet/StatusItemRescuer.swift
@@ -1,0 +1,36 @@
+import AppKit
+
+/// Moves one of Pelmet's OWN status items by recreating it at a seeded
+/// position — the only sanctioned way to reposition a status item without
+/// the Accessibility permission.
+///
+/// The order of operations is load-bearing:
+///  1. `removeStatusItem` DELETES the "NSStatusItem Preferred Position"
+///     default as a side effect, so the new position must be written AFTER
+///     removal and BEFORE creation (write-then-create is how macOS reads it).
+///  2. `isVisible = false` is never used — it also deletes the default and
+///     loses the position permanently (FB9052637).
+///
+/// Positions are order hints, not coordinates: on a crowded bar macOS packs
+/// items and only preserves relative order (verified empirically), so
+/// callers pass small constants (0 = rightmost, next to the clock).
+enum StatusItemRescuer {
+
+    static func recreate(
+        _ item: NSStatusItem,
+        autosaveName: String,
+        length: CGFloat,
+        preferredPosition: CGFloat,
+        configure: (NSStatusItem) -> Void
+    ) -> NSStatusItem {
+        NSStatusBar.system.removeStatusItem(item)
+        UserDefaults.standard.set(
+            preferredPosition,
+            forKey: "NSStatusItem Preferred Position \(autosaveName)"
+        )
+        let fresh = NSStatusBar.system.statusItem(withLength: length)
+        fresh.autosaveName = autosaveName
+        configure(fresh)
+        return fresh
+    }
+}

--- a/Sources/Pelmet/WindowListSource.swift
+++ b/Sources/Pelmet/WindowListSource.swift
@@ -1,0 +1,37 @@
+import AppKit
+
+/// The only file that talks to the window server. Everything it uses is
+/// public API that requires no permission, triggers no TCC prompt, and never
+/// lights the screen-capture privacy indicator: `CGWindowListCopyWindowInfo`
+/// returns window bounds/level metadata freely (only window *titles* are
+/// gated behind Screen Recording, and Pelmet never reads those).
+enum WindowListSource {
+
+    /// Level 25 is the status-item window level (`NSWindow.Level.statusBar`).
+    private static let statusItemWindowLevel = 25
+
+    /// Frames of every status-item window on all displays, converted to
+    /// AppKit screen coordinates (bottom-left origin). Includes duplicates
+    /// and Pelmet's own items — `MenuBarLayoutClassifier` filters both.
+    static func statusItemWindowFrames() -> [CGRect] {
+        guard
+            let primary = NSScreen.screens.first,
+            let list = CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as? [[String: Any]]
+        else { return [] }
+
+        // CG global coordinates are top-left-origin; x is shared, y flips
+        // around the primary screen's top edge.
+        let primaryMaxY = primary.frame.maxY
+
+        return list.compactMap { info in
+            guard
+                let level = info[kCGWindowLayer as String] as? Int,
+                level == statusItemWindowLevel,
+                let bounds = info[kCGWindowBounds as String] as? [String: CGFloat],
+                let x = bounds["X"], let y = bounds["Y"],
+                let width = bounds["Width"], let height = bounds["Height"]
+            else { return nil }
+            return CGRect(x: x, y: primaryMaxY - y - height, width: width, height: height)
+        }
+    }
+}

--- a/Sources/PelmetCore/MenuBarLayoutClassifier.swift
+++ b/Sources/PelmetCore/MenuBarLayoutClassifier.swift
@@ -1,0 +1,236 @@
+import CoreGraphics
+import Foundation
+
+/// Pure geometry: given raw menu-bar-item window frames and the notch rect,
+/// decide which items macOS is silently refusing to draw.
+///
+/// Everything here is derived from empirical probes on macOS 26.5 (Tahoe),
+/// where the only reliable signal is geometry:
+///  - swallowed items keep window frames that continue under the notch and
+///    past the left screen edge, laid out as if the notch didn't exist;
+///  - `kCGWindowIsOnscreen` is absent without Screen Recording permission;
+///  - `NSWindow.occlusionState` reports "occluded" even for visible items;
+///  - each item can be backed by more than one window: an exact-frame
+///    duplicate (Control Center mirror) and, during layout churn, a stale
+///    ghost offset by ~10–20pt — hence overlap-clustering, not exact dedupe;
+///  - non-item windows can live at the status-item window level (observed:
+///    a 450pt-wide clipboard-manager panel) — hence the width sanity cap;
+///  - when items MOVE (notably: Pelmet's own collapse/expand relocating the
+///    whole managed section), one window of a twin pair can linger at the
+///    old position for minutes with no distinguishing field (alpha, memory,
+///    store type all identical to live windows). These stale twins park in
+///    two signature zones: exactly x == 0 (the item-birth position) and past
+///    the left screen edge (old collapsed-layout positions). Both zones are
+///    excluded from the swallowed count — genuine overflow only reaches
+///    negative x when 15+ icons deep, at which point the on-screen-zone
+///    count is still directionally right.
+public enum ItemVisibility: Equatable {
+    /// Drawn in the menu bar.
+    case visible
+    /// Frame in or left of the notch while the bar is full — macOS gives it
+    /// no space and no indication. The user cannot see or reach it.
+    case swallowedByNotch
+    /// Pushed past the left screen edge by Pelmet's own inflated separator —
+    /// expected and intentional while collapsed.
+    case offscreenLeft
+    /// Almost certainly a stale twin window, not a real icon (see below) —
+    /// never counted.
+    case suspectedGhost
+}
+
+public struct ClassifiedItem: Equatable {
+    public let frame: CGRect
+    public let visibility: ItemVisibility
+
+    public init(frame: CGRect, visibility: ItemVisibility) {
+        self.frame = frame
+        self.visibility = visibility
+    }
+}
+
+public enum SeparatorHealth: Equatable {
+    case visible
+    case swallowed
+    /// Collapsed (glyph hidden by design) or measurement unavailable.
+    case unknown
+}
+
+/// Inputs are all in AppKit screen coordinates (bottom-left origin).
+public struct MenuBarGeometry: Equatable {
+    public let screenFrame: CGRect
+    /// nil on screens without a camera housing.
+    public let notchRect: CGRect?
+    /// Height of the menu bar band at the top of `screenFrame`.
+    public let menuBarHeight: CGFloat
+
+    public init(screenFrame: CGRect, notchRect: CGRect?, menuBarHeight: CGFloat) {
+        self.screenFrame = screenFrame
+        self.notchRect = notchRect
+        self.menuBarHeight = menuBarHeight
+    }
+
+    /// The horizontal strip status items live in on this screen.
+    public var band: CGRect {
+        CGRect(
+            x: screenFrame.minX - 10_000, // pushed items keep band-height frames far past the edge
+            y: screenFrame.maxY - menuBarHeight - 2,
+            width: screenFrame.width + 20_000,
+            height: menuBarHeight + 4
+        )
+    }
+}
+
+public struct LayoutClassification: Equatable {
+    public let items: [ClassifiedItem]
+    public let separatorHealth: SeparatorHealth
+    public let toggleVisible: Bool
+
+    public var swallowedCount: Int {
+        items.filter { $0.visibility == .swallowedByNotch }.count
+    }
+
+    public var offscreenLeftCount: Int {
+        items.filter { $0.visibility == .offscreenLeft }.count
+    }
+
+    /// The fields user-facing state hangs off; two consecutive measurements
+    /// must agree on this before the UI reacts (transient-noise guard).
+    public struct Digest: Equatable {
+        public let swallowedCount: Int
+        public let separatorHealth: SeparatorHealth
+        public let toggleVisible: Bool
+    }
+
+    public var digest: Digest {
+        Digest(swallowedCount: swallowedCount, separatorHealth: separatorHealth, toggleVisible: toggleVisible)
+    }
+}
+
+public enum MenuBarLayoutClassifier {
+
+    /// Wider than any plausible status item; filters panels that share the
+    /// status window level (and Pelmet's own inflated separator, if its
+    /// frames ever slip past exclusion).
+    public static let maxPlausibleItemWidth: CGFloat = 300
+
+    /// Two frames whose x-ranges overlap by more than this fraction of the
+    /// narrower one are the same item (mirror or mid-layout ghost).
+    static let overlapDedupeFraction: CGFloat = 0.4
+
+    static let frameMatchTolerance: CGFloat = 1.5
+
+    public static func classify(
+        rawItemFrames: [CGRect],
+        ownSeparatorFrame: CGRect?,
+        ownToggleFrame: CGRect?,
+        isCollapsed: Bool,
+        geometry: MenuBarGeometry
+    ) -> LayoutClassification {
+        let band = geometry.band
+        let ownFrames = [ownSeparatorFrame, ownToggleFrame].compactMap { $0 }
+
+        let candidates = rawItemFrames.filter { frame in
+            band.contains(CGPoint(x: frame.midX, y: frame.midY))
+                && frame.width > 4 && frame.width <= maxPlausibleItemWidth
+                && !ownFrames.contains(where: { matches($0, frame) })
+        }
+
+        let deduped = dedupe(candidates)
+
+        let items = deduped.map { frame in
+            ClassifiedItem(
+                frame: frame,
+                visibility: visibility(
+                    of: frame,
+                    isCollapsed: isCollapsed,
+                    separatorFrame: ownSeparatorFrame,
+                    geometry: geometry
+                )
+            )
+        }
+
+        let separatorHealth: SeparatorHealth
+        if isCollapsed {
+            separatorHealth = .unknown
+        } else if let sep = ownSeparatorFrame {
+            separatorHealth = isSwallowed(sep, geometry: geometry) ? .swallowed : .visible
+        } else {
+            separatorHealth = .unknown
+        }
+
+        let toggleVisible: Bool
+        if let toggle = ownToggleFrame {
+            toggleVisible = !isSwallowed(toggle, geometry: geometry)
+                && toggle.maxX <= geometry.screenFrame.maxX + frameMatchTolerance
+        } else {
+            toggleVisible = false
+        }
+
+        return LayoutClassification(
+            items: items,
+            separatorHealth: separatorHealth,
+            toggleVisible: toggleVisible
+        )
+    }
+
+    // MARK: - Internals
+
+    private static func visibility(
+        of frame: CGRect,
+        isCollapsed: Bool,
+        separatorFrame: CGRect?,
+        geometry: MenuBarGeometry
+    ) -> ItemVisibility {
+        if isCollapsed, let sep = separatorFrame, frame.maxX <= sep.minX + 2 {
+            return .offscreenLeft
+        }
+        if abs(frame.minX - 0) < 0.5 {
+            // Exactly x == 0 is the item-birth position — a stale twin left
+            // behind when an item was created and immediately moved. Real
+            // packed items land at arbitrary offsets, not exactly 0.
+            return .suspectedGhost
+        }
+        if frame.maxX <= geometry.screenFrame.minX {
+            // Past the left edge. While collapsed that's our own doing even
+            // when the separator frame was unreadable; while expanded these
+            // are overwhelmingly stale twins parked at old collapsed-layout
+            // positions (verified: an ordinary expand leaves the previous
+            // collapse's mirror windows lingering there).
+            return isCollapsed ? .offscreenLeft : .suspectedGhost
+        }
+        if isSwallowed(frame, geometry: geometry) {
+            return .swallowedByNotch
+        }
+        return .visible
+    }
+
+    private static func isSwallowed(_ frame: CGRect, geometry: MenuBarGeometry) -> Bool {
+        guard let notch = geometry.notchRect else { return false }
+        // Items never render in or left of the notch; a band frame there is
+        // invisible. Small inset absorbs frames that merely kiss the edge.
+        return frame.intersects(notch.insetBy(dx: 2, dy: 0)) || frame.maxX <= notch.minX + 2
+    }
+
+    private static func matches(_ a: CGRect, _ b: CGRect) -> Bool {
+        abs(a.minX - b.minX) <= frameMatchTolerance && abs(a.width - b.width) <= frameMatchTolerance
+    }
+
+    /// Cluster frames whose x-ranges substantially overlap and keep one per
+    /// cluster. Adjacent distinct items never overlap; mirrors overlap fully
+    /// and mid-layout ghosts by half or more.
+    static func dedupe(_ frames: [CGRect]) -> [CGRect] {
+        let sorted = frames.sorted { $0.minX < $1.minX }
+        var result: [CGRect] = []
+        for frame in sorted {
+            if let last = result.last {
+                let overlap = min(last.maxX, frame.maxX) - max(last.minX, frame.minX)
+                let narrower = min(last.width, frame.width)
+                if overlap > narrower * overlapDedupeFraction {
+                    continue
+                }
+            }
+            result.append(frame)
+        }
+        return result
+    }
+}

--- a/Tests/PelmetCoreTests/MenuBarLayoutClassifierTests.swift
+++ b/Tests/PelmetCoreTests/MenuBarLayoutClassifierTests.swift
@@ -1,0 +1,238 @@
+import Testing
+@testable import PelmetCore
+import CoreGraphics
+
+/// Fixture geometry and frames are real values captured by the probe
+/// harness on a notched 14" MacBook Pro running macOS 26.5 (Tahoe):
+/// screen 1512×982, notch x∈[663, 848], menu bar band 33pt at y=949.
+struct MenuBarLayoutClassifierTests {
+
+    private let geometry = MenuBarGeometry(
+        screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+        notchRect: CGRect(x: 663, y: 950, width: 185, height: 32),
+        menuBarHeight: 33
+    )
+
+    private func bar(_ minX: CGFloat, _ width: CGFloat) -> CGRect {
+        CGRect(x: minX, y: 949, width: width, height: 33)
+    }
+
+    // MARK: - Swallowed detection (expanded)
+
+    @Test func testExpandedOverflowCountsUnderAndLeftOfNotch() {
+        let raw = [
+            bar(900, 40),   // visible, right of notch
+            bar(1000, 40),  // visible
+            bar(700, 46),   // under the notch
+            bar(472, 46),   // left of the notch
+        ]
+        let result = MenuBarLayoutClassifier.classify(
+            rawItemFrames: raw,
+            ownSeparatorFrame: bar(1170, 26),
+            ownToggleFrame: bar(1198, 38),
+            isCollapsed: false,
+            geometry: geometry
+        )
+        #expect(result.swallowedCount == 2)
+        #expect(result.offscreenLeftCount == 0)
+        #expect(result.separatorHealth == .visible)
+        #expect(result.toggleVisible)
+    }
+
+    // MARK: - Stale twin windows (Tahoe leaves them at old positions)
+
+    @Test func testExpandedNegativeXWindowsAreGhostsNotSwallowed() {
+        // After an ordinary expand, the previous collapse's mirror windows
+        // linger past the left screen edge for minutes.
+        let raw = [bar(-926, 45), bar(-444, 31), bar(700, 46)]
+        let result = MenuBarLayoutClassifier.classify(
+            rawItemFrames: raw,
+            ownSeparatorFrame: bar(1170, 26),
+            ownToggleFrame: bar(1198, 38),
+            isCollapsed: false,
+            geometry: geometry
+        )
+        #expect(result.swallowedCount == 1)
+        #expect(result.items.filter { $0.visibility == .suspectedGhost }.count == 2)
+    }
+
+    @Test func testBirthPositionWindowAtExactlyZeroIsGhost() {
+        // Items are born at x == 0 and immediately move to their seeded
+        // position; the birth twin can stay behind.
+        let raw = [bar(0, 26), bar(0, 56), bar(700, 46)]
+        let result = MenuBarLayoutClassifier.classify(
+            rawItemFrames: raw,
+            ownSeparatorFrame: bar(1170, 26),
+            ownToggleFrame: bar(1198, 38),
+            isCollapsed: false,
+            geometry: geometry
+        )
+        #expect(result.swallowedCount == 1)
+        // The two overlapping birth twins dedupe to one entry first.
+        #expect(result.items.filter { $0.visibility == .suspectedGhost }.count == 1)
+    }
+
+    @Test func testAllVisibleWhenBarFits() {
+        let raw = [bar(900, 40), bar(1000, 40), bar(1100, 40)]
+        let result = MenuBarLayoutClassifier.classify(
+            rawItemFrames: raw,
+            ownSeparatorFrame: bar(1170, 26),
+            ownToggleFrame: bar(1198, 38),
+            isCollapsed: false,
+            geometry: geometry
+        )
+        #expect(result.swallowedCount == 0)
+        #expect(result.items.allSatisfy { $0.visibility == .visible })
+    }
+
+    // MARK: - Collapsed state
+
+    @Test func testCollapsedManagedItemsAreOffscreenLeftNotSwallowed() {
+        // Separator inflated: frame observed at x=-2818, width 4016.
+        let separator = CGRect(x: -2818, y: 949, width: 4016, height: 33)
+        let raw = [
+            bar(-2864, 46), // managed, pushed past the left edge — expected
+            bar(900, 40),   // always-visible icon
+        ]
+        let result = MenuBarLayoutClassifier.classify(
+            rawItemFrames: raw,
+            ownSeparatorFrame: separator,
+            ownToggleFrame: bar(1198, 38),
+            isCollapsed: true,
+            geometry: geometry
+        )
+        #expect(result.swallowedCount == 0)
+        #expect(result.offscreenLeftCount == 1)
+        #expect(result.separatorHealth == .unknown)
+    }
+
+    @Test func testCollapsedStillOverflowingCountsUnmanagedUnderNotch() {
+        let separator = CGRect(x: -2818, y: 949, width: 4016, height: 33)
+        let raw = [
+            bar(-2864, 46), // managed
+            bar(700, 40),   // unmanaged icon that STILL doesn't fit collapsed
+        ]
+        let result = MenuBarLayoutClassifier.classify(
+            rawItemFrames: raw,
+            ownSeparatorFrame: separator,
+            ownToggleFrame: bar(1198, 38),
+            isCollapsed: true,
+            geometry: geometry
+        )
+        #expect(result.swallowedCount == 1)
+        #expect(result.offscreenLeftCount == 1)
+    }
+
+    // MARK: - Own-item handling
+
+    @Test func testOwnFramesAreExcludedFromTheCount() {
+        let separatorFrame = bar(700, 26) // divider itself swallowed
+        let result = MenuBarLayoutClassifier.classify(
+            rawItemFrames: [separatorFrame, bar(1198, 38), bar(900, 40)],
+            ownSeparatorFrame: separatorFrame,
+            ownToggleFrame: bar(1198, 38),
+            isCollapsed: false,
+            geometry: geometry
+        )
+        #expect(result.swallowedCount == 0)
+        #expect(result.separatorHealth == .swallowed)
+    }
+
+    @Test func testToggleUnderNotchReportsNotVisible() {
+        let result = MenuBarLayoutClassifier.classify(
+            rawItemFrames: [bar(900, 40)],
+            ownSeparatorFrame: bar(660, 26),
+            ownToggleFrame: bar(700, 38),
+            isCollapsed: false,
+            geometry: geometry
+        )
+        #expect(!(result.toggleVisible))
+        #expect(result.separatorHealth == .swallowed)
+    }
+
+    // MARK: - Dedupe (Tahoe double windows and mid-layout ghosts)
+
+    @Test func testExactDuplicateFramesCollapseToOne() {
+        let result = MenuBarLayoutClassifier.classify(
+            rawItemFrames: [bar(700, 46), bar(700, 46)],
+            ownSeparatorFrame: bar(1170, 26),
+            ownToggleFrame: bar(1198, 38),
+            isCollapsed: false,
+            geometry: geometry
+        )
+        #expect(result.swallowedCount == 1)
+    }
+
+    @Test func testGhostPairOffsetByHalfWidthCollapsesToOne() {
+        // Observed on Tahoe during layout churn: the same item backed by two
+        // windows offset ~13pt ([854,886] and [867,899]).
+        let result = MenuBarLayoutClassifier.classify(
+            rawItemFrames: [bar(854, 32), bar(867, 32)],
+            ownSeparatorFrame: bar(1170, 26),
+            ownToggleFrame: bar(1198, 38),
+            isCollapsed: false,
+            geometry: geometry
+        )
+        #expect(result.items.count == 1)
+    }
+
+    @Test func testAdjacentDistinctItemsAreNotMerged() {
+        let result = MenuBarLayoutClassifier.classify(
+            rawItemFrames: [bar(854, 32), bar(886, 38)],
+            ownSeparatorFrame: bar(1170, 26),
+            ownToggleFrame: bar(1198, 38),
+            isCollapsed: false,
+            geometry: geometry
+        )
+        #expect(result.items.count == 2)
+    }
+
+    // MARK: - Non-item windows at the status level
+
+    @Test func testOversizedPanelInTheBandIsIgnored() {
+        // Observed on Tahoe: a 450pt-wide clipboard-manager window at the
+        // status-item window level.
+        let result = MenuBarLayoutClassifier.classify(
+            rawItemFrames: [bar(1062, 450), bar(700, 40)],
+            ownSeparatorFrame: bar(1170, 26),
+            ownToggleFrame: bar(1198, 38),
+            isCollapsed: false,
+            geometry: geometry
+        )
+        #expect(result.items.count == 1)
+        #expect(result.swallowedCount == 1)
+    }
+
+    @Test func testWindowsOutsideTheMenuBarBandAreIgnored() {
+        let floatingPanel = CGRect(x: 700, y: 400, width: 40, height: 33)
+        let result = MenuBarLayoutClassifier.classify(
+            rawItemFrames: [floatingPanel],
+            ownSeparatorFrame: bar(1170, 26),
+            ownToggleFrame: bar(1198, 38),
+            isCollapsed: false,
+            geometry: geometry
+        )
+        #expect(result.items.count == 0)
+    }
+
+    // MARK: - No notch
+
+    @Test func testNoNotchNeverReportsSwallowed() {
+        let flat = MenuBarGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+            notchRect: nil,
+            menuBarHeight: 24
+        )
+        let raw = [CGRect(x: 700, y: 957, width: 40, height: 24)]
+        let result = MenuBarLayoutClassifier.classify(
+            rawItemFrames: raw,
+            ownSeparatorFrame: CGRect(x: 1170, y: 957, width: 26, height: 24),
+            ownToggleFrame: CGRect(x: 1198, y: 957, width: 38, height: 24),
+            isCollapsed: false,
+            geometry: flat
+        )
+        #expect(result.swallowedCount == 0)
+        #expect(result.separatorHealth == .visible)
+        #expect(result.toggleVisible)
+    }
+}

--- a/project.yml
+++ b/project.yml
@@ -5,9 +5,23 @@ options:
     macOS: "13.0"
 
 targets:
+  # Pure geometry/classification, mirrored from Package.swift so
+  # `import PelmetCore` resolves in the Xcode build too.
+  PelmetCore:
+    type: library.static
+    platform: macOS
+    sources:
+      - Sources/PelmetCore
+    settings:
+      base:
+        MACOSX_DEPLOYMENT_TARGET: "13.0"
+        SWIFT_VERSION: "5.0"
+
   Pelmet:
     type: application
     platform: macOS
+    dependencies:
+      - target: PelmetCore
     sources:
       - Sources/Pelmet
       - Resources/Assets.xcassets
@@ -27,7 +41,8 @@ targets:
         PRODUCT_BUNDLE_IDENTIFIER: com.ismatbabirli.Pelmet
         ASSETCATALOG_COMPILER_APPICON_NAME: AppIcon
         MACOSX_DEPLOYMENT_TARGET: "13.0"
-        SWIFT_VERSION: "5.9"
+        # Swift 5 language mode, matching Package.swift's swiftLanguageModes.
+        SWIFT_VERSION: "5.0"
         ENABLE_HARDENED_RUNTIME: true
         # App Sandbox intentionally OFF for now; distribute outside
         # the Mac App Store (GitHub Releases + Homebrew cask).


### PR DESCRIPTION
## Problem

On notched MacBooks (screenshots in the linked feedback):

1. Expanding on a crowded bar looked broken — macOS silently gives no space to status items that would land at/left of the notch, so some icons never came back.
2. The ╱ divider was invisible — created unseeded, it was born at the far left of the status area, exactly the region the notch swallows first, so users couldn't find it or learn ⌘-drag.
3. A red warning dot (from a discarded experimental build) read as the macOS screen-recording indicator.

## What changed

**Divider seeding (root-cause fix for the invisible ╱).** Both items are seeded next to the clock: toggle at Preferred Position 0, divider at 1 — Ice's recipe. Existing installs whose divider was never dragged self-heal on next launch (no saved position → seed applies); a user-placed divider is untouched (verified). The model flips across all copy: *⌘-drag icons you want always visible to the RIGHT of ╱*. A **Reset Divider Position** menu action recreates a lost divider next to the chevron (remove → rewrite position default → recreate; the default is deleted by removal, so order is load-bearing).

**Zero-permission notch detection (fix for "expand looks broken").**
- `WindowListSource` — the only window-server touchpoint: `CGWindowListCopyWindowInfo` layer-25 bounds. Public metadata; no TCC prompt, no purple recording indicator (verified by repeated live runs).
- `PelmetCore/MenuBarLayoutClassifier` — new pure target: classifies every item frame against the notch rect (`NSScreen` safe-area APIs). Handles Tahoe's double windows per item (overlap-clustering dedupe), non-item panels at the status window level (width cap), and stale twin windows that linger at x==0 and past the left screen edge after items move (ghost filtering).
- `NotchLayoutMonitor` — event-driven measurements only (launch, expand/collapse settle, screen changes, workspace events; no polling), two consecutive agreeing snapshots before the UI reacts, measurements deferred while the mouse is down (mid-⌘-drag).

**The affordance (replaces the red dot).** When expanded icons don't fit, the toggle shows a plain-text count — `› +3` — in template rendering. Never a colored dot: small colored dots in the menu bar are macOS privacy vocabulary (camera/mic/screen). Tooltip explains; right-click menu carries the status lines and remedy hints. VoiceOver value carries the same state.

**Bounded collapse spacer.** `max(500, min(widest screen + 200, 4000))` replaces 10,000 — measured on macOS 26.5: status item windows silently cap near 5,000pt, so 10,000 already behaved as 5,000. Recomputed on display changes.

## Empirical grounding

Design decisions were probe-verified on a notched 14" MBP running macOS 26.5 before implementation: swallowed items keep frames laid out under/past the notch (geometry is reliable); `NSWindow.occlusionState` reports "occluded" for plainly visible status items (unusable); our own `windowNumber` is synthetic and absent from the CG list (frame-matching used instead); Preferred Position is an order hint, not a coordinate (seeds use small constants).

## Testing

- `swift test`: 14 Swift Testing cases for the classifier with probe-derived fixtures (tools bumped to 6.0, Swift 5 language mode kept; CLT-only invocation documented in CONTRIBUTING).
- Live verification on the notched machine: fresh first launch shows ╱ and ‹› next to the clock; expanded state reported `+2` matching the visually missing icons; collapse hid 14 managed items (classified `offscreenLeft`, not warned); migration and Reset flows verified; `PELMET_DEBUG_LAYOUT=1` env var prints confirmed measurements for debugging.
- Not verified locally: the XcodeGen path (`project.yml` gained a PelmetCore static-library target; no Xcode on this machine — please smoke-test `xcodegen generate` + build when convenient).

## Zero-permission audit

No new APIs beyond CG window metadata and NSScreen geometry. No Screen Recording, no Accessibility, no private SPIs (Ice/Thaw are GPL — behaviors referenced, no code).