### PR TITLE
The Shelf: make menu bar icons hidden by the notch reachable

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,6 +99,11 @@ run the smoke test:
 4. On a notched MacBook with a crowded bar: confirm the +N count appears when
    expanded icons don't fit, and that right-click → Reset Divider Position
    brings the ╱ divider back next to the chevron
+5. If you touched the Shelf or the activation engine, run through
+   [docs/shelf-verification.md](docs/shelf-verification.md). The opt-in
+   Accessibility path (one-click activation) must be tested with a **bundled
+   `.app`** — TCC keys the permission to the code signature, so `swift run`
+   grants are unreliable across rebuilds.
 
 If your change adds genuinely testable logic, put it in `PelmetCore` with
 tests alongside.

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -68,11 +68,44 @@ Pelmet occupies a deliberate position in that landscape:
 
 *Goal: the beautiful, actionable answer to the notch.*
 
-- A **floating frosted panel** that slides out below the notch (or below the toggle on external displays), rendering the hidden icons live via **ScreenCaptureKit**
-- **Click forwarding** with CGEvent: click an icon in the Shelf, its real menu opens
-- Opt-in Screen Recording permission with a plain-language explanation screen; the app remains fully functional without it (falls back to Phase 0 behavior)
-- Configurable trigger: click, hover, hotkey, or notch-tap
-- Appearance options: blur material, rounded corners, light/dark, reduce-transparency support
+A **floating frosted panel** below the notch listing exactly the icons macOS
+hid, opened by clicking the "+N" count (or ⌥⌘N). Two tiers, degrading
+gracefully:
+
+- **Tier 0 — permission-free.** Rows render as the owning app's icon + name
+  (via `NSRunningApplication`), never captured pixels. On macOS ≤ 15 owners
+  come free from `CGWindowListCopyWindowInfo`; on macOS 26 Tahoe — where
+  Control Center re-parents every status-item window — rows honestly show as
+  "Hidden item N" until the user opts into Tier 1. Clicking a row brings the
+  owning app forward and offers the opt-in.
+- **Tier 1 — opt-in Accessibility.** One toggle enables reading which app
+  owns each item (restoring identity on Tahoe) and **single-click activation**
+  of the real item via synthetic events, with a make-room/drag-to-expose
+  fallback for items in the notch dead zone. Plain-language consent; never
+  reads the screen; fully degradable — turn it off and Tier 0 keeps working.
+
+> **Why not ScreenCaptureKit?** The original spec captured live item pixels.
+> Verified dead end (mid-2026): Screen Recording brings recurring
+> re-approval prompts and a permanent purple indicator, the capture APIs are
+> obsoleted (the maintained Ice fork resorts to a private, leaking SkyLight
+> call), and it contradicts Pelmet's permission-free positioning. An
+> **Accessibility-first** design (proven by MenuDown, ChocolateBar) is the
+> trust-preserving answer.
+
+- Interaction: always-visible "+N" indicator → click-to-open (hover is a
+  later opt-in accelerator, never the only path); single-click activation;
+  never auto-reorders the main bar; real buttons for VoiceOver + keyboard nav.
+- Appearance: `NSVisualEffectView` blur, rounded corners, respects Reduce
+  Transparency / Reduce Motion. Enabled on the notched built-in display.
+
+> **macOS 27 "Golden Gate" (ships ~Sept 2026)** adds a native overflow button
+> and merges all status items into a single window, breaking the expanding-
+> spacer mechanic and per-item detection every manager relies on. Pelmet's
+> engine already degrades to a frames-only honest state via a runtime
+> re-parenting heuristic (the same tripwire that handles Tahoe); a dedicated
+> macOS 27 compatibility pass is its own follow-up. The Shelf's audience
+> until then is the large Sequoia/Tahoe installed base, which gets nothing
+> native.
 
 ### ⚡ Phase 3 — Actionable Power Features
 
@@ -97,6 +130,7 @@ Pelmet occupies a deliberate position in that landscape:
 ## 5. Non-Goals
 
 - **No menu bar "styling"** (tints, borders) in early phases — Ice does this well; we stay focused
+- **No Screen Recording, ever** — the Shelf renders app icons/names, not captured pixels; the purple indicator and re-approval nags are exactly what users flee
 - **No Mac App Store initially** — the sandbox is incompatible with the Shelf; direct + Homebrew distribution instead
 - **No analytics, no accounts, no network calls** except Sparkle update checks
 
@@ -105,10 +139,11 @@ Pelmet occupies a deliberate position in that landscape:
 | Area | Choice |
 |---|---|
 | Language / UI | Swift 5.9+, SwiftUI for windows, AppKit for menu bar machinery |
-| Minimum macOS | 13 Ventura (phases 0–1); Shelf may require 14 for ScreenCaptureKit APIs |
+| Minimum macOS | 13 Ventura (all phases) |
 | Hide mechanism | `NSStatusItem` expanding spacer (no private APIs) |
-| Shelf rendering | ScreenCaptureKit capture of the hidden menu bar region |
-| Click forwarding | CGEvent synthesis at real item coordinates |
+| Shelf rendering | App icon + name from `NSRunningApplication` (no screen capture) |
+| Item identity | `CGWindowListCopyWindowInfo` owner PID (≤ Sequoia); `kAXExtrasMenuBarAttribute` sweep (Tahoe, opt-in Accessibility) |
+| Click forwarding | Synthetic `CGEvent` at real item coordinates + drag-to-expose fallback (opt-in Accessibility) |
 | Hotkeys | Carbon `RegisterEventHotKey` (permission-free) |
 | Updates | Sparkle 2 |
 | CI/CD | GitHub Actions: build → sign → notarize → release |

--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ open Pelmet.xcodeproj   # then build & run with ⌘R
 
 ## Roadmap
 
-- [ ] **Notch panel** — a blurred, rounded panel below the notch that shows hidden icons live and forwards clicks (opt-in Screen Recording)
+- [x] **The Shelf** — a blurred, rounded panel below the notch listing the icons macOS hid, opened by clicking the count (or ⌥⌘N). Rows show each item's app icon and name — **never a screen capture**, so no Screen Recording permission and no purple recording dot.
+- [x] **One-click access** — an *opt-in* Accessibility toggle that opens hidden items with a single click (and identifies them on macOS 26 Tahoe). Off by default; everything else works without it.
 - [ ] Show on hover — reveal when the pointer touches the menu bar
 - [ ] Profiles and per-item rules (e.g. "presentation mode")
 - [ ] Custom hotkey recorder (replace the hardcoded ⌥⌘B)

--- a/Sources/Pelmet/Activation/AXMenuBarExtrasReader.swift
+++ b/Sources/Pelmet/Activation/AXMenuBarExtrasReader.swift
@@ -1,0 +1,113 @@
+import AppKit
+import ApplicationServices
+import PelmetCore
+
+/// One menu bar extra as the Accessibility API reports it. Holds the live
+/// AXUIElement so activation can attempt AXPress without re-enumerating.
+struct AXExtraObservation {
+    let pid: pid_t
+    let title: String?
+    let axDescription: String?
+    /// AppKit screen coordinates; nil when position/size were unreadable.
+    let frameAppKit: CGRect?
+    let element: AXUIElement
+}
+
+/// Seam for the AX layer so the engine (and tests) never touch AXUIElement
+/// directly. Call ONLY off the main thread — AX round-trips to unresponsive
+/// apps block until the messaging timeout.
+protocol MenuBarExtrasReading: AnyObject {
+    /// The given app's menu bar extras (including notch-hidden ones — their
+    /// AX elements stay alive with valid frames).
+    func extras(forPID pid: pid_t, primaryMaxY: CGFloat) -> [AXExtraObservation]
+}
+
+final class LiveAXMenuBarExtrasReader: MenuBarExtrasReading {
+
+    /// Per-app cap so one hung process can't stall a sweep for long.
+    private static let messagingTimeout: Float = 1.0
+
+    func extras(forPID pid: pid_t, primaryMaxY: CGFloat) -> [AXExtraObservation] {
+        let app = AXUIElementCreateApplication(pid)
+        AXUIElementSetMessagingTimeout(app, Self.messagingTimeout)
+
+        guard let extrasBar = copyElement(app, kAXExtrasMenuBarAttribute),
+              let children = copyElementArray(extrasBar, kAXChildrenAttribute)
+        else { return [] }
+
+        return children.map { child in
+            AXExtraObservation(
+                pid: pid,
+                title: copyString(child, kAXTitleAttribute),
+                axDescription: copyString(child, kAXDescriptionAttribute),
+                frameAppKit: copyFrame(child, primaryMaxY: primaryMaxY),
+                element: child
+            )
+        }
+    }
+
+    // MARK: - Raw attribute helpers (every copy checked; partial data wins
+    // over no data)
+
+    private func copyValue(_ element: AXUIElement, _ attribute: String) -> CFTypeRef? {
+        var value: CFTypeRef?
+        let error = AXUIElementCopyAttributeValue(element, attribute as CFString, &value)
+        return error == .success ? value : nil
+    }
+
+    private func copyElement(_ element: AXUIElement, _ attribute: String) -> AXUIElement? {
+        guard let value = copyValue(element, attribute),
+              CFGetTypeID(value) == AXUIElementGetTypeID() else { return nil }
+        return (value as! AXUIElement)
+    }
+
+    private func copyElementArray(_ element: AXUIElement, _ attribute: String) -> [AXUIElement]? {
+        guard let value = copyValue(element, attribute),
+              let array = value as? [AnyObject] else { return nil }
+        return array.compactMap {
+            CFGetTypeID($0) == AXUIElementGetTypeID() ? ($0 as! AXUIElement) : nil
+        }
+    }
+
+    private func copyString(_ element: AXUIElement, _ attribute: String) -> String? {
+        copyValue(element, attribute) as? String
+    }
+
+    private func copyFrame(_ element: AXUIElement, primaryMaxY: CGFloat) -> CGRect? {
+        Self.frame(of: element, primaryMaxY: primaryMaxY)
+    }
+
+    /// Live frame of an AX element (AppKit coords), bounded by a messaging
+    /// timeout so a hung app fails fast. Call off-main only. This is how
+    /// cached observations get FRESH positions on every directory rebuild —
+    /// items move every time Pelmet collapses/expands, so cached frames rot
+    /// within seconds while elements and titles stay valid.
+    static func frame(
+        of element: AXUIElement,
+        primaryMaxY: CGFloat,
+        timeout: Float = 0.25
+    ) -> CGRect? {
+        AXUIElementSetMessagingTimeout(element, timeout)
+        var positionValue: CFTypeRef?
+        var sizeValue: CFTypeRef?
+        guard AXUIElementCopyAttributeValue(element, kAXPositionAttribute as CFString, &positionValue) == .success,
+              AXUIElementCopyAttributeValue(element, kAXSizeAttribute as CFString, &sizeValue) == .success,
+              let positionValue, let sizeValue,
+              CFGetTypeID(positionValue) == AXValueGetTypeID(),
+              CFGetTypeID(sizeValue) == AXValueGetTypeID()
+        else { return nil }
+
+        var position = CGPoint.zero
+        var size = CGSize.zero
+        guard AXValueGetValue(positionValue as! AXValue, .cgPoint, &position),
+              AXValueGetValue(sizeValue as! AXValue, .cgSize, &size),
+              size.width > 0, size.height > 0
+        else { return nil }
+
+        // AX positions are CG global top-left origin.
+        return ScreenCoordinates.appKitRect(
+            fromCG: CGRect(origin: position, size: size),
+            primaryMaxY: primaryMaxY
+        )
+    }
+}

--- a/Sources/Pelmet/Activation/AXPermissionMonitor.swift
+++ b/Sources/Pelmet/Activation/AXPermissionMonitor.swift
@@ -1,0 +1,77 @@
+import AppKit
+import ApplicationServices
+
+/// Tracks the Accessibility grant reactively. There is no TCC KVO, so:
+/// recompute on app-activation round-trips (the return from System
+/// Settings), and poll briefly right after the prompt was triggered —
+/// that's the window where the user is actively flipping the switch.
+final class AXPermissionMonitor {
+
+    static let shared = AXPermissionMonitor()
+
+    /// Fired (on main) whenever the trusted state may have changed.
+    var onChange: (() -> Void)?
+
+    private var observers: [NSObjectProtocol] = []
+    private var pollTimer: Timer?
+    private var pollDeadline = Date.distantPast
+    private var lastKnownTrusted = AXIsProcessTrusted()
+
+    private static let pollInterval: TimeInterval = 2
+    private static let pollWindow: TimeInterval = 120
+
+    func startObserving() {
+        guard observers.isEmpty else { return }
+        let recompute: (Notification) -> Void = { [weak self] _ in self?.recompute() }
+        observers = [
+            NotificationCenter.default.addObserver(
+                forName: NSApplication.didBecomeActiveNotification,
+                object: nil, queue: .main, using: recompute
+            ),
+            NSWorkspace.shared.notificationCenter.addObserver(
+                forName: NSWorkspace.didActivateApplicationNotification,
+                object: nil, queue: .main, using: recompute
+            ),
+        ]
+    }
+
+    /// Triggers the system prompt (once per install unless the user resets
+    /// TCC) and arms the polling window that catches the grant.
+    func requestWithPrompt() {
+        Preferences.didPromptForAccessibility = true
+        let options = [
+            kAXTrustedCheckOptionPrompt.takeUnretainedValue() as String: true,
+        ] as CFDictionary
+        _ = AXIsProcessTrustedWithOptions(options)
+        armPolling()
+        recompute()
+    }
+
+    func recompute() {
+        let trusted = AXIsProcessTrusted()
+        guard trusted != lastKnownTrusted else { return }
+        lastKnownTrusted = trusted
+        if trusted { disarmPolling() }
+        onChange?()
+    }
+
+    private func armPolling() {
+        pollDeadline = Date().addingTimeInterval(Self.pollWindow)
+        guard pollTimer == nil else { return }
+        pollTimer = Timer.scheduledTimer(
+            withTimeInterval: Self.pollInterval, repeats: true
+        ) { [weak self] _ in
+            guard let self else { return }
+            if Date() > self.pollDeadline || self.lastKnownTrusted {
+                self.disarmPolling()
+                return
+            }
+            self.recompute()
+        }
+    }
+
+    private func disarmPolling() {
+        pollTimer?.invalidate()
+        pollTimer = nil
+    }
+}

--- a/Sources/Pelmet/Activation/ActivationExecutor.swift
+++ b/Sources/Pelmet/Activation/ActivationExecutor.swift
@@ -1,0 +1,381 @@
+import AppKit
+import ApplicationServices
+import PelmetCore
+import os
+
+/// Drives a pure `ActivationSession` against real effects: synthetic
+/// clicks, AXPress, drag-to-expose, verification, and the safety rails that
+/// keep Pelmet from fighting the user or wedging the mouse.
+///
+/// One activation at a time. Everything decision-shaped lives in the
+/// session; this only performs effects and reports results back.
+final class ActivationExecutor {
+
+    static let shared = ActivationExecutor()
+
+    private let poster: EventPosting
+    private let detector = MenuOpenDetector()
+    private let logger = Logger(subsystem: "com.ismatbabirli.Pelmet", category: "Activation")
+
+    /// True while an activation is in flight. The Shelf reads this to keep
+    /// its dismiss monitors from closing the panel when our own synthetic
+    /// click lands in another app (global monitors see cross-app events).
+    private(set) var isActivating = false
+    private var lastActivation = Date.distantPast
+    private var lastDrag = Date.distantPast
+    private var abortObservers: [(center: NotificationCenter, token: NSObjectProtocol)] = []
+    private var aborted = false
+
+    /// State for the single in-flight activation. The session is a value
+    /// type but the effect loop is async, so it lives here rather than
+    /// threading an `inout` through escaping callbacks.
+    private var session: ActivationSession?
+    private var activeTarget: MenuBarItemRecord?
+    private var activeEngine: StatusItemActivationEngine?
+    private var activeCompletion: ((ActivationResult) -> Void)?
+    private var activeGeometry: MenuBarGeometry?
+    /// Frontmost app before appMenuClearance activated Finder — restored
+    /// when the session finishes so activation never steals focus for good.
+    private var previousFrontmost: NSRunningApplication?
+    /// Right-of-notch item frames captured just before the expose drag —
+    /// diffing against the post-drag list finds where an identity-less
+    /// target landed (clicking its stale frame could hit the wrong icon).
+    private var preDragRightOfNotchFrames: [CGRect]?
+
+    private static let minActivationInterval: TimeInterval = 1.0
+    private static let minDragInterval: TimeInterval = 5.0
+
+    init(poster: EventPosting = SyntheticEventPoster()) {
+        self.poster = poster
+    }
+
+    var isDisabledByEnv: Bool {
+        ProcessInfo.processInfo.environment["PELMET_DISABLE_ACTIVATION"] == "1"
+    }
+
+    /// Resolve `recordID` in the engine's current directory and run the
+    /// activation. `completion` is always called on main.
+    func activate(
+        recordID: String,
+        engine: StatusItemActivationEngine,
+        completion: @escaping (ActivationResult) -> Void
+    ) {
+        guard !isDisabledByEnv else { return completion(.failed(.permissionDenied)) }
+        guard engine.canActivate else { return completion(.failed(.permissionDenied)) }
+        guard !isActivating else { return completion(.failed(.busy)) }
+        guard Date().timeIntervalSince(lastActivation) >= Self.minActivationInterval else {
+            return completion(.failed(.busy))
+        }
+        guard NSEvent.pressedMouseButtons == 0 else {
+            return completion(.failed(.userInteracting))
+        }
+        guard let geometry = NotchLayoutMonitor.shared.currentGeometry()
+            ?? NotchLayoutMonitor.shared.lastGeometry else {
+            return completion(.failed(.itemVanished))
+        }
+        guard let target = engine.directory.records.first(where: { $0.id == recordID }) else {
+            return completion(.failed(.itemVanished))
+        }
+
+        // Offscreen-left targets are Pelmet's own collapse hiding them:
+        // expand and let the next directory refresh make them clickable,
+        // rather than clicking into the void now.
+        if target.visibility == .offscreenLeft {
+            MenuBarManager.shared.expandForActivation()
+            return completion(.failed(.itemVanished))
+        }
+
+        let strategies = ActivationPlanner.plan(
+            target: target,
+            allItems: engine.directory.records,
+            ownFrames: MenuBarManager.shared.ownItemFrames,
+            geometry: geometry,
+            hasAXElement: engine.elementForRecordID[recordID] != nil
+        )
+
+        isActivating = true
+        aborted = false
+        lastActivation = Date()
+        lastOpenedMenuID = nil
+        activeGeometry = geometry
+        previousFrontmost = nil
+        preDragRightOfNotchFrames = nil
+        installAbortObservers()
+
+        session = ActivationSession(
+            strategies: strategies,
+            targetWasSwallowed: target.visibility == .swallowedByNotch
+        )
+        activeTarget = target
+        activeEngine = engine
+        activeCompletion = completion
+        dispatch(session!.handle(.begin))
+    }
+
+    // MARK: - Effect interpretation
+
+    /// Feed an event through the session and dispatch the resulting effects.
+    private func advance(_ event: ActivationSession.Event) {
+        guard session != nil else { return }
+        let effects = session!.handle(event)
+        dispatch(effects)
+    }
+
+    private func dispatch(_ effects: [ActivationSession.Effect]) {
+        guard let target = activeTarget, let engine = activeEngine else { return }
+        for effect in effects {
+            switch effect {
+            case .perform(let strategy):
+                perform(strategy, target: target, engine: engine) { [weak self] event in
+                    self?.advance(event)
+                }
+                return // async; the callback re-enters via advance()
+
+            case .startVerification(let deadline):
+                startVerification(near: pendingVerificationPoint, deadline: deadline) { [weak self] event in
+                    self?.advance(event)
+                }
+                return
+
+            case .releaseMouseButtons:
+                poster.releaseMouseButtons()
+
+            case .restoreDrag(let plan):
+                scheduleRestore(plan)
+
+            case .finish(let result):
+                finish(result)
+                return
+            }
+        }
+    }
+
+    /// Synthetic events, AX position reads and AXPress all block their
+    /// caller for tens of ms to seconds (a hung target). They must never run
+    /// on the main thread — the whole AX architecture is built around that.
+    /// Main-thread guards run first; the blocking work hops to `ioQueue`;
+    /// the result reports back on main.
+    private let ioQueue = DispatchQueue(label: "com.ismatbabirli.Pelmet.activation-io", qos: .userInitiated)
+
+    private func perform(
+        _ strategy: ActivationStrategy,
+        target: MenuBarItemRecord,
+        engine: StatusItemActivationEngine,
+        report: @escaping (ActivationSession.Event) -> Void
+    ) {
+        if aborted { return report(.aborted(.interrupted)) }
+        if NSEvent.pressedMouseButtons != 0 { return report(.aborted(.userInteracting)) }
+
+        switch strategy {
+        case .expandCollapsedBar:
+            MenuBarManager.shared.expandForActivation()
+            report(.stepCompleted)
+
+        case .syntheticClick(let point):
+            offMainClick(at: point, report: report)
+
+        case .clickTargetAfterReflow:
+            // Re-resolve the target's live position after the reflow — off
+            // main, since it may read the AX element's position. No stale
+            // fallback here: clicking the pre-reflow frame after items
+            // shifted would hit a DIFFERENT icon.
+            let element = engine.elementForRecordID[target.id]
+            let pid = target.identity?.pid
+            let preDrag = preDragRightOfNotchFrames
+            let notch = activeGeometry?.notchRect
+            ioQueue.async { [weak self] in
+                guard let self else { return }
+                let point = self.reresolvedPoint(
+                    element: element, pid: pid, preDragFrames: preDrag, notch: notch
+                )
+                let ok = point.map { self.poster.click(atAppKit: $0) } ?? false
+                DispatchQueue.main.async {
+                    if let point { self.pendingVerificationPoint = point }
+                    report(ok ? .stepCompleted : .stepFailed)
+                }
+            }
+
+        case .axPress:
+            guard let element = engine.elementForRecordID[target.id] else {
+                return report(.stepFailed)
+            }
+            ioQueue.async {
+                // Bound the round-trip on THIS element (the messaging timeout
+                // is per-ref, so the reader's app-ref timeout doesn't cover
+                // this child) so a hung target fails fast, not forever.
+                AXUIElementSetMessagingTimeout(element, 1.0)
+                let ok = AXUIElementPerformAction(element, kAXPressAction as CFString) == .success
+                DispatchQueue.main.async { report(ok ? .stepCompleted : .stepFailed) }
+            }
+
+        case .appMenuClearance:
+            // Remember who had focus — clearance must be a loan, not a theft.
+            let frontmost = NSWorkspace.shared.frontmostApplication
+            if frontmost?.bundleIdentifier != "com.apple.finder" {
+                previousFrontmost = frontmost
+            }
+            NSRunningApplication
+                .runningApplications(withBundleIdentifier: "com.apple.finder")
+                .first?.activate(options: [])
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.25) { report(.stepCompleted) }
+
+        case .dragToExpose(let plan):
+            guard Date().timeIntervalSince(lastDrag) >= Self.minDragInterval else {
+                return report(.stepFailed)
+            }
+            lastDrag = Date()
+            preDragRightOfNotchFrames = rightOfNotchFrames()
+            ioQueue.async { [weak self] in
+                let ok = self?.poster.commandDrag(fromAppKit: plan.from, toAppKit: plan.to) ?? false
+                DispatchQueue.main.async { report(ok ? .stepCompleted : .stepFailed) }
+            }
+        }
+    }
+
+    /// Item frames currently right of the notch (main thread).
+    private func rightOfNotchFrames() -> [CGRect] {
+        guard let notch = activeGeometry?.notchRect else { return [] }
+        return WindowListSource.statusItemWindows()
+            .map(\.frame)
+            .filter { $0.minX > notch.maxX }
+    }
+
+    private func offMainClick(at point: CGPoint, report: @escaping (ActivationSession.Event) -> Void) {
+        pendingVerificationPoint = point
+        ioQueue.async { [weak self] in
+            let ok = self?.poster.click(atAppKit: point) ?? false
+            DispatchQueue.main.async { report(ok ? .stepCompleted : .stepFailed) }
+        }
+    }
+
+    private var pendingVerificationPoint: CGPoint = .zero
+
+    private func startVerification(
+        near point: CGPoint,
+        deadline: TimeInterval,
+        report: @escaping (ActivationSession.Event) -> Void
+    ) {
+        let baseline = detector.baselineWindowIDs()
+        let start = Date()
+        func poll() {
+            if aborted { return report(.aborted(.interrupted)) }
+            if let id = detector.newMenuWindowID(near: point, baseline: baseline) {
+                lastOpenedMenuID = id
+                return report(.verified(.menuOpened))
+            }
+            if Date().timeIntervalSince(start) >= deadline {
+                return report(.verificationTimedOut)
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { poll() }
+        }
+        // Give the click a beat to open the menu before the first poll.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { poll() }
+    }
+
+    private var lastOpenedMenuID: Int?
+
+    /// The reflow moved the target; find where it landed. Runs on `ioQueue`.
+    ///
+    /// The AX element's live `kAXPosition` is the reliable source: on Tahoe
+    /// every status window is owned by Control Center, so matching a
+    /// CGWindow by the app's PID finds nothing there. For identity-less
+    /// targets, diff the right-of-notch frames against the pre-drag capture
+    /// — the newly appeared frame is where the target reflowed to. Nil when
+    /// nothing is trustworthy: clicking a stale frame after items shifted
+    /// would open a DIFFERENT app's menu.
+    private func reresolvedPoint(
+        element: AXUIElement?,
+        pid: Int32?,
+        preDragFrames: [CGRect]?,
+        notch: CGRect?
+    ) -> CGPoint? {
+        let primaryMaxY = NSScreen.screens.first?.frame.maxY ?? 0
+        if let element,
+           let frame = LiveAXMenuBarExtrasReader.frame(of: element, primaryMaxY: primaryMaxY, timeout: 1.0) {
+            return CGPoint(x: frame.midX, y: frame.midY)
+        }
+        if let pid, let match = WindowListSource.statusItemWindows().first(where: { $0.ownerPID == pid }) {
+            return CGPoint(x: match.frame.midX, y: match.frame.midY)
+        }
+        if let preDragFrames, let notch {
+            let fresh = WindowListSource.statusItemWindows()
+                .map(\.frame)
+                .filter { $0.minX > notch.maxX }
+            let appeared = fresh.filter { frame in
+                !preDragFrames.contains { abs($0.minX - frame.minX) < 3 && abs($0.width - frame.width) < 3 }
+            }
+            // The exposed slot opens right beside the notch; take the new
+            // frame nearest to it. Ambiguity (several new frames) still
+            // resolves to the notch-adjacent one — that's where reflow
+            // inserts the freed item.
+            if let landed = appeared.min(by: { $0.minX < $1.minX }) {
+                return CGPoint(x: landed.midX, y: landed.midY)
+            }
+        }
+        return nil
+    }
+
+    private func scheduleRestore(_ plan: DragPlan) {
+        // Restore only after the opened menu closes, so we don't yank the
+        // bar out from under an open menu. Bounded wait.
+        let menuID = lastOpenedMenuID
+        let deadline = Date().addingTimeInterval(30)
+        func waitAndRestore() {
+            let menuClosed = menuID.map { !detector.isWindowPresent($0) } ?? true
+            if menuClosed || Date() > deadline {
+                guard NSEvent.pressedMouseButtons == 0 else {
+                    // User is interacting; don't fight them. Leave the order
+                    // as-is rather than risk a tug of war.
+                    return
+                }
+                let restorePoint = CGPoint(x: plan.neighborFrame.midX, y: plan.neighborFrame.midY)
+                poster.commandDrag(fromAppKit: plan.to, toAppKit: restorePoint)
+                return
+            }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { waitAndRestore() }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { waitAndRestore() }
+    }
+
+    private func finish(_ result: ActivationResult) {
+        isActivating = false
+        removeAbortObservers()
+        StatusItemActivationEngine.debugTrace { "activation finished: \(result)" }
+        // Clearance borrowed focus for Finder; give it back.
+        if let previousFrontmost, !previousFrontmost.isTerminated {
+            previousFrontmost.activate(options: [])
+        }
+        previousFrontmost = nil
+        let completion = activeCompletion
+        session = nil
+        activeTarget = nil
+        activeEngine = nil
+        activeCompletion = nil
+        completion?(result)
+    }
+
+    // MARK: - Abort rails
+
+    private func installAbortObservers() {
+        guard abortObservers.isEmpty else { return }
+        let workspaceCenter = NSWorkspace.shared.notificationCenter
+        let markAborted: (Notification) -> Void = { [weak self] _ in self?.aborted = true }
+        abortObservers = [
+            (workspaceCenter, workspaceCenter.addObserver(
+                forName: NSWorkspace.activeSpaceDidChangeNotification, object: nil, queue: .main, using: markAborted
+            )),
+            (workspaceCenter, workspaceCenter.addObserver(
+                forName: NSWorkspace.sessionDidResignActiveNotification, object: nil, queue: .main, using: markAborted
+            )),
+            (DistributedNotificationCenter.default() as NotificationCenter,
+             DistributedNotificationCenter.default().addObserver(
+                forName: Notification.Name("com.apple.screenIsLocked"), object: nil, queue: .main, using: markAborted
+            )),
+        ]
+    }
+
+    private func removeAbortObservers() {
+        abortObservers.forEach { $0.center.removeObserver($0.token) }
+        abortObservers = []
+    }
+}

--- a/Sources/Pelmet/Activation/MenuOpenDetector.swift
+++ b/Sources/Pelmet/Activation/MenuOpenDetector.swift
@@ -1,0 +1,69 @@
+import AppKit
+import PelmetCore
+
+/// Permission-free verification that a click opened something: watch for a
+/// new window at the menu/popover level near the click, appearing after we
+/// posted the click. Also detects that menu closing (gates the restore
+/// drag). Uses only CGWindowList bounds/level metadata — no Screen
+/// Recording, no titles.
+final class MenuOpenDetector {
+
+    /// Window layers a menu or status popover lives at. Menus sit at/above
+    /// the status-item level (25); include a generous band up through the
+    /// pop-up menu level (101) and a little beyond.
+    private static let menuLayerRange = 20...200
+    private static let horizontalTolerance: CGFloat = 250
+    private static let topTolerance: CGFloat = 80
+
+    /// Window IDs present at the menu level before the click.
+    func baselineWindowIDs() -> Set<Int> {
+        Set(menuWindows().map(\.id))
+    }
+
+    /// A new menu-level window near `clickPoint` (AppKit coords) that wasn't
+    /// in `baseline` — i.e. our click opened a menu. Status-item menus drop
+    /// down from the bar, so the window's top edge sits just under it and
+    /// its horizontal span overlaps the clicked item.
+    func newMenuWindowID(near clickPoint: CGPoint, baseline: Set<Int>) -> Int? {
+        let screen = NSScreen.screens.first { $0.frame.contains(clickPoint) } ?? NSScreen.main
+        let primaryMaxY = NSScreen.screens.first?.frame.maxY ?? 0
+        let menuBarBottom = (screen?.frame.maxY ?? primaryMaxY) - (screen?.safeAreaInsets.top ?? 24)
+
+        for window in menuWindows() where !baseline.contains(window.id) {
+            let appKit = ScreenCoordinates.appKitRect(fromCG: window.bounds, primaryMaxY: primaryMaxY)
+            let nearX = appKit.minX - Self.horizontalTolerance <= clickPoint.x
+                && clickPoint.x <= appKit.maxX + Self.horizontalTolerance
+            // A dropped menu's top edge is within a small band of the bar.
+            let nearTop = abs(appKit.maxY - menuBarBottom) <= Self.topTolerance
+            if nearX && nearTop { return window.id }
+        }
+        return nil
+    }
+
+    /// Whether a given window ID is still present (menu still open).
+    func isWindowPresent(_ id: Int) -> Bool {
+        menuWindows().contains { $0.id == id }
+    }
+
+    // MARK: - Window snapshot
+
+    private struct MenuWindow {
+        let id: Int
+        let bounds: CGRect
+    }
+
+    private func menuWindows() -> [MenuWindow] {
+        guard let list = CGWindowListCopyWindowInfo([.optionOnScreenOnly], kCGNullWindowID) as? [[String: Any]]
+        else { return [] }
+        return list.compactMap { info in
+            guard let layer = info[kCGWindowLayer as String] as? Int,
+                  Self.menuLayerRange.contains(layer),
+                  let id = info[kCGWindowNumber as String] as? Int,
+                  let bounds = info[kCGWindowBounds as String] as? [String: CGFloat],
+                  let x = bounds["X"], let y = bounds["Y"],
+                  let width = bounds["Width"], let height = bounds["Height"]
+            else { return nil }
+            return MenuWindow(id: id, bounds: CGRect(x: x, y: y, width: width, height: height))
+        }
+    }
+}

--- a/Sources/Pelmet/Activation/StatusItemActivationEngine.swift
+++ b/Sources/Pelmet/Activation/StatusItemActivationEngine.swift
@@ -1,0 +1,521 @@
+import AppKit
+import ApplicationServices
+import PelmetCore
+
+/// The seam between the Shelf UI and the (opt-in, Accessibility-gated)
+/// activation machinery. Main-thread public surface, closure callbacks —
+/// house style.
+///
+/// The engine is ALWAYS present and publishes a directory even without any
+/// permission: identity comes free from CGWindow owner PIDs on macOS ≤ 15
+/// (Sequoia); on Tahoe, where Control Center re-parents every status-item
+/// window, the ungranted directory honestly degrades to `.framesOnly`.
+/// With the grant, an AX sweep (`kAXExtrasMenuBarAttribute` per running
+/// app) restores identity on Tahoe and adds item titles everywhere.
+protocol StatusItemActivating: AnyObject {
+    var availability: ActivationAvailability { get }
+    var onAvailabilityChange: ((ActivationAvailability) -> Void)? { get set }
+
+    var directory: DirectorySnapshot { get }
+    var onDirectoryChange: ((DirectorySnapshot) -> Void)? { get set }
+
+    /// True when the directory carries (or could carry) real ownership.
+    var canIdentify: Bool { get }
+    /// True only when activation can actually run (permission granted).
+    var canActivate: Bool { get }
+
+    /// Descriptors the Shelf deriver uses to make rows one-click
+    /// activatable — empty unless activation can actually run. Tokens are
+    /// `MenuBarItemRecord` ids, fed back to `activate(recordID:)`.
+    var activatableDescriptors: [EngineItemDescriptor] { get }
+
+    func setEnabled(_ enabled: Bool)
+    func requestAccess()
+    func refreshDirectory(reason: String)
+    func activate(recordID: String, completion: @escaping (ActivationResult) -> Void)
+}
+
+extension Notification.Name {
+    /// Posted whenever the engine's availability changes — the multicast
+    /// channel for SwiftUI surfaces (the closure is single-consumer).
+    static let pelmetActivationAvailabilityChanged =
+        Notification.Name("PelmetActivationAvailabilityChanged")
+}
+
+/// SwiftUI-observable mirror of the engine's availability, for Settings and
+/// the Shelf.
+final class ActivationStatus: ObservableObject {
+
+    static let shared = ActivationStatus()
+
+    @Published private(set) var availability: ActivationAvailability
+
+    private var observer: NSObjectProtocol?
+
+    private init() {
+        availability = StatusItemActivationEngine.shared.availability
+        observer = NotificationCenter.default.addObserver(
+            forName: .pelmetActivationAvailabilityChanged,
+            object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.availability = StatusItemActivationEngine.shared.availability
+        }
+    }
+}
+
+final class StatusItemActivationEngine: StatusItemActivating {
+
+    static let shared = StatusItemActivationEngine()
+
+    // MARK: - Published state
+
+    private(set) var availability: ActivationAvailability = .notDetermined {
+        didSet {
+            if availability != oldValue {
+                onAvailabilityChange?(availability)
+                NotificationCenter.default.post(name: .pelmetActivationAvailabilityChanged, object: self)
+            }
+        }
+    }
+    var onAvailabilityChange: ((ActivationAvailability) -> Void)?
+
+    private(set) var directory: DirectorySnapshot = .empty
+    var onDirectoryChange: ((DirectorySnapshot) -> Void)?
+
+    var canIdentify: Bool { directory.fidelity == .identified }
+    var canActivate: Bool { availability == .granted }
+
+    var activatableDescriptors: [EngineItemDescriptor] {
+        guard canActivate else { return [] }
+        return directory.records
+            .filter { $0.visibility == .swallowedByNotch }
+            .map { record in
+                EngineItemDescriptor(
+                    token: record.id,
+                    // nil when identity is unknown — the deriver numbers the
+                    // fallback so rows never collapse into identical
+                    // unnumbered "Hidden item" entries.
+                    title: record.identity.map { $0.axTitle ?? $0.appName },
+                    ownerPID: record.identity?.pid,
+                    frame: record.frame
+                )
+            }
+    }
+
+    // MARK: - Internals
+
+    /// Injectable AX seam — swapped out in future tests.
+    var extrasReader: MenuBarExtrasReading = LiveAXMenuBarExtrasReader()
+
+    private var observers: [(center: NotificationCenter, token: NSObjectProtocol)] = []
+    private let ownPID = Int32(ProcessInfo.processInfo.processIdentifier)
+
+    /// All AX reads happen here, never on main — a hung app blocks only
+    /// this queue (per-app 1s messaging timeout + sweep deadline).
+    private let sweepQueue = DispatchQueue(
+        label: "com.ismatbabirli.Pelmet.ax-sweep", qos: .userInitiated
+    )
+    private var isSweeping = false
+    private var sweepGeneration = 0
+    /// Bounded retries when a swallowed record publishes without identity —
+    /// position reads racing a mid-toggle bar animation resolve on a
+    /// re-read moments later. Reset on every confirmed layout change; capped
+    /// so apps that genuinely expose no AX extras don't cause a rebuild loop.
+    private var healAttempts = 0
+    private var axCache: [pid_t: (observations: [AXExtraObservation], stamp: Date)] = [:]
+    private var slowPIDs: Set<pid_t> = []
+    /// Live AX elements for the current directory's records (AXPress path).
+    private(set) var elementForRecordID: [String: AXUIElement] = [:]
+
+    private static let cacheTTL: TimeInterval = 30
+    private static let sweepDeadline: TimeInterval = 3
+
+    /// Fraction of owned in-band items that must be Control-Center-owned
+    /// before ownership data is declared untrustworthy (Tahoe re-parenting;
+    /// doubles as the macOS-27 tripwire).
+    private static let reparentThreshold = 0.7
+
+    /// System agents that own extras despite a `.prohibited` policy.
+    private static let systemAgentAllowlist: Set<String> = [
+        "com.apple.controlcenter",
+        "com.apple.TextInputMenuAgent",
+        "com.apple.systemuiserver",
+    ]
+
+    // MARK: - Lifecycle
+
+    func start() {
+        guard observers.isEmpty else { return }
+        let workspaceCenter = NSWorkspace.shared.notificationCenter
+        observers = [
+            (.default, NotificationCenter.default.addObserver(
+                forName: .pelmetLayoutDidChange, object: nil, queue: .main
+            ) { [weak self] _ in
+                self?.healAttempts = 0
+                self?.rebuildDirectory()
+            }),
+            (workspaceCenter, workspaceCenter.addObserver(
+                forName: NSWorkspace.didLaunchApplicationNotification, object: nil, queue: .main
+            ) { [weak self] note in
+                self?.invalidateCache(for: note)
+            }),
+            (workspaceCenter, workspaceCenter.addObserver(
+                forName: NSWorkspace.didTerminateApplicationNotification, object: nil, queue: .main
+            ) { [weak self] note in
+                self?.invalidateCache(for: note)
+            }),
+            (workspaceCenter, workspaceCenter.addObserver(
+                forName: NSWorkspace.activeSpaceDidChangeNotification, object: nil, queue: .main
+            ) { [weak self] _ in
+                self?.axCache.removeAll()
+            }),
+            (.default, NotificationCenter.default.addObserver(
+                forName: NSApplication.didChangeScreenParametersNotification, object: nil, queue: .main
+            ) { [weak self] _ in
+                self?.axCache.removeAll()
+            }),
+        ]
+        AXPermissionMonitor.shared.onChange = { [weak self] in
+            self?.recomputeAvailability()
+        }
+        AXPermissionMonitor.shared.startObserving()
+        recomputeAvailability()
+        Self.debugTrace {
+            "start: enabled=\(Preferences.activationEngineEnabled) "
+                + "trusted=\(AXIsProcessTrusted()) availability=\(availability)"
+        }
+        rebuildDirectory()
+    }
+
+    func setEnabled(_ enabled: Bool) {
+        Preferences.activationEngineEnabled = enabled
+        recomputeAvailability()
+    }
+
+    func requestAccess() {
+        guard Preferences.activationEngineEnabled, availability != .granted else { return }
+        AXPermissionMonitor.shared.requestWithPrompt()
+        recomputeAvailability()
+    }
+
+    func refreshDirectory(reason: String) {
+        _ = reason
+        rebuildDirectory()
+    }
+
+    func activate(recordID: String, completion: @escaping (ActivationResult) -> Void) {
+        ActivationExecutor.shared.activate(recordID: recordID, engine: self, completion: completion)
+    }
+
+    // MARK: - Availability
+
+    func recomputeAvailability() {
+        let wasGranted = availability == .granted
+        let newValue: ActivationAvailability
+        if !Preferences.activationEngineEnabled {
+            newValue = .notDetermined
+        } else if AXIsProcessTrusted() {
+            newValue = .granted
+        } else if Preferences.didPromptForAccessibility {
+            newValue = .denied
+        } else {
+            newValue = .notDetermined
+        }
+        availability = newValue
+        if (newValue == .granted) != wasGranted {
+            // Grant arrived or was revoked: identity and descriptors change.
+            rebuildDirectory()
+        }
+    }
+
+    // MARK: - Directory
+
+    private func rebuildDirectory() {
+        guard let classification = NotchLayoutMonitor.shared.confirmed else {
+            elementForRecordID = [:]
+            publish(.empty)
+            return
+        }
+
+        let controlCenterPID = OwnerResolver.shared.controlCenterPID()
+        let items = classification.items.filter {
+            $0.visibility != .suspectedGhost && !$0.ownerPIDs.contains(ownPID)
+        }
+        let reparented = Self.isReparented(items: items, controlCenterPID: controlCenterPID)
+
+        let cached = freshCachedObservations()
+        if canActivate, !cached.isEmpty {
+            // Cached FRAMES rot the moment the layout moves (every
+            // collapse/expand relocates every item) — re-read each cached
+            // element's live position off-main, then publish.
+            refreshPositionsAndPublish(
+                controlCenterPID: controlCenterPID,
+                reparented: reparented,
+                observations: cached
+            )
+        } else {
+            // Free CGWindow data only; the sweep (when granted) enriches.
+            publishSnapshot(
+                items: items,
+                controlCenterPID: controlCenterPID,
+                reparented: reparented,
+                observations: []
+            )
+        }
+
+        if canActivate {
+            scheduleSweep(controlCenterPID: controlCenterPID, reparented: reparented)
+        }
+    }
+
+    /// Re-reads live positions for cached AX elements (off-main, bounded
+    /// timeouts), then publishes against the latest classification.
+    private func refreshPositionsAndPublish(
+        controlCenterPID: Int32?,
+        reparented: Bool,
+        observations: [AXExtraObservation]
+    ) {
+        let primaryMaxY = NSScreen.screens.first?.frame.maxY ?? 0
+        sweepQueue.async { [weak self] in
+            let refreshed = observations.map { observation in
+                AXExtraObservation(
+                    pid: observation.pid,
+                    title: observation.title,
+                    axDescription: observation.axDescription,
+                    frameAppKit: LiveAXMenuBarExtrasReader.frame(
+                        of: observation.element, primaryMaxY: primaryMaxY
+                    ),
+                    element: observation.element
+                )
+            }
+            DispatchQueue.main.async {
+                guard let self else { return }
+                // Publish against the LATEST confirmed classification — the
+                // layout may have moved again while positions were read.
+                guard let classification = NotchLayoutMonitor.shared.confirmed else { return }
+                let freshItems = classification.items.filter {
+                    $0.visibility != .suspectedGhost && !$0.ownerPIDs.contains(self.ownPID)
+                }
+                self.publishSnapshot(
+                    items: freshItems,
+                    controlCenterPID: controlCenterPID,
+                    reparented: reparented,
+                    observations: refreshed
+                )
+            }
+        }
+    }
+
+    private static func isReparented(items: [ClassifiedItem], controlCenterPID: Int32?) -> Bool {
+        guard let controlCenterPID else { return false }
+        let owned = items.filter { !$0.ownerPIDs.isEmpty }
+        guard !owned.isEmpty else { return false }
+        let controlCenterOnly = owned.filter { item in
+            item.ownerPIDs.allSatisfy { $0 == controlCenterPID }
+        }
+        return Double(controlCenterOnly.count) / Double(owned.count) >= reparentThreshold
+    }
+
+    private func publishSnapshot(
+        items: [ClassifiedItem],
+        controlCenterPID: Int32?,
+        reparented: Bool,
+        observations: [AXExtraObservation]
+    ) {
+        let itemObservations = observations.map { observation in
+            ItemObservation(
+                pid: observation.pid,
+                title: observation.title ?? observation.axDescription,
+                frame: observation.frameAppKit
+            )
+        }
+        let correlated = StatusItemCorrelator.correlate(
+            classified: items, observed: itemObservations
+        )
+
+        var records: [MenuBarItemRecord] = []
+        var elements: [String: AXUIElement] = [:]
+        var identifiedAny = false
+
+        for pair in correlated {
+            let item = pair.item
+            var identity: ItemIdentity?
+
+            // AX observation wins (it has titles and survives Tahoe);
+            // CGWindow ownership is the free fallback where trustworthy.
+            var identityPID: Int32?
+            if let observation = pair.observation {
+                identityPID = observation.pid
+            } else if !reparented {
+                identityPID = item.ownerPIDs.first { $0 != controlCenterPID }
+            }
+
+            if let pid = identityPID,
+               let info = OwnerResolver.shared.info(for: pid),
+               let name = info.localizedName ?? info.bundleID {
+                identity = ItemIdentity(
+                    pid: pid,
+                    bundleIdentifier: info.bundleID,
+                    appName: name,
+                    axTitle: TitleHygiene.meaningfulTitle(
+                        pair.observation?.title,
+                        appName: name,
+                        bundleID: info.bundleID
+                    )
+                )
+                identifiedAny = true
+            }
+
+            let record = MenuBarItemRecord(
+                frame: item.frame,
+                visibility: item.visibility,
+                identity: identity
+            )
+            records.append(record)
+
+            // itemObservations is index-aligned with `observations`, so the
+            // matched value maps straight back to its live AX element.
+            if let observation = pair.observation,
+               let index = itemObservations.firstIndex(of: observation) {
+                elements[record.id] = observations[index].element
+            }
+        }
+
+        elementForRecordID = elements
+        Self.debugTrace {
+            let described = records.map { record -> String in
+                let who = record.identity.map { "\($0.appName)(\($0.pid))" } ?? "?"
+                return "[\(Int(record.frame.minX)),\(Int(record.frame.maxX))] \(record.visibility) → \(who)"
+            }
+            return "directory: reparented=\(reparented) observations=\(observations.count) "
+                + "records=\(records.count)\n  " + described.joined(separator: "\n  ")
+        }
+        publish(DirectorySnapshot(
+            records: records,
+            fidelity: identifiedAny ? .identified : .framesOnly,
+            capturedAt: Date()
+        ))
+
+        // Self-heal: a swallowed row without identity is the user-visible
+        // failure ("Hidden item N", no logo). When it's a transient (element
+        // positions read mid-animation), a re-read moments later fixes it.
+        let unidentifiedSwallowed = records.contains {
+            $0.visibility == .swallowedByNotch && $0.identity == nil
+        }
+        if canActivate, unidentifiedSwallowed, !axCache.isEmpty, healAttempts < 2 {
+            healAttempts += 1
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
+                self?.rebuildDirectory()
+            }
+        }
+    }
+
+    private func publish(_ snapshot: DirectorySnapshot) {
+        directory = snapshot
+        onDirectoryChange?(snapshot)
+    }
+
+    // MARK: - AX sweep
+
+    private func freshCachedObservations() -> [AXExtraObservation] {
+        let now = Date()
+        return axCache.values
+            .filter { now.timeIntervalSince($0.stamp) < Self.cacheTTL }
+            .flatMap(\.observations)
+    }
+
+    private func invalidateCache(for note: Notification) {
+        guard let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else {
+            axCache.removeAll()
+            return
+        }
+        axCache.removeValue(forKey: app.processIdentifier)
+    }
+
+    private func scheduleSweep(controlCenterPID: Int32?, reparented: Bool) {
+        guard !isSweeping else { return }
+        isSweeping = true
+        sweepGeneration += 1
+        let generation = sweepGeneration
+
+        // Everything AppKit-derived is captured on main before hopping off.
+        let primaryMaxY = NSScreen.screens.first?.frame.maxY ?? 0
+        let staleCutoff = Date().addingTimeInterval(-Self.cacheTTL)
+        let cachedPIDs = Set(axCache.filter { $0.value.stamp > staleCutoff }.keys)
+        let candidates = sweepCandidates().filter { !cachedPIDs.contains($0) }
+        guard !candidates.isEmpty else {
+            isSweeping = false
+            return
+        }
+        let reader = extrasReader
+        let slow = slowPIDs
+
+        sweepQueue.async { [weak self] in
+            let deadline = Date().addingTimeInterval(Self.sweepDeadline)
+            var results: [pid_t: [AXExtraObservation]] = [:]
+            var newSlow: Set<pid_t> = []
+
+            // Previously slow apps go last so they can only eat the tail of
+            // the budget.
+            let ordered = candidates.sorted { slow.contains($0) ? false : slow.contains($1) }
+            for pid in ordered {
+                guard Date() < deadline else { break }
+                let start = Date()
+                results[pid] = reader.extras(forPID: pid, primaryMaxY: primaryMaxY)
+                if Date().timeIntervalSince(start) > 0.9 { newSlow.insert(pid) }
+            }
+            let attemptedAll = results.count == ordered.count
+
+            DispatchQueue.main.async {
+                guard let self else { return }
+                self.isSweeping = false
+                guard generation == self.sweepGeneration else { return }
+                let stamp = Date()
+                for (pid, observations) in results {
+                    self.axCache[pid] = (observations, stamp)
+                }
+                self.slowPIDs.formUnion(newSlow)
+                Self.debugTrace {
+                    let found = results.filter { !$0.value.isEmpty }
+                    return "AX sweep: attempted \(results.count)/\(ordered.count) apps, "
+                        + "\(found.count) with extras (\(found.values.map(\.count).reduce(0, +)) items)"
+                        + (attemptedAll ? "" : " — continuing")
+                }
+
+                // Route back through rebuildDirectory: it refreshes cached
+                // element positions, publishes, and — because swept PIDs are
+                // now cached — schedules the NEXT pass only while unswept
+                // candidates remain (one 3s pass can't cover a busy Mac's
+                // app list; each pass caches ≥1 PID, so this terminates).
+                guard !results.isEmpty else { return }
+                self.rebuildDirectory()
+            }
+        }
+    }
+
+    /// stdout tracing for `swift run` users, mirroring PELMET_DEBUG_LAYOUT.
+    static func debugTrace(_ message: () -> String) {
+        guard ProcessInfo.processInfo.environment["PELMET_DEBUG_ACTIVATION"] != nil else { return }
+        print("Pelmet activation: \(message())")
+        fflush(stdout)
+    }
+
+    /// Apps that could plausibly own a menu bar extra. `kAXExtrasMenuBar`
+    /// is per-app, cannot see our own extras, and some LSUIElement apps
+    /// expose nothing — those fall back to CGWindow/frame data.
+    private func sweepCandidates() -> [pid_t] {
+        NSWorkspace.shared.runningApplications.compactMap { app in
+            guard !app.isTerminated, app.processIdentifier != ownPID else { return nil }
+            switch app.activationPolicy {
+            case .regular, .accessory:
+                return app.processIdentifier
+            case .prohibited:
+                guard let bundleID = app.bundleIdentifier,
+                      Self.systemAgentAllowlist.contains(bundleID) else { return nil }
+                return app.processIdentifier
+            @unknown default:
+                return nil
+            }
+        }
+    }
+}

--- a/Sources/Pelmet/Activation/SyntheticEventPoster.swift
+++ b/Sources/Pelmet/Activation/SyntheticEventPoster.swift
@@ -1,0 +1,130 @@
+import AppKit
+import CoreGraphics
+import PelmetCore
+
+/// Posts synthetic mouse events to activate status items. Warps the cursor
+/// so the window server's hit-test matches the event location (status-item
+/// hit-testing happens in WindowServer at the cursor, not per-PID), then
+/// restores it. Requires the Accessibility grant (TCC's PostEvent bucket
+/// rides along); the app must be signed for Tahoe's synthetic-event gate.
+protocol EventPosting: AnyObject {
+    /// AppKit-coordinate click. Returns false if the event source couldn't
+    /// be created.
+    @discardableResult func click(atAppKit point: CGPoint) -> Bool
+    @discardableResult func commandDrag(fromAppKit: CGPoint, toAppKit: CGPoint) -> Bool
+    /// Belt-and-braces: post a bare mouse-up in case a synthetic button is
+    /// stuck down after an abort.
+    func releaseMouseButtons()
+}
+
+final class SyntheticEventPoster: EventPosting {
+
+    /// Tag on every event we post, so our own event taps (and debugging)
+    /// can recognize Pelmet-origin events. "PLMT".
+    static let sourceUserData: Int64 = 0x504C4D54
+
+    private var primaryMaxY: CGFloat { NSScreen.screens.first?.frame.maxY ?? 0 }
+
+    @discardableResult
+    func click(atAppKit point: CGPoint) -> Bool {
+        guard let source = CGEventSource(stateID: .hidSystemState) else { return false }
+        source.userData = Self.sourceUserData
+        let cg = ScreenCoordinates.cgPoint(fromAppKit: point, primaryMaxY: primaryMaxY)
+
+        let cursorWasNear = distance(NSEvent.mouseLocation, point) < 6
+        let restore = NSEvent.mouseLocation
+        if !cursorWasNear {
+            hideCursor()
+            CGAssociateMouseAndMouseCursorPosition(0)
+            CGWarpMouseCursorPosition(cg)
+        }
+        defer {
+            if !cursorWasNear {
+                let restoreCG = ScreenCoordinates.cgPoint(fromAppKit: restore, primaryMaxY: primaryMaxY)
+                CGWarpMouseCursorPosition(restoreCG)
+                CGAssociateMouseAndMouseCursorPosition(1)
+                showCursor()
+            }
+        }
+        usleep(20_000) // 20ms settle after the warp
+
+        post(source, type: .leftMouseDown, at: cg, clickState: 1)
+        usleep(40_000)
+        post(source, type: .leftMouseUp, at: cg, clickState: 1)
+        return true
+    }
+
+    @discardableResult
+    func commandDrag(fromAppKit: CGPoint, toAppKit: CGPoint) -> Bool {
+        guard let source = CGEventSource(stateID: .hidSystemState) else { return false }
+        source.userData = Self.sourceUserData
+        let from = ScreenCoordinates.cgPoint(fromAppKit: fromAppKit, primaryMaxY: primaryMaxY)
+        let to = ScreenCoordinates.cgPoint(fromAppKit: toAppKit, primaryMaxY: primaryMaxY)
+
+        let restore = NSEvent.mouseLocation
+        hideCursor()
+        CGAssociateMouseAndMouseCursorPosition(0)
+        CGWarpMouseCursorPosition(from)
+        defer {
+            let restoreCG = ScreenCoordinates.cgPoint(fromAppKit: restore, primaryMaxY: primaryMaxY)
+            CGWarpMouseCursorPosition(restoreCG)
+            CGAssociateMouseAndMouseCursorPosition(1)
+            showCursor()
+        }
+        usleep(20_000)
+
+        post(source, type: .leftMouseDown, at: from, flags: .maskCommand)
+        let steps = 10
+        for i in 1...steps {
+            let t = CGFloat(i) / CGFloat(steps)
+            let point = CGPoint(x: from.x + (to.x - from.x) * t, y: from.y + (to.y - from.y) * t)
+            post(source, type: .leftMouseDragged, at: point, flags: .maskCommand)
+            usleep(16_000)
+        }
+        post(source, type: .leftMouseUp, at: to, flags: .maskCommand)
+        return true
+    }
+
+    /// The synthetic sequence drives the REAL cursor (warp + event
+    /// positions), which reads as "my mouse is moving by itself". Hide it
+    /// for the few hundred ms the sequence runs. Balanced hide/show; may be
+    /// a no-op for background apps on some macOS versions — harmless then.
+    private func hideCursor() {
+        CGDisplayHideCursor(CGMainDisplayID())
+    }
+
+    private func showCursor() {
+        CGDisplayShowCursor(CGMainDisplayID())
+    }
+
+    func releaseMouseButtons() {
+        guard let source = CGEventSource(stateID: .hidSystemState) else { return }
+        source.userData = Self.sourceUserData
+        let location = ScreenCoordinates.cgPoint(fromAppKit: NSEvent.mouseLocation, primaryMaxY: primaryMaxY)
+        post(source, type: .leftMouseUp, at: location)
+    }
+
+    // MARK: - Helpers
+
+    private func post(
+        _ source: CGEventSource,
+        type: CGEventType,
+        at point: CGPoint,
+        flags: CGEventFlags = [],
+        clickState: Int64? = nil
+    ) {
+        guard let event = CGEvent(
+            mouseEventSource: source,
+            mouseType: type,
+            mouseCursorPosition: point,
+            mouseButton: .left
+        ) else { return }
+        event.flags = flags
+        if let clickState { event.setIntegerValueField(.mouseEventClickState, value: clickState) }
+        event.post(tap: .cghidEventTap)
+    }
+
+    private func distance(_ a: CGPoint, _ b: CGPoint) -> CGFloat {
+        hypot(a.x - b.x, a.y - b.y)
+    }
+}

--- a/Sources/Pelmet/AppDelegate.swift
+++ b/Sources/Pelmet/AppDelegate.swift
@@ -19,13 +19,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         MenuBarManager.shared.setUp()
 
-        // Global hotkey: ⌥⌘B toggles hidden items.
+        // Global hotkeys: ⌥⌘B toggles hidden items, ⌥⌘N opens the Shelf.
         HotkeyManager.shared.onToggle = {
             MenuBarManager.shared.toggle()
         }
-        let hotkeyRegistered = HotkeyManager.shared.register()
+        HotkeyManager.shared.onShelf = {
+            MenuBarManager.shared.openShelfFromHotkey()
+        }
+        let registration = HotkeyManager.shared.register()
 
-        printStartupBanner(hotkeyRegistered: hotkeyRegistered)
+        printStartupBanner(hotkeys: registration)
     }
 
     func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
@@ -62,12 +65,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// invisible menu-bar app is alive. A bundled .app has no visible stdout,
     /// and os.Logger goes to the unified log, not the terminal, so print is
     /// the right channel for this audience.
-    private func printStartupBanner(hotkeyRegistered: Bool) {
+    private func printStartupBanner(hotkeys: HotkeyManager.Registration) {
         var lines = [
             "Pelmet is running as a menu-bar-only app (no Dock icon, no window).",
             "  Look for the ‹/› chevron toggle next to the clock; the ╱ divider",
             "  sits just left of the chevron.",
-            hotkeyRegistered
+            hotkeys.toggle
                 ? "  • Click the chevron or press ⌥⌘B to hide/show icons."
                 : "  • Click the chevron to hide/show icons. (⌥⌘B is unavailable — another app claimed it.)",
             "  • Pelmet hides everything LEFT of ╱ — ⌘-drag icons you always",
@@ -78,7 +81,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         lines.append(contentsOf: [
             "  • A number next to the chevron (like +3) means that many icons don't fit",
-            "    beside the notch — right-click the chevron for tips.",
+            "    beside the notch — click the chevron to see them on the Shelf"
+                + (hotkeys.shelf ? " (or press ⌥⌘N)." : "."),
             "  • Can't find Pelmet in the bar? Launching it again opens its Settings window.",
             "  • Ctrl-C here (or closing this terminal) quits Pelmet.",
         ])

--- a/Sources/Pelmet/HotkeyManager.swift
+++ b/Sources/Pelmet/HotkeyManager.swift
@@ -1,23 +1,35 @@
 import Carbon.HIToolbox
 import os
 
-/// Registers a global hotkey using the Carbon RegisterEventHotKey API.
+/// Registers global hotkeys using the Carbon RegisterEventHotKey API.
 /// Unlike NSEvent global monitors, this does NOT require the
-/// Accessibility permission — ideal for a zero-permission MVP.
+/// Accessibility permission — ideal for a zero-permission core.
 final class HotkeyManager {
 
     static let shared = HotkeyManager()
 
     var onToggle: (() -> Void)?
+    var onShelf: (() -> Void)?
 
-    private var hotKeyRef: EventHotKeyRef?
+    struct Registration {
+        let toggle: Bool
+        let shelf: Bool
+    }
+
+    private enum HotkeyID: UInt32 {
+        case toggle = 1
+        case shelf = 2
+    }
+
+    private var toggleHotKeyRef: EventHotKeyRef?
+    private var shelfHotKeyRef: EventHotKeyRef?
     private var eventHandlerRef: EventHandlerRef?
     private let logger = Logger(subsystem: "com.ismatbabirli.Pelmet", category: "HotkeyManager")
 
-    /// Registers ⌥⌘B as the global toggle shortcut.
-    /// - Returns: `true` if the hotkey is live; `false` if installation or
-    ///   registration failed (usually another app already claimed ⌥⌘B).
-    func register() -> Bool {
+    /// Registers ⌥⌘B (toggle) and ⌥⌘N (Shelf) as global shortcuts.
+    /// Each registration can fail independently — usually because another
+    /// app already claimed the combination.
+    func register() -> Registration {
         var eventType = EventTypeSpec(
             eventClass: OSType(kEventClassKeyboard),
             eventKind: UInt32(kEventHotKeyPressed)
@@ -25,9 +37,24 @@ final class HotkeyManager {
 
         let handlerStatus = InstallEventHandler(
             GetApplicationEventTarget(),
-            { _, _, _ -> OSStatus in
+            { _, event, _ -> OSStatus in
+                var hotKeyID = EventHotKeyID()
+                let status = GetEventParameter(
+                    event,
+                    EventParamName(kEventParamDirectObject),
+                    EventParamType(typeEventHotKeyID),
+                    nil,
+                    MemoryLayout<EventHotKeyID>.size,
+                    nil,
+                    &hotKeyID
+                )
+                guard status == noErr else { return status }
                 DispatchQueue.main.async {
-                    HotkeyManager.shared.onToggle?()
+                    switch HotkeyID(rawValue: hotKeyID.id) {
+                    case .toggle: HotkeyManager.shared.onToggle?()
+                    case .shelf: HotkeyManager.shared.onShelf?()
+                    case nil: break
+                    }
                 }
                 return noErr
             },
@@ -38,30 +65,47 @@ final class HotkeyManager {
         )
         guard handlerStatus == noErr else {
             logger.error("Failed to install hotkey event handler (OSStatus \(handlerStatus))")
-            return false
+            return Registration(toggle: false, shelf: false)
         }
 
-        let hotKeyID = EventHotKeyID(signature: fourCharCode("PLMT"), id: 1)
-        let hotKeyStatus = RegisterEventHotKey(
-            UInt32(kVK_ANSI_B),
+        let toggle = registerHotkey(
+            id: .toggle, keyCode: UInt32(kVK_ANSI_B), ref: &toggleHotKeyRef, label: "⌥⌘B"
+        )
+        let shelf = registerHotkey(
+            id: .shelf, keyCode: UInt32(kVK_ANSI_N), ref: &shelfHotKeyRef, label: "⌥⌘N"
+        )
+        return Registration(toggle: toggle, shelf: shelf)
+    }
+
+    private func registerHotkey(
+        id: HotkeyID,
+        keyCode: UInt32,
+        ref: inout EventHotKeyRef?,
+        label: String
+    ) -> Bool {
+        let hotKeyID = EventHotKeyID(signature: fourCharCode("PLMT"), id: id.rawValue)
+        let status = RegisterEventHotKey(
+            keyCode,
             UInt32(cmdKey | optionKey),
             hotKeyID,
             GetApplicationEventTarget(),
             0,
-            &hotKeyRef
+            &ref
         )
-        if hotKeyStatus != noErr {
-            // Usually means another app already claimed ⌥⌘B.
-            logger.error("Failed to register ⌥⌘B global hotkey (OSStatus \(hotKeyStatus))")
+        if status != noErr {
+            // Usually means another app already claimed the combination.
+            logger.error("Failed to register \(label) global hotkey (OSStatus \(status))")
             return false
         }
         return true
     }
 
     func unregister() {
-        if let hotKeyRef { UnregisterEventHotKey(hotKeyRef) }
+        if let toggleHotKeyRef { UnregisterEventHotKey(toggleHotKeyRef) }
+        if let shelfHotKeyRef { UnregisterEventHotKey(shelfHotKeyRef) }
         if let eventHandlerRef { RemoveEventHandler(eventHandlerRef) }
-        hotKeyRef = nil
+        toggleHotKeyRef = nil
+        shelfHotKeyRef = nil
         eventHandlerRef = nil
     }
 }

--- a/Sources/Pelmet/LayoutStatus.swift
+++ b/Sources/Pelmet/LayoutStatus.swift
@@ -1,8 +1,9 @@
 import AppKit
 import Combine
+import PelmetCore
 
 /// Bridges live layout facts from MenuBarManager (AppKit) into SwiftUI
-/// surfaces (Settings, Make Room window).
+/// surfaces (Settings, Make Room window, the Shelf).
 final class LayoutStatus: ObservableObject {
 
     static let shared = LayoutStatus()
@@ -10,14 +11,18 @@ final class LayoutStatus: ObservableObject {
     @Published var swallowedCount = 0
     @Published var hasNotchedDisplay: Bool
     @Published var spacingProfile: MenuBarSpacing.Profile
+    /// One row per icon the notch hid — same source of truth as
+    /// `swallowedCount` (badge parity).
+    @Published var shelfEntries: [ShelfEntryModel] = []
 
     private init() {
         hasNotchedDisplay = NSScreen.screens.contains { $0.safeAreaInsets.top > 0 }
         spacingProfile = MenuBarSpacing.currentProfile()
     }
 
-    func refresh(swallowedCount: Int) {
+    func refresh(swallowedCount: Int, shelfEntries: [ShelfEntryModel]) {
         self.swallowedCount = swallowedCount
+        self.shelfEntries = shelfEntries
         hasNotchedDisplay = NSScreen.screens.contains { $0.safeAreaInsets.top > 0 }
     }
 

--- a/Sources/Pelmet/MenuBarManager.swift
+++ b/Sources/Pelmet/MenuBarManager.swift
@@ -54,6 +54,10 @@ final class MenuBarManager: NSObject {
     private var toggleRescueAttempts = 0
     private var lastToggleRescue = Date.distantPast
 
+    /// The Shelf's seam to the opt-in activation machinery. Always present;
+    /// degrades honestly when the Accessibility grant is absent.
+    var shelfEngine: StatusItemActivating { StatusItemActivationEngine.shared }
+
     // MARK: - Setup
 
     func setUp() {
@@ -118,6 +122,14 @@ final class MenuBarManager: NSObject {
             collapse()
         } else {
             expand(scheduleRehide: false)
+        }
+
+        StatusItemActivationEngine.shared.start()
+        // The engine's directory changes on its own schedule (grant lands,
+        // AX sweep enriches identity) — independent of the layout digest, so
+        // re-derive Shelf rows when it does.
+        shelfEngine.onDirectoryChange = { [weak self] _ in
+            self?.refreshShelfEntries()
         }
 
         NotchLayoutMonitor.shared.requestMeasurement(reason: .launch)
@@ -187,6 +199,8 @@ final class MenuBarManager: NSObject {
     }
 
     func collapse() {
+        // A Shelf left open over a collapsing bar would show stale rows.
+        ShelfPanelController.shared.hide(animated: false)
         isCollapsed = true
         Preferences.isCollapsed = true
         rehideTimer?.invalidate()
@@ -209,7 +223,8 @@ final class MenuBarManager: NSObject {
         separatorSwallowed = !isCollapsed && classification.separatorHealth == .swallowed
         updateToggleIcon()
 
-        LayoutStatus.shared.refresh(swallowedCount: swallowedCount)
+        refreshShelfEntries()
+
         if isCollapsed, classification.offscreenLeftCount > 0, !Preferences.hasEverManagedItems {
             Preferences.hasEverManagedItems = true
         }
@@ -219,6 +234,30 @@ final class MenuBarManager: NSObject {
         }
 
         reapplyOnboardingChecks()
+    }
+
+    /// Re-derives Shelf rows from the latest confirmed layout and the
+    /// engine's current directory, then pushes them to SwiftUI and any open
+    /// panel. Called both on a new layout snapshot AND when the engine's
+    /// directory changes (e.g. the Accessibility grant lands and the AX
+    /// sweep enriches identity) — the layout digest doesn't move on a grant,
+    /// so without this second trigger an open Shelf would stay stale.
+    func refreshShelfEntries() {
+        // Prefer the monitor's confirmed snapshot: on a fresh layout the
+        // engine's directory-change fires (via the multicast) before apply()
+        // updates our own `latestClassification`, so reading the monitor
+        // avoids deriving against a one-snapshot-stale classification.
+        guard let classification = NotchLayoutMonitor.shared.confirmed ?? latestClassification else { return }
+        let pids = Set(classification.items.flatMap(\.ownerPIDs))
+        let entries = ShelfContentDeriver.derive(
+            classification: classification,
+            apps: OwnerResolver.shared.resolve(pids: pids),
+            controlCenterPID: OwnerResolver.shared.controlCenterPID(),
+            ownPID: Int32(ProcessInfo.processInfo.processIdentifier),
+            engineItems: shelfEngine.activatableDescriptors
+        )
+        LayoutStatus.shared.refresh(swallowedCount: classification.swallowedCount, shelfEntries: entries)
+        ShelfPanelController.shared.update(entries: entries)
     }
 
     /// Runs the pending one-time tips against the latest confirmed layout.
@@ -232,6 +271,10 @@ final class MenuBarManager: NSObject {
             separatorVisible: classification.separatorHealth == .visible
         )
         OnboardingController.shared.maybeShowSwallowedEducation(
+            count: classification.swallowedCount,
+            toggle: toggleItem
+        )
+        OnboardingController.shared.maybeShowShelfTip(
             count: classification.swallowedCount,
             toggle: toggleItem
         )
@@ -263,12 +306,68 @@ final class MenuBarManager: NSObject {
 
     // MARK: - UI plumbing
 
+    /// Left-click matrix. The behavior differs from plain toggle ONLY when
+    /// the "+N" badge is visibly present — the button looks different in
+    /// exactly the states where it acts differently:
+    ///
+    ///   shelf open                              → close the Shelf
+    ///   collapsed                               → expand (unchanged)
+    ///   expanded, nothing swallowed             → collapse (unchanged)
+    ///   expanded, +N showing, shelf enabled     → open the Shelf
+    ///   expanded, +N showing, shelf disabled    → collapse (pre-Shelf behavior)
+    ///
+    /// ⌥⌘B always means plain toggle; right-click always means the menu.
     @objc private func toggleButtonClicked(_ sender: NSStatusBarButton) {
         if NSApp.currentEvent?.type == .rightMouseUp {
             showContextMenu()
-        } else {
-            toggle()
+            return
         }
+        if ShelfPanelController.shared.isVisible {
+            ShelfPanelController.shared.hide()
+            return
+        }
+        // Only diverge to "open Shelf" when the "+N" badge is actually
+        // visible — same condition updateToggleIcon() draws it under. If the
+        // user hid the count, the chevron looks like the plain toggle and
+        // must act like it.
+        if !isCollapsed, swallowedCount > 0,
+           Preferences.showSwallowedCount, Preferences.shelfEnabled {
+            openShelf(reason: .toggleClick)
+            return
+        }
+        toggle()
+    }
+
+    // MARK: - Shelf
+
+    func openShelfFromHotkey() {
+        if ShelfPanelController.shared.isVisible {
+            ShelfPanelController.shared.hide()
+        } else {
+            openShelf(reason: .hotkey)
+        }
+    }
+
+    @objc private func openShelfFromMenu() {
+        openShelf(reason: .menu)
+    }
+
+    private func openShelf(reason: ShelfPanelController.ShowReason) {
+        ShelfPanelController.shared.show(anchor: toggleItem.button, reason: reason)
+    }
+
+    /// The activation engine calls this when a target is one of Pelmet's
+    /// own collapse-hidden items: reveal the bar so it becomes clickable.
+    func expandForActivation() {
+        guard isCollapsed else { return }
+        expand(scheduleRehide: false)
+    }
+
+    /// Pelmet's own status-item window frames — excluded from activation
+    /// targets and drag neighbors.
+    var ownItemFrames: [CGRect] {
+        [separatorItem?.button?.window?.frame, toggleItem?.button?.window?.frame]
+            .compactMap { $0 }
     }
 
     /// State is conveyed by the chevron glyph and a plain-text count ONLY —
@@ -303,8 +402,15 @@ final class MenuBarManager: NSObject {
             tooltip = "The menu bar is full — Pelmet's divider is hidden by the notch. Right-click for options."
             accessibilityValue = "Icons shown. The divider is hidden — the menu bar is full."
         } else if swallowedCount > 0 {
-            tooltip = "\(countPhrase(swallowedCount)) by the notch. Right-click for ways to make room."
-            accessibilityValue = "Icons shown. \(countPhrase(swallowedCount)) by the notch."
+            // "Click to see them" only when a click actually opens the Shelf
+            // — i.e. the badge is visible (showCount) and the Shelf is on.
+            if showCount && Preferences.shelfEnabled {
+                tooltip = "\(countPhrase(swallowedCount)) by the notch. Click to see them; right-click for options."
+                accessibilityValue = "Icons shown. \(countPhrase(swallowedCount)) by the notch. Click to open the Shelf."
+            } else {
+                tooltip = "\(countPhrase(swallowedCount)) by the notch. Right-click for ways to make room."
+                accessibilityValue = "Icons shown. \(countPhrase(swallowedCount)) by the notch."
+            }
         } else {
             tooltip = "Pelmet — hide icons (⌥⌘B)"
             accessibilityValue = "Icons shown"
@@ -357,6 +463,19 @@ final class MenuBarManager: NSObject {
                 ]
             )
             menu.addItem(hint)
+
+            if swallowedCount > 0 {
+                // Always offered while something is hidden — the menu is the
+                // path that works even with the click-to-open pref off.
+                let shelfEntry = NSMenuItem(
+                    title: "See What's Hidden…",
+                    action: #selector(openShelfFromMenu),
+                    keyEquivalent: "n"
+                )
+                shelfEntry.keyEquivalentModifierMask = [.command, .option]
+                shelfEntry.target = self
+                menu.addItem(shelfEntry)
+            }
 
             let makeRoomEntry = NSMenuItem(
                 title: "Make Room…",

--- a/Sources/Pelmet/NotchLayoutMonitor.swift
+++ b/Sources/Pelmet/NotchLayoutMonitor.swift
@@ -16,6 +16,12 @@ import PelmetCore
 ///
 /// Main-thread only, like the rest of the app: timers and observers are
 /// scheduled on the main run loop.
+extension Notification.Name {
+    /// Posted after every newly confirmed layout classification, alongside
+    /// the single-consumer `onConfirmedChange` closure.
+    static let pelmetLayoutDidChange = Notification.Name("PelmetLayoutDidChange")
+}
+
 final class NotchLayoutMonitor {
 
     static let shared = NotchLayoutMonitor()
@@ -24,6 +30,10 @@ final class NotchLayoutMonitor {
 
     private(set) var confirmed: LayoutClassification?
     var onConfirmedChange: ((LayoutClassification) -> Void)?
+
+    /// Geometry of the most recent measurement (fresh or not) — a fallback
+    /// for consumers that need to position UI when a live read fails.
+    private(set) var lastGeometry: MenuBarGeometry?
 
     // MARK: - Wiring
 
@@ -105,11 +115,12 @@ final class NotchLayoutMonitor {
         }
 
         guard let geometry = currentGeometry() else { return }
-        let rawFrames = WindowListSource.statusItemWindowFrames()
-        guard !rawFrames.isEmpty else { return } // degraded read; keep prior state
+        lastGeometry = geometry
+        let rawWindows = WindowListSource.statusItemWindows()
+        guard !rawWindows.isEmpty else { return } // degraded read; keep prior state
 
         let classification = MenuBarLayoutClassifier.classify(
-            rawItemFrames: rawFrames,
+            rawItems: rawWindows,
             ownSeparatorFrame: separatorItem?.button?.window?.frame,
             ownToggleFrame: toggleItem?.button?.window?.frame,
             isCollapsed: isCollapsed(),
@@ -140,6 +151,10 @@ final class NotchLayoutMonitor {
                 }
                 fflush(stdout)
             }
+            // Multicast first: the activation engine rebuilds its directory
+            // on this, and MenuBarManager's closure below reads that
+            // directory — this order keeps them coherent within one snapshot.
+            NotificationCenter.default.post(name: .pelmetLayoutDidChange, object: self)
             onConfirmedChange?(classification)
         } else {
             // New reading — require one confirming measurement before the UI moves.
@@ -151,7 +166,7 @@ final class NotchLayoutMonitor {
         }
     }
 
-    private func currentGeometry() -> MenuBarGeometry? {
+    func currentGeometry() -> MenuBarGeometry? {
         // Warn only about the notched (built-in) display; on every other
         // display the full bar fits and there is nothing to say. Fall back
         // to the toggle's screen so collapse bookkeeping still works.

--- a/Sources/Pelmet/Onboarding/OnboardingController.swift
+++ b/Sources/Pelmet/Onboarding/OnboardingController.swift
@@ -47,7 +47,8 @@ final class OnboardingController: NSObject, NSPopoverDelegate {
     }
 
     /// The first time icons are detected hidden by the notch: explain the
-    /// count once, quietly.
+    /// count once, quietly. New users learn the Shelf here too — no second
+    /// popover for them.
     func maybeShowSwallowedEducation(count: Int, toggle: NSStatusItem) {
         guard activePopover == nil,
               !Preferences.didShowSwallowedEducation,
@@ -55,13 +56,34 @@ final class OnboardingController: NSObject, NSPopoverDelegate {
               count > 0,
               let button = toggle.button else { return }
         Preferences.didShowSwallowedEducation = true
+        Preferences.didShowShelfTip = true
         let phrase = count == 1 ? "1 icon doesn't fit" : "\(count) icons don't fit"
         show(
             title: phrase,
             message: "The notch hides menu bar icons that run out of room — macOS gives no warning. "
                 + "Pelmet shows a count beside its chevron whenever that happens. "
-                + "Right-click the chevron for ways to make room.",
+                + "Click the chevron to open the Shelf and see exactly what's hidden; "
+                + "right-click for ways to make room.",
             buttonTitle: "OK",
+            on: button
+        )
+    }
+
+    /// For users who learned the count BEFORE the Shelf existed: one quiet
+    /// popover the next time something is actually hidden.
+    func maybeShowShelfTip(count: Int, toggle: NSStatusItem) {
+        guard activePopover == nil,
+              Preferences.didShowSwallowedEducation,
+              !Preferences.didShowShelfTip,
+              Preferences.shelfEnabled,
+              count > 0,
+              let button = toggle.button else { return }
+        Preferences.didShowShelfTip = true
+        show(
+            title: "See what's hidden",
+            message: "New: when the chevron shows +\(count), click it to open the Shelf — "
+                + "a panel listing the icons the notch hid. ⌥⌘N works too.",
+            buttonTitle: "Got It",
             on: button
         )
     }

--- a/Sources/Pelmet/Preferences.swift
+++ b/Sources/Pelmet/Preferences.swift
@@ -14,6 +14,10 @@ enum Preferences {
         static let didShowToggleTip = "didShowToggleTip"
         static let didShowSwallowedEducation = "didShowSwallowedEducation"
         static let hasEverManagedItems = "hasEverManagedItems"
+        static let shelfEnabled = "shelfEnabled"
+        static let didShowShelfTip = "didShowShelfTip"
+        static let activationEngineEnabled = "activationEngineEnabled"
+        static let didPromptForAccessibility = "didPromptForAccessibility"
     }
 
     /// Last collapse state, restored at launch. Defaults to expanded so a
@@ -39,6 +43,29 @@ enum Preferences {
         UserDefaults.standard.object(forKey: Keys.showSwallowedCount) as? Bool ?? true
     }
 
+    /// Clicking the chevron while it shows "+N" opens the Shelf (the panel
+    /// listing icons the notch hid) instead of collapsing. The right-click
+    /// menu and ⌥⌘N open the Shelf regardless of this setting.
+    static var shelfEnabled: Bool {
+        UserDefaults.standard.object(forKey: Keys.shelfEnabled) as? Bool ?? true
+    }
+
+    /// Opt-in for the Accessibility-gated activation engine (one-click
+    /// opening of hidden items). Strictly off by default: the zero-permission
+    /// core is sacred.
+    static var activationEngineEnabled: Bool {
+        get { UserDefaults.standard.bool(forKey: Keys.activationEngineEnabled) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.activationEngineEnabled) }
+    }
+
+    /// Whether the system Accessibility prompt was ever triggered — needed to
+    /// tell "never asked" apart from "asked and declined" (TCC exposes no
+    /// notDetermined/denied distinction to the app).
+    static var didPromptForAccessibility: Bool {
+        get { UserDefaults.standard.bool(forKey: Keys.didPromptForAccessibility) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.didPromptForAccessibility) }
+    }
+
     // MARK: - One-time onboarding flags
 
     static var didShowDividerTip: Bool {
@@ -56,6 +83,11 @@ enum Preferences {
         set { UserDefaults.standard.set(newValue, forKey: Keys.didShowSwallowedEducation) }
     }
 
+    static var didShowShelfTip: Bool {
+        get { UserDefaults.standard.bool(forKey: Keys.didShowShelfTip) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.didShowShelfTip) }
+    }
+
     /// Set the first time a collapse actually hides icons — used to tell a
     /// brand-new user apart from someone who already uses the divider.
     static var hasEverManagedItems: Bool {
@@ -67,5 +99,6 @@ enum Preferences {
         didShowDividerTip = false
         didShowToggleTip = false
         didShowSwallowedEducation = false
+        didShowShelfTip = false
     }
 }

--- a/Sources/Pelmet/Settings/SettingsView.swift
+++ b/Sources/Pelmet/Settings/SettingsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 import ServiceManagement
 
@@ -6,7 +7,10 @@ struct SettingsView: View {
     @AppStorage(Preferences.Keys.autoRehide) private var autoRehide = true
     @AppStorage(Preferences.Keys.rehideDelay) private var rehideDelay = 10.0
     @AppStorage(Preferences.Keys.showSwallowedCount) private var showSwallowedCount = true
+    @AppStorage(Preferences.Keys.shelfEnabled) private var shelfEnabled = true
+    @AppStorage(Preferences.Keys.activationEngineEnabled) private var activationEngineEnabled = false
     @ObservedObject private var status = LayoutStatus.shared
+    @ObservedObject private var activation = ActivationStatus.shared
     @State private var launchAtLogin = (SMAppService.mainApp.status == .enabled)
     @State private var launchAtLoginError: String?
 
@@ -44,6 +48,17 @@ struct SettingsView: View {
                         value: status.swallowedCount == 0 ? "None right now" : "\(status.swallowedCount)"
                     )
                     Toggle("Show a count on the chevron when icons don't fit", isOn: $showSwallowedCount)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Toggle("Open the Shelf when clicking the count", isOn: $shelfEnabled)
+                        Text("The Shelf is a panel under the notch listing the icons macOS hid. "
+                            + "Turned off, a click always hides/shows icons instead — the Shelf stays "
+                            + "one right-click (or ⌥⌘N) away.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
                     LabeledContent("Icon spacing", value: status.spacingProfile.label)
                     HStack {
                         Button("Make Room…") {
@@ -54,6 +69,43 @@ struct SettingsView: View {
                                 MenuBarSpacing.apply(.systemDefault)
                                 status.refreshSpacing()
                             }
+                        }
+                    }
+                }
+
+                Section("One-Click Access") {
+                    VStack(alignment: .leading, spacing: 4) {
+                        Toggle("Open hidden icons with one click", isOn: Binding(
+                            get: { activationEngineEnabled },
+                            set: { enabled in
+                                MenuBarManager.shared.shelfEngine.setEnabled(enabled)
+                                if enabled { MenuBarManager.shared.shelfEngine.requestAccess() }
+                            }
+                        ))
+                        Text("Pelmet will read which app owns each menu bar icon and simulate "
+                            + "clicks to open them. It never reads your screen. Turn this off any "
+                            + "time; everything else keeps working.")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+
+                    if activationEngineEnabled {
+                        switch activation.availability {
+                        case .granted:
+                            LabeledContent("Accessibility permission", value: "Granted")
+                        case .denied:
+                            VStack(alignment: .leading, spacing: 4) {
+                                LabeledContent("Accessibility permission", value: "Not granted")
+                                Text("Grant it in System Settings → Privacy & Security → Accessibility.")
+                                    .font(.caption)
+                                    .foregroundStyle(.secondary)
+                                Button("Open System Settings…") {
+                                    openAccessibilitySettings()
+                                }
+                            }
+                        case .notDetermined:
+                            LabeledContent("Accessibility permission", value: "Waiting for approval…")
                         }
                     }
                 }
@@ -87,6 +139,7 @@ struct SettingsView: View {
                 }
 
                 LabeledContent("Toggle shortcut", value: "⌥⌘B")
+                LabeledContent("Shelf shortcut", value: "⌥⌘N")
 
                 Button("Show Welcome Tips Again") {
                     OnboardingController.shared.replayTips()
@@ -96,6 +149,11 @@ struct SettingsView: View {
         .formStyle(.grouped)
         .frame(width: 420)
         .fixedSize(horizontal: false, vertical: true)
+    }
+
+    private func openAccessibilitySettings() {
+        let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!
+        NSWorkspace.shared.open(url)
     }
 
     private func updateLaunchAtLogin(_ enabled: Bool) {

--- a/Sources/Pelmet/Shelf/OwnerResolver.swift
+++ b/Sources/Pelmet/Shelf/OwnerResolver.swift
@@ -1,0 +1,65 @@
+import AppKit
+import PelmetCore
+
+/// Resolves window-owner PIDs to app metadata and icons via
+/// NSRunningApplication — permission-free. The Shelf and the activation
+/// engine both lean on this.
+final class OwnerResolver {
+
+    static let shared = OwnerResolver()
+
+    private var iconCache: [Int32: NSImage] = [:]
+    private var observer: NSObjectProtocol?
+
+    private init() {
+        observer = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didTerminateApplicationNotification,
+            object: nil, queue: .main
+        ) { [weak self] note in
+            guard let app = note.userInfo?[NSWorkspace.applicationUserInfoKey] as? NSRunningApplication else {
+                self?.iconCache.removeAll()
+                return
+            }
+            self?.iconCache.removeValue(forKey: app.processIdentifier)
+        }
+    }
+
+    func info(for pid: Int32) -> RunningAppInfo? {
+        guard let app = NSRunningApplication(processIdentifier: pid) else { return nil }
+        return RunningAppInfo(
+            pid: pid,
+            bundleID: app.bundleIdentifier,
+            localizedName: app.localizedName
+        )
+    }
+
+    func resolve(pids: Set<Int32>) -> [Int32: RunningAppInfo] {
+        var result: [Int32: RunningAppInfo] = [:]
+        for pid in pids {
+            if let info = info(for: pid) { result[pid] = info }
+        }
+        return result
+    }
+
+    /// Control Center's PID — on macOS 26 (Tahoe) it owns every status-item
+    /// window, which is exactly why its PID must never count as identity.
+    func controlCenterPID() -> Int32? {
+        NSRunningApplication
+            .runningApplications(withBundleIdentifier: "com.apple.controlcenter")
+            .first?.processIdentifier
+    }
+
+    func icon(forPID pid: Int32) -> NSImage? {
+        if let cached = iconCache[pid] { return cached }
+        guard let icon = NSRunningApplication(processIdentifier: pid)?.icon else { return nil }
+        iconCache[pid] = icon
+        return icon
+    }
+
+    /// Tier-0 fallback "activation": bring the owning app forward. Not the
+    /// item's menu — that needs the engine — but proof of life the user can
+    /// act on.
+    func activateApp(pid: Int32) {
+        NSRunningApplication(processIdentifier: pid)?.activate(options: [])
+    }
+}

--- a/Sources/Pelmet/Shelf/ShelfPanel.swift
+++ b/Sources/Pelmet/Shelf/ShelfPanel.swift
@@ -1,0 +1,63 @@
+import AppKit
+
+/// The Shelf's window: borderless, non-activating, floating just below the
+/// menu bar (level 25 — the same `.statusBar` level status items live at,
+/// verified against `NSWindow.Level.mainMenu.rawValue == 24`). It follows
+/// the active Space and shows over fullscreen apps as an auxiliary panel.
+///
+/// IMPORTANT: the panel's width must stay ABOVE 300pt. It shares the
+/// status-item window level, and `MenuBarLayoutClassifier` rejects windows
+/// wider than `maxPlausibleItemWidth` (300) — plus the panel sits below the
+/// menu bar band. Two independent guards keep Pelmet from classifying its
+/// own Shelf as a menu bar item.
+final class ShelfPanel: NSPanel {
+
+    /// Arrow keys, Return and Esc arrive here from `keyDown` and are routed
+    /// by the controller; SwiftUI focus in borderless panels is unreliable
+    /// on macOS 13, so keyboard handling stays at the AppKit layer.
+    var onKeyCommand: ((KeyCommand) -> Bool)?
+
+    enum KeyCommand {
+        case moveUp, moveDown, activate, cancel
+    }
+
+    init() {
+        super.init(
+            contentRect: .zero,
+            styleMask: [.nonactivatingPanel, .borderless, .fullSizeContentView],
+            backing: .buffered,
+            defer: true
+        )
+        level = .statusBar
+        collectionBehavior = [.fullScreenAuxiliary, .ignoresCycle, .moveToActiveSpace]
+        isOpaque = false
+        backgroundColor = .clear
+        hasShadow = true
+        isMovable = false
+        hidesOnDeactivate = false
+        becomesKeyOnlyIfNeeded = true
+        isReleasedWhenClosed = false
+        animationBehavior = .none // fades are driven manually, gated on Reduce Motion
+    }
+
+    /// Non-activating panels may still become key so keyboard users can
+    /// drive the Shelf without activating Pelmet.
+    override var canBecomeKey: Bool { true }
+
+    override func keyDown(with event: NSEvent) {
+        let command: KeyCommand?
+        switch event.keyCode {
+        case 126: command = .moveUp
+        case 125: command = .moveDown
+        case 36, 76: command = .activate   // Return, keypad Enter
+        case 53: command = .cancel         // Esc
+        default: command = nil
+        }
+        if let command, onKeyCommand?(command) == true { return }
+        super.keyDown(with: event)
+    }
+
+    override func cancelOperation(_ sender: Any?) {
+        _ = onKeyCommand?(.cancel)
+    }
+}

--- a/Sources/Pelmet/Shelf/ShelfPanelController.swift
+++ b/Sources/Pelmet/Shelf/ShelfPanelController.swift
@@ -1,0 +1,230 @@
+import AppKit
+import SwiftUI
+import PelmetCore
+
+/// Owns the Shelf panel's lifecycle: placement below the notch, dismiss
+/// triggers, live content updates, and the auto-rehide pause while open.
+/// Every show() is user-initiated (click, hotkey, menu item) — the Shelf
+/// NEVER auto-shows, which is also what keeps it out of fullscreen apps
+/// uninvited. (A future hover accelerator must preserve that constraint.)
+final class ShelfPanelController {
+
+    static let shared = ShelfPanelController()
+
+    enum ShowReason {
+        case toggleClick, hotkey, menu
+    }
+
+    private(set) lazy var panel: ShelfPanel = makePanel()
+    private lazy var viewModel = ShelfViewModel(engine: MenuBarManager.shared.shelfEngine)
+    private var hosting: NSHostingController<ShelfView>?
+
+    private weak var anchorButton: NSStatusBarButton?
+    private var globalMouseMonitor: Any?
+    private var localMouseMonitor: Any?
+    private var observers: [(center: NotificationCenter, token: NSObjectProtocol)] = []
+    private var emptyAutoHideTimer: Timer?
+    private var lastRowCount = 0
+
+    var isVisible: Bool { panelIfLoaded?.isVisible ?? false }
+    private var panelLoaded = false
+    private var panelIfLoaded: ShelfPanel? { panelLoaded ? panel : nil }
+
+    // MARK: - Show / hide
+
+    func show(anchor: NSStatusBarButton?, reason: ShowReason) {
+        anchorButton = anchor
+        let panel = self.panel // force lazy construction (sets `hosting`)
+
+        // Fresh facts for a surface the user is looking at right now.
+        NotchLayoutMonitor.shared.requestMeasurement(reason: .menuOpened)
+        viewModel.update(entries: LayoutStatus.shared.shelfEntries)
+        lastRowCount = viewModel.rows.count
+
+        guard let hosting else { return }
+        hosting.view.layoutSubtreeIfNeeded()
+        let size = hosting.view.fittingSize
+        let geometry = NotchLayoutMonitor.shared.currentGeometry()
+            ?? NotchLayoutMonitor.shared.lastGeometry
+            ?? fallbackGeometry()
+        let frame = ShelfPlacement.panelFrame(
+            panelSize: size,
+            anchorFrame: anchor?.window?.frame,
+            geometry: geometry
+        )
+
+        let wasVisible = panel.isVisible
+        panel.setFrame(frame, display: true)
+
+        if !wasVisible {
+            UIActivityTracker.shared.surfaceOpened()
+            installDismissMonitors()
+            revealPanel(reason: reason)
+        } else if reason == .hotkey {
+            panel.makeKey()
+        }
+    }
+
+    func hide(animated: Bool = true) {
+        guard isVisible else { return }
+        removeDismissMonitors()
+        emptyAutoHideTimer?.invalidate()
+        emptyAutoHideTimer = nil
+        viewModel.expandedExplanationID = nil
+
+        let finish = { [panel] in
+            panel.orderOut(nil)
+            panel.alphaValue = 1
+        }
+        if animated, !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion {
+            NSAnimationContext.runAnimationGroup({ context in
+                context.duration = 0.12
+                panel.animator().alphaValue = 0
+            }, completionHandler: finish)
+        } else {
+            finish()
+        }
+        UIActivityTracker.shared.surfaceClosed()
+    }
+
+    /// Live refresh from every confirmed layout snapshot while open.
+    func update(entries: [ShelfEntryModel]) {
+        guard isVisible else { return }
+        viewModel.update(entries: entries)
+
+        if entries.isEmpty, lastRowCount > 0 {
+            // Everything fits again — say so briefly, then get out of the way.
+            emptyAutoHideTimer?.invalidate()
+            emptyAutoHideTimer = Timer.scheduledTimer(withTimeInterval: 1.5, repeats: false) { [weak self] _ in
+                self?.hide()
+            }
+        } else if !entries.isEmpty {
+            emptyAutoHideTimer?.invalidate()
+            emptyAutoHideTimer = nil
+        }
+        lastRowCount = entries.count
+
+        if let hosting {
+            hosting.view.layoutSubtreeIfNeeded()
+            let size = hosting.view.fittingSize
+            if abs(size.height - panel.frame.height) > 0.5 {
+                var frame = panel.frame
+                frame.origin.y = frame.maxY - size.height
+                frame.size = size
+                panel.setFrame(frame, display: true)
+            }
+        }
+    }
+
+    // MARK: - Panel construction
+
+    private func makePanel() -> ShelfPanel {
+        let panel = ShelfPanel()
+        let hosting = NSHostingController(rootView: ShelfView(model: viewModel))
+        hosting.view.wantsLayer = true
+        panel.contentViewController = hosting
+        self.hosting = hosting
+        viewModel.onRequestClose = { [weak self] in self?.hide() }
+        panel.onKeyCommand = { [weak self] command in
+            self?.viewModel.handle(command) ?? false
+        }
+        panelLoaded = true
+        return panel
+    }
+
+    private func revealPanel(reason: ShowReason) {
+        let reduceMotion = NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+        if reduceMotion {
+            panel.alphaValue = 1
+            panel.orderFrontRegardless()
+        } else {
+            // Fade in with a 4pt downward settle.
+            let target = panel.frame
+            var start = target
+            start.origin.y += 4
+            panel.setFrame(start, display: false)
+            panel.alphaValue = 0
+            panel.orderFrontRegardless()
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.18
+                context.timingFunction = CAMediaTimingFunction(name: .easeOut)
+                panel.animator().alphaValue = 1
+                panel.animator().setFrame(target, display: true)
+            }
+        }
+        // Always become key so Esc and arrow-key navigation work regardless
+        // of how the Shelf was opened. A .nonactivatingPanel becomes key
+        // without activating Pelmet, so this doesn't steal focus from the
+        // frontmost app. `reason` no longer changes this — kept for the
+        // future hover accelerator, which will want to stay non-key.
+        _ = reason
+        panel.makeKey()
+    }
+
+    private func fallbackGeometry() -> MenuBarGeometry {
+        let screen = NSScreen.screens.first { $0.safeAreaInsets.top > 0 } ?? NSScreen.main
+        let frame = screen?.frame ?? CGRect(x: 0, y: 0, width: 1512, height: 982)
+        return MenuBarGeometry(
+            screenFrame: frame,
+            notchRect: nil,
+            menuBarHeight: max(NSStatusBar.system.thickness, screen?.safeAreaInsets.top ?? 24)
+        )
+    }
+
+    // MARK: - Dismiss triggers
+
+    private func installDismissMonitors() {
+        // Global mouse monitors are permission-free (only keyboard monitoring
+        // is Accessibility-gated). Clicks on the toggle itself are left to
+        // the click matrix — hiding here on mouseDown would make the
+        // toggle's mouseUp handler reopen the shelf it just closed.
+        globalMouseMonitor = NSEvent.addGlobalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown]
+        ) { [weak self] _ in
+            guard let self else { return }
+            // Our own Tier-1 activation posts a synthetic click into another
+            // app; a global monitor sees it. Never treat that as a dismiss.
+            if ActivationExecutor.shared.isActivating { return }
+            if let toggleWindow = self.anchorButton?.window,
+               toggleWindow.frame.contains(NSEvent.mouseLocation) { return }
+            self.hide()
+        }
+        localMouseMonitor = NSEvent.addLocalMonitorForEvents(
+            matching: [.leftMouseDown, .rightMouseDown]
+        ) { [weak self] event in
+            guard let self else { return event }
+            if ActivationExecutor.shared.isActivating { return event }
+            if event.window !== self.panelIfLoaded {
+                if let toggleWindow = self.anchorButton?.window, event.window === toggleWindow {
+                    return event
+                }
+                self.hide()
+            }
+            return event
+        }
+        let workspaceCenter = NSWorkspace.shared.notificationCenter
+        observers = [
+            (workspaceCenter, workspaceCenter.addObserver(
+                forName: NSWorkspace.activeSpaceDidChangeNotification,
+                object: nil, queue: .main
+            ) { [weak self] _ in
+                self?.hide(animated: false)
+            }),
+            (.default, NotificationCenter.default.addObserver(
+                forName: NSApplication.didChangeScreenParametersNotification,
+                object: nil, queue: .main
+            ) { [weak self] _ in
+                self?.hide(animated: false)
+            }),
+        ]
+    }
+
+    private func removeDismissMonitors() {
+        if let globalMouseMonitor { NSEvent.removeMonitor(globalMouseMonitor) }
+        if let localMouseMonitor { NSEvent.removeMonitor(localMouseMonitor) }
+        globalMouseMonitor = nil
+        localMouseMonitor = nil
+        observers.forEach { $0.center.removeObserver($0.token) }
+        observers = []
+    }
+}

--- a/Sources/Pelmet/Shelf/ShelfView.swift
+++ b/Sources/Pelmet/Shelf/ShelfView.swift
@@ -1,0 +1,239 @@
+import SwiftUI
+import PelmetCore
+
+/// The Shelf's content: a frosted card listing the icons the notch hid.
+/// Rows are real buttons (VoiceOver reads them for free); keyboard events
+/// arrive from the panel via the view model, not SwiftUI focus.
+struct ShelfView: View {
+
+    @ObservedObject var model: ShelfViewModel
+
+    /// Must stay above 300 — see the classifier note in ShelfPanel.
+    static let panelWidth: CGFloat = 340
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            if !model.rows.isEmpty {
+                header
+                    .padding(.horizontal, 14)
+                    .padding(.top, 12)
+                    .padding(.bottom, 6)
+            }
+
+            if model.rows.isEmpty {
+                emptyState
+                    .padding(.top, 12)
+            } else {
+                VStack(spacing: 1) {
+                    ForEach(Array(model.rows.enumerated()), id: \.element.id) { index, row in
+                        rowView(row, isSelected: model.selectedIndex == index)
+                        if model.expandedExplanationID == row.id {
+                            explanationCallout(for: row)
+                        }
+                        if let failure = model.inlineFailure, failure.rowID == row.id {
+                            failureCallout(failure.message)
+                        }
+                    }
+                }
+                .padding(.horizontal, 6)
+            }
+
+            if !model.rows.isEmpty {
+                footer
+                    .padding(.horizontal, 14)
+                    .padding(.top, 8)
+                    .padding(.bottom, 10)
+            }
+        }
+        .frame(width: Self.panelWidth)
+        .background(ShelfBackground())
+        .clipShape(RoundedRectangle(cornerRadius: 12, style: .continuous))
+        .overlay(
+            RoundedRectangle(cornerRadius: 12, style: .continuous)
+                .strokeBorder(Color.primary.opacity(0.12), lineWidth: 0.5)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Pelmet Shelf — icons hidden by the notch")
+    }
+
+    // MARK: - Sections
+
+    private var header: some View {
+        Text(headerText)
+            .font(.subheadline.weight(.semibold))
+            .foregroundStyle(.secondary)
+            .accessibilityAddTraits(.isHeader)
+    }
+
+    private var headerText: String {
+        switch model.tier {
+        case .owners, .engine:
+            return "Hidden by the notch"
+        case .anonymous:
+            return "Hidden by the notch — macOS 26 hides which apps these belong to"
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: 6) {
+            Image(systemName: "checkmark.circle")
+                .font(.title2)
+                .foregroundStyle(.secondary)
+            Text("Everything fits — nothing is hidden by the notch.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity)
+        .padding(.vertical, 18)
+    }
+
+    private func rowView(_ row: ShelfRow, isSelected: Bool) -> some View {
+        Button {
+            model.activate(row)
+        } label: {
+            HStack(spacing: 10) {
+                rowIcon(row)
+                    .frame(width: 20, height: 20)
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(rowTitle(row))
+                        .font(.body)
+                        .lineLimit(1)
+                    if let subtitle = rowSubtitle(row) {
+                        Text(subtitle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                            .lineLimit(1)
+                    }
+                }
+                Spacer(minLength: 0)
+            }
+            .padding(.horizontal, 8)
+            .frame(height: 36)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+            .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(isSelected ? Color.accentColor.opacity(0.22) : Color.clear)
+            )
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(rowTitle(row))
+        .accessibilityHint(rowAccessibilityHint(row))
+    }
+
+    @ViewBuilder
+    private func rowIcon(_ row: ShelfRow) -> some View {
+        if let icon = row.icon {
+            Image(nsImage: icon)
+                .resizable()
+                .scaledToFit()
+        } else {
+            Image(systemName: "questionmark.app.dashed")
+                .font(.system(size: 15))
+                .foregroundStyle(.secondary)
+        }
+    }
+
+    private func rowTitle(_ row: ShelfRow) -> String {
+        switch row.model.kind {
+        case .app(_, let name, _): return name
+        case .engineItem(_, let title, _): return title
+        case .unknown(let ordinal): return "Hidden item \(ordinal)"
+        }
+    }
+
+    private func rowSubtitle(_ row: ShelfRow) -> String? {
+        if case .app(_, _, let count) = row.model.kind, count > 1 {
+            return "\(count) items"
+        }
+        return nil
+    }
+
+    private func rowAccessibilityHint(_ row: ShelfRow) -> String {
+        switch row.model.kind {
+        case .engineItem:
+            return "Opens this menu bar item."
+        case .app:
+            return "Brings the app forward. Enable one-click access to open the menu bar item directly."
+        case .unknown:
+            return "Shows what Pelmet can do about this hidden item."
+        }
+    }
+
+    @ViewBuilder
+    private func explanationCallout(for row: ShelfRow) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(explanationText(for: row))
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            if model.canOfferEngineOptIn {
+                Button("Enable one-click access…") {
+                    model.requestEngineOptIn()
+                }
+                .font(.caption)
+            }
+        }
+        .padding(10)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(
+            RoundedRectangle(cornerRadius: 6, style: .continuous)
+                .fill(Color.primary.opacity(0.05))
+        )
+    }
+
+    private func explanationText(for row: ShelfRow) -> String {
+        switch row.model.kind {
+        case .app(_, let name, _):
+            return "macOS won't let Pelmet open \(name)'s menu without the Accessibility permission — one-click access is opt-in and never reads your screen."
+        default:
+            return "Enable one-click access to identify these items and open them with a single click. It uses the Accessibility permission and never reads your screen."
+        }
+    }
+
+    private func failureCallout(_ message: String) -> some View {
+        Text(message)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
+            .padding(10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(Color.yellow.opacity(0.12))
+            )
+    }
+
+    private var footer: some View {
+        HStack {
+            Button("Make Room…") {
+                MakeRoomWindowController.shared.show()
+                model.onRequestClose?()
+            }
+            .font(.caption)
+            Spacer()
+            if model.canOfferEngineOptIn, !model.rows.isEmpty {
+                Button("Enable one-click access…") {
+                    model.requestEngineOptIn()
+                }
+                .font(.caption)
+            }
+        }
+        .buttonStyle(.link)
+    }
+}
+
+/// Frosted background. NSVisualEffectView natively honors Reduce
+/// Transparency (draws opaque), so no extra handling is needed.
+private struct ShelfBackground: NSViewRepresentable {
+    func makeNSView(context: Context) -> NSVisualEffectView {
+        let view = NSVisualEffectView()
+        view.material = .menu
+        view.blendingMode = .behindWindow
+        view.state = .active
+        return view
+    }
+
+    func updateNSView(_ nsView: NSVisualEffectView, context: Context) {}
+}

--- a/Sources/Pelmet/Shelf/ShelfViewModel.swift
+++ b/Sources/Pelmet/Shelf/ShelfViewModel.swift
@@ -1,0 +1,158 @@
+import AppKit
+import Combine
+import PelmetCore
+
+/// What the Shelf currently knows how to say about its rows.
+enum ShelfTier {
+    /// Rows carry app identity (≤ Sequoia CGWindow owners, permission-free).
+    case owners
+    /// Ownership unknown (Tahoe without the engine grant).
+    case anonymous
+    /// Engine-enriched rows — one click opens the real item.
+    case engine
+}
+
+struct ShelfRow: Identifiable, Equatable {
+    let model: ShelfEntryModel
+    let icon: NSImage?
+    var id: String { model.id }
+
+    static func == (lhs: ShelfRow, rhs: ShelfRow) -> Bool {
+        lhs.model == rhs.model && lhs.icon === rhs.icon
+    }
+}
+
+final class ShelfViewModel: ObservableObject {
+
+    @Published private(set) var rows: [ShelfRow] = []
+    @Published private(set) var tier: ShelfTier = .owners
+    @Published private(set) var engineAvailability: ActivationAvailability = .notDetermined
+    /// Row whose inline explanation callout is expanded (Tier 0 clicks).
+    @Published var expandedExplanationID: String?
+    /// Row whose activation just failed, with the message to show.
+    @Published private(set) var inlineFailure: (rowID: String, message: String)?
+    /// Keyboard selection; nil until the user arrows into the list.
+    @Published private(set) var selectedIndex: Int?
+
+    /// Set by the controller: close the panel (successful activation, Esc).
+    var onRequestClose: (() -> Void)?
+
+    private let engine: StatusItemActivating
+
+    init(engine: StatusItemActivating) {
+        self.engine = engine
+        engineAvailability = engine.availability
+    }
+
+    var canOfferEngineOptIn: Bool {
+        tier != .engine && engineAvailability != .granted
+    }
+
+    func update(entries: [ShelfEntryModel]) {
+        rows = entries.map { entry in
+            ShelfRow(model: entry, icon: icon(for: entry))
+        }
+        tier = Self.tier(for: entries)
+        engineAvailability = engine.availability
+        if let selected = selectedIndex, selected >= rows.count {
+            selectedIndex = rows.isEmpty ? nil : rows.count - 1
+        }
+        if let expanded = expandedExplanationID, !rows.contains(where: { $0.id == expanded }) {
+            expandedExplanationID = nil
+        }
+        if let failure = inlineFailure, !rows.contains(where: { $0.id == failure.rowID }) {
+            inlineFailure = nil
+        }
+    }
+
+    static func tier(for entries: [ShelfEntryModel]) -> ShelfTier {
+        if entries.contains(where: { if case .engineItem = $0.kind { return true } else { return false } }) {
+            return .engine
+        }
+        if !entries.isEmpty, entries.allSatisfy({ if case .unknown = $0.kind { return true } else { return false } }) {
+            return .anonymous
+        }
+        return .owners
+    }
+
+    // MARK: - Row content helpers
+
+    private func icon(for entry: ShelfEntryModel) -> NSImage? {
+        switch entry.kind {
+        case .app(let pid, _, _):
+            return OwnerResolver.shared.icon(forPID: pid)
+        case .engineItem(_, _, let ownerPID):
+            return ownerPID.flatMap { OwnerResolver.shared.icon(forPID: $0) }
+        case .unknown:
+            return nil
+        }
+    }
+
+    // MARK: - Actions
+
+    func activate(_ row: ShelfRow) {
+        inlineFailure = nil
+        switch row.model.kind {
+        case .engineItem(let token, _, _):
+            engine.activate(recordID: token) { [weak self] result in
+                guard let self else { return }
+                switch result {
+                case .activated:
+                    self.onRequestClose?()
+                case .failed(let failure):
+                    self.inlineFailure = (row.id, Self.failureMessage(failure))
+                }
+            }
+        case .app(let pid, _, _):
+            // Tier 0: the honest best effort is bringing the app forward,
+            // plus the explanation of why the icon itself can't open yet.
+            OwnerResolver.shared.activateApp(pid: pid)
+            expandedExplanationID = expandedExplanationID == row.id ? nil : row.id
+        case .unknown:
+            expandedExplanationID = expandedExplanationID == row.id ? nil : row.id
+        }
+    }
+
+    func requestEngineOptIn() {
+        engine.setEnabled(true)
+        engine.requestAccess()
+    }
+
+    static func failureMessage(_ failure: ActivationFailure) -> String {
+        switch failure {
+        case .permissionDenied:
+            return "Pelmet needs the Accessibility permission to open items."
+        case .itemVanished:
+            return "That icon just disappeared — it may have been closed."
+        case .blockedByNotch, .noRoomToExpose:
+            return "Couldn't open it — the bar is too full. Try Make Room."
+        case .busy, .userInteracting:
+            return "Busy — try again in a moment."
+        case .interrupted, .timedOut:
+            return "Couldn't open it — try again."
+        }
+    }
+
+    // MARK: - Keyboard
+
+    /// Returns true when the key was consumed.
+    func handle(_ command: ShelfPanel.KeyCommand) -> Bool {
+        switch command {
+        case .moveUp:
+            guard !rows.isEmpty else { return false }
+            selectedIndex = max((selectedIndex ?? rows.count) - 1, 0)
+            return true
+        case .moveDown:
+            guard !rows.isEmpty else { return false }
+            selectedIndex = min((selectedIndex ?? -1) + 1, rows.count - 1)
+            return true
+        case .activate:
+            guard let index = selectedIndex, rows.indices.contains(index) else { return false }
+            activate(rows[index])
+            return true
+        case .cancel:
+            onRequestClose?()
+            return true
+        }
+    }
+}

--- a/Sources/Pelmet/WindowListSource.swift
+++ b/Sources/Pelmet/WindowListSource.swift
@@ -1,19 +1,27 @@
 import AppKit
+import PelmetCore
 
 /// The only file that talks to the window server. Everything it uses is
 /// public API that requires no permission, triggers no TCC prompt, and never
 /// lights the screen-capture privacy indicator: `CGWindowListCopyWindowInfo`
-/// returns window bounds/level metadata freely (only window *titles* are
-/// gated behind Screen Recording, and Pelmet never reads those).
+/// returns window bounds/level/owner metadata freely (only window *titles*
+/// are gated behind Screen Recording, and Pelmet never reads those —
+/// `kCGWindowOwnerPID` is in the same free metadata tier as bounds).
 enum WindowListSource {
 
     /// Level 25 is the status-item window level (`NSWindow.Level.statusBar`).
     private static let statusItemWindowLevel = 25
 
-    /// Frames of every status-item window on all displays, converted to
-    /// AppKit screen coordinates (bottom-left origin). Includes duplicates
-    /// and Pelmet's own items — `MenuBarLayoutClassifier` filters both.
-    static func statusItemWindowFrames() -> [CGRect] {
+    /// Every status-item window on all displays, converted to AppKit screen
+    /// coordinates (bottom-left origin), with its owning process where the
+    /// window server reports one. Includes duplicates and Pelmet's own items
+    /// — `MenuBarLayoutClassifier` filters both.
+    ///
+    /// Ownership caveat: on macOS 26 (Tahoe) Control Center re-parents
+    /// third-party status-item windows, so `ownerPID` is Control Center's
+    /// for all of them. Consumers must treat Control-Center-owned frames as
+    /// "owner unknown" rather than trusting the PID.
+    static func statusItemWindows() -> [RawStatusWindow] {
         guard
             let primary = NSScreen.screens.first,
             let list = CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as? [[String: Any]]
@@ -31,7 +39,10 @@ enum WindowListSource {
                 let x = bounds["X"], let y = bounds["Y"],
                 let width = bounds["Width"], let height = bounds["Height"]
             else { return nil }
-            return CGRect(x: x, y: primaryMaxY - y - height, width: width, height: height)
+            return RawStatusWindow(
+                frame: CGRect(x: x, y: primaryMaxY - y - height, width: width, height: height),
+                ownerPID: info[kCGWindowOwnerPID as String] as? Int32
+            )
         }
     }
 }

--- a/Sources/PelmetCore/Activation/ActivationPlanner.swift
+++ b/Sources/PelmetCore/Activation/ActivationPlanner.swift
@@ -1,0 +1,142 @@
+import CoreGraphics
+import Foundation
+
+/// A drag of one visible neighbor item leftward past the notch, so macOS
+/// reflows the status area and the blocked target shifts into visible
+/// space. Coordinates are AppKit screen coordinates.
+public struct DragPlan: Equatable {
+    /// The neighbor being dragged (its frame at planning time).
+    public let neighborFrame: CGRect
+    public let from: CGPoint
+    public let to: CGPoint
+
+    public init(neighborFrame: CGRect, from: CGPoint, to: CGPoint) {
+        self.neighborFrame = neighborFrame
+        self.from = from
+        self.to = to
+    }
+}
+
+/// One step the executor knows how to perform. Strategies run in planner
+/// order; each click-ish step gets a verification window before the next
+/// one runs.
+public enum ActivationStrategy: Equatable {
+    /// Target was pushed off-screen by Pelmet's own collapse: expand first,
+    /// re-resolve, and re-plan. (Handled by the executor before any session
+    /// starts — never reaches a session.)
+    case expandCollapsedBar
+    /// Warp-assisted synthetic click at a fixed point (the speculative
+    /// in-place click for notch-swallowed items; the only step needed for
+    /// visible ones).
+    case syntheticClick(at: CGPoint)
+    /// AXPress on the item's live AX element. Unreliable on many apps
+    /// (menus collapse after ~1s) — verification requires persistence.
+    case axPress
+    /// Temporarily activate Finder so a frontmost app's wide menus don't
+    /// overlap the slot the drag is about to expose.
+    case appMenuClearance
+    /// Cmd-drag a visible neighbor left of the notch to make room.
+    case dragToExpose(DragPlan)
+    /// After the reflow: click the target at its freshly re-resolved
+    /// position (the executor computes the actual point).
+    case clickTargetAfterReflow
+}
+
+/// Pure strategy planning from classifier facts. The executor interprets;
+/// this decides.
+public enum ActivationPlanner {
+
+    public static func plan(
+        target: MenuBarItemRecord,
+        allItems: [MenuBarItemRecord],
+        ownFrames: [CGRect],
+        geometry: MenuBarGeometry,
+        hasAXElement: Bool
+    ) -> [ActivationStrategy] {
+        switch target.visibility {
+        case .suspectedGhost:
+            return []
+        case .offscreenLeft:
+            return [.expandCollapsedBar]
+        case .visible:
+            return [.syntheticClick(at: center(of: target.frame))]
+        case .swallowedByNotch:
+            // MenuDown's proven order: speculative in-place click (the
+            // window server discards notch-zone clicks "often, but not
+            // always"), AXPress if we hold an element, then make room.
+            var strategies: [ActivationStrategy] = [
+                .syntheticClick(at: center(of: target.frame)),
+            ]
+            if hasAXElement {
+                strategies.append(.axPress)
+            }
+            if let dragPlan = DragPlanner.plan(
+                target: target, allItems: allItems, ownFrames: ownFrames, geometry: geometry
+            ) {
+                strategies.append(.appMenuClearance)
+                strategies.append(.dragToExpose(dragPlan))
+                strategies.append(.clickTargetAfterReflow)
+            }
+            return strategies
+        }
+    }
+
+    static func center(of frame: CGRect) -> CGPoint {
+        CGPoint(x: frame.midX, y: frame.midY)
+    }
+}
+
+public enum DragPlanner {
+
+    /// Gap kept between the dragged neighbor and the notch / screen edge.
+    public static let margin: CGFloat = 8
+    /// Frames ending this close to the right screen edge are the clock
+    /// cluster — never drag those.
+    public static let clockClusterMargin: CGFloat = 8
+
+    /// Picks the visible neighbor nearest to the notch (right side) and
+    /// computes the leftward drag that fully vacates its slot. Returns nil
+    /// when nothing can safely move — the caller fails with
+    /// `.noRoomToExpose` instead of guessing.
+    public static func plan(
+        target: MenuBarItemRecord,
+        allItems: [MenuBarItemRecord],
+        ownFrames: [CGRect],
+        geometry: MenuBarGeometry
+    ) -> DragPlan? {
+        guard let notch = geometry.notchRect else { return nil }
+
+        let candidates = allItems.filter { item in
+            item.visibility == .visible
+                && item.id != target.id
+                && item.frame.minX > notch.maxX
+                && item.frame.maxX < geometry.screenFrame.maxX - clockClusterMargin
+                && !ownFrames.contains { own in
+                    abs(own.midX - item.frame.midX) < 2
+                }
+        }
+
+        // Nearest to the notch; when identity is known, prefer third-party
+        // items (dragging aggregated system items is the fragile case).
+        let neighbor = candidates.min { a, b in
+            let aOwned = a.identity != nil, bOwned = b.identity != nil
+            if aOwned != bOwned { return aOwned }
+            return a.frame.minX < b.frame.minX
+        }
+        guard let neighbor else { return nil }
+
+        let width = neighbor.frame.width
+        var destinationX = notch.minX - width / 2 - margin
+        destinationX = max(destinationX, geometry.screenFrame.minX + width / 2 + margin)
+        // If clamping couldn't put the neighbor fully left of the notch,
+        // the left side is packed too — moving it wouldn't free the slot.
+        guard destinationX + width / 2 <= notch.minX else { return nil }
+
+        let y = neighbor.frame.midY
+        return DragPlan(
+            neighborFrame: neighbor.frame,
+            from: CGPoint(x: neighbor.frame.midX, y: y),
+            to: CGPoint(x: destinationX, y: y)
+        )
+    }
+}

--- a/Sources/PelmetCore/Activation/ActivationSession.swift
+++ b/Sources/PelmetCore/Activation/ActivationSession.swift
@@ -1,0 +1,158 @@
+import CoreGraphics
+import Foundation
+
+/// The pure activation state machine: events in, effects out, no I/O.
+/// The executor performs effects and feeds results back as events; every
+/// rule about ordering, retries, verification and aborts lives HERE so it
+/// is unit-testable without AppKit.
+///
+/// Rules encoded:
+///  - strategies run in planner order; each click-ish step gets one
+///    verification window (0.7s clicks, 1.2s AXPress — an AXPress "menu"
+///    that collapses before ~1.1s is the known ghost-menu failure, so its
+///    verification uses persistence, which the executor implements);
+///  - exactly ONE retry total: the first strategy re-runs once after all
+///    strategies exhaust, and only if no drag was performed;
+///  - the drag path never retries; a failed drag ends the session;
+///  - any abort releases mouse buttons BEFORE finishing, and schedules the
+///    restore drag if the neighbor already moved;
+///  - unverified after the FINAL click is soft success for targets that
+///    were visible (or made visible by reflow) — many items open panels we
+///    can't classify; for swallowed targets that never got a reflow click,
+///    it is an honest failure instead.
+public struct ActivationSession {
+
+    public enum Event: Equatable {
+        case begin
+        /// The current strategy's action was performed (click posted, drag
+        /// completed, clearance done).
+        case stepCompleted
+        /// The current strategy could not be performed at all.
+        case stepFailed
+        case verified(ActivationVerification)
+        case verificationTimedOut
+        case aborted(ActivationFailure)
+    }
+
+    public enum Effect: Equatable {
+        case perform(ActivationStrategy)
+        /// Start polling for a newly opened menu window; feed back
+        /// `.verified` or `.verificationTimedOut`.
+        case startVerification(deadline: TimeInterval)
+        /// Post a balanced mouse-up if any synthetic button might be down.
+        case releaseMouseButtons
+        /// After the session finishes and the opened menu closes: drag the
+        /// neighbor back to its original slot.
+        case restoreDrag(DragPlan)
+        case finish(ActivationResult)
+    }
+
+    public static let clickVerification: TimeInterval = 0.7
+    public static let axPressVerification: TimeInterval = 1.2
+
+    private let strategies: [ActivationStrategy]
+    private let targetWasSwallowed: Bool
+    private var index = 0
+    private var didRetry = false
+    /// True while the single first-strategy retry is in flight — the chain
+    /// does NOT continue past it.
+    private var retrying = false
+    private var dragPerformed: DragPlan?
+    private var reflowClickHappened = false
+    private var anyClickPosted = false
+    private var finished = false
+
+    public init(strategies: [ActivationStrategy], targetWasSwallowed: Bool) {
+        self.strategies = strategies
+        self.targetWasSwallowed = targetWasSwallowed
+    }
+
+    public mutating func handle(_ event: Event) -> [Effect] {
+        guard !finished else { return [] }
+        switch event {
+        case .begin:
+            guard let first = strategies.first else {
+                return finish(.failed(.itemVanished))
+            }
+            return [.perform(first)]
+
+        case .stepCompleted:
+            switch current {
+            case .syntheticClick:
+                anyClickPosted = true
+                return [.startVerification(deadline: Self.clickVerification)]
+            case .clickTargetAfterReflow:
+                anyClickPosted = true
+                reflowClickHappened = true
+                return [.startVerification(deadline: Self.clickVerification)]
+            case .axPress:
+                return [.startVerification(deadline: Self.axPressVerification)]
+            case .appMenuClearance, .expandCollapsedBar:
+                return advance()
+            case .dragToExpose(let plan):
+                dragPerformed = plan
+                return advance()
+            case nil:
+                return []
+            }
+
+        case .stepFailed:
+            if case .dragToExpose = current {
+                // A drag that couldn't run means the make-room path is
+                // closed; clicking "after reflow" without a reflow would
+                // hit the dead zone again.
+                return finish(.failed(.noRoomToExpose))
+            }
+            return advance()
+
+        case .verified(let verification):
+            return finish(.activated(verification))
+
+        case .verificationTimedOut:
+            return advance()
+
+        case .aborted(let failure):
+            var effects: [Effect] = [.releaseMouseButtons]
+            effects.append(contentsOf: finish(.failed(failure)))
+            return effects
+        }
+    }
+
+    // MARK: - Internals
+
+    private var current: ActivationStrategy? {
+        if retrying { return strategies.first }
+        return strategies.indices.contains(index) ? strategies[index] : nil
+    }
+
+    private mutating func advance() -> [Effect] {
+        if !retrying {
+            index += 1
+            if let next = current {
+                return [.perform(next)]
+            }
+            // Exhausted. One retry of the FIRST strategy only, unless the
+            // bar was already rearranged by a drag.
+            if !didRetry, dragPerformed == nil, let first = strategies.first,
+               case .syntheticClick = first {
+                didRetry = true
+                retrying = true
+                return [.perform(first)]
+            }
+        }
+        if anyClickPosted, reflowClickHappened || !targetWasSwallowed {
+            return finish(.activated(.unverified))
+        }
+        return finish(.failed(targetWasSwallowed ? .noRoomToExpose : .timedOut))
+    }
+
+    private mutating func finish(_ result: ActivationResult) -> [Effect] {
+        finished = true
+        var effects: [Effect] = []
+        if let dragPerformed {
+            effects.append(.restoreDrag(dragPerformed))
+        }
+        effects.append(.finish(result))
+        return effects
+    }
+}

--- a/Sources/PelmetCore/Activation/ActivationTypes.swift
+++ b/Sources/PelmetCore/Activation/ActivationTypes.swift
@@ -1,0 +1,132 @@
+import CoreGraphics
+import Foundation
+
+/// Whether the Accessibility-gated activation engine may act. TCC exposes no
+/// notDetermined/denied distinction, so the split is reconstructed from
+/// "feature enabled" + "did we ever trigger the prompt" + `AXIsProcessTrusted`.
+public enum ActivationAvailability: Equatable {
+    /// Feature never enabled, or enabled but the system prompt never shown.
+    case notDetermined
+    /// Enabled and prompted, but the app is not trusted (declined/revoked).
+    case denied
+    case granted
+}
+
+/// Hygiene filter for AX titles: many apps expose junk internal identifiers
+/// ("menubaricon_v3", bundle ids, UUIDs). Only titles that look like words
+/// a human wrote are worth showing over the app name.
+public enum TitleHygiene {
+    public static func meaningfulTitle(
+        _ raw: String?,
+        appName: String,
+        bundleID: String?
+    ) -> String? {
+        guard let raw else { return nil }
+        let title = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !title.isEmpty,
+              title.count <= 40,
+              title.rangeOfCharacter(from: .letters) != nil,
+              title.caseInsensitiveCompare(appName) != .orderedSame,
+              title != bundleID,
+              !title.contains("_"),
+              // Reverse-DNS-ish strings are identifiers, not titles.
+              title.filter({ $0 == "." }).count < 2
+        else { return nil }
+        return title
+    }
+}
+
+/// Who owns a status item, as far as any data source could tell.
+public struct ItemIdentity: Equatable {
+    public let pid: Int32
+    public let bundleIdentifier: String?
+    /// Display string — always prefer this; AX titles are often junk
+    /// internal identifiers.
+    public let appName: String
+    /// Surfaced only when it passed the "meaningful title" hygiene filter.
+    public let axTitle: String?
+
+    public init(pid: Int32, bundleIdentifier: String?, appName: String, axTitle: String?) {
+        self.pid = pid
+        self.bundleIdentifier = bundleIdentifier
+        self.appName = appName
+        self.axTitle = axTitle
+    }
+}
+
+/// How much the current directory actually knows.
+public enum DirectoryFidelity: Equatable {
+    /// Frames + visibility only — no trustworthy ownership (Tahoe without
+    /// the Accessibility grant, or a future macOS that broke both sources).
+    case framesOnly
+    /// Ownership available (CGWindow owner on ≤ Sequoia, or the AX sweep).
+    case identified
+}
+
+/// One status item the engine knows about: classifier geometry + optional
+/// identity.
+public struct MenuBarItemRecord: Identifiable, Equatable {
+    public let id: String
+    /// Classifier frame, AppKit screen coordinates.
+    public let frame: CGRect
+    public let visibility: ItemVisibility
+    public let identity: ItemIdentity?
+
+    public init(frame: CGRect, visibility: ItemVisibility, identity: ItemIdentity?) {
+        self.id = MenuBarItemRecord.makeID(frame: frame, pid: identity?.pid)
+        self.frame = frame
+        self.visibility = visibility
+        self.identity = identity
+    }
+
+    /// Stable across re-measurements of an unmoved item: PID plus rounded
+    /// midX (identity survives small frame jitter via the rounding).
+    public static func makeID(frame: CGRect, pid: Int32?) -> String {
+        let midX = Int((frame.midX / 4).rounded()) * 4
+        if let pid { return "\(pid):\(midX)" }
+        return "frame:\(midX)x\(Int(frame.width.rounded()))"
+    }
+}
+
+public struct DirectorySnapshot: Equatable {
+    public let records: [MenuBarItemRecord]
+    public let fidelity: DirectoryFidelity
+    public let capturedAt: Date
+
+    public init(records: [MenuBarItemRecord], fidelity: DirectoryFidelity, capturedAt: Date) {
+        self.records = records
+        self.fidelity = fidelity
+        self.capturedAt = capturedAt
+    }
+
+    public static let empty = DirectorySnapshot(records: [], fidelity: .framesOnly, capturedAt: .distantPast)
+}
+
+/// Whether an activation was confirmed to have opened something.
+public enum ActivationVerification: Equatable {
+    case menuOpened
+    /// The final click was posted but no new menu window was detected —
+    /// reported as soft success (many items open panels we can't classify).
+    case unverified
+}
+
+public enum ActivationFailure: Equatable {
+    case permissionDenied
+    case itemVanished
+    /// The item sits in the notch dead zone and no strategy got through.
+    case blockedByNotch
+    /// No visible neighbor could be moved to make room.
+    case noRoomToExpose
+    /// Another activation is already in flight (or rate-limited).
+    case busy
+    /// The user is mid-drag/mid-click; refusing to fight them.
+    case userInteracting
+    /// Space change, screen lock, or session resign mid-flight.
+    case interrupted
+    case timedOut
+}
+
+public enum ActivationResult: Equatable {
+    case activated(ActivationVerification)
+    case failed(ActivationFailure)
+}

--- a/Sources/PelmetCore/Activation/StatusItemCorrelator.swift
+++ b/Sources/PelmetCore/Activation/StatusItemCorrelator.swift
@@ -1,0 +1,75 @@
+import CoreGraphics
+import Foundation
+
+/// One status item as an identity source observed it (AX sweep or CGWindow
+/// owner) — pure value type, AppKit coordinates.
+public struct ItemObservation: Equatable {
+    public let pid: Int32
+    public let title: String?
+    /// nil when the source couldn't read a position.
+    public let frame: CGRect?
+
+    public init(pid: Int32, title: String?, frame: CGRect?) {
+        self.pid = pid
+        self.title = title
+        self.frame = frame
+    }
+}
+
+/// Merges identity observations onto classifier output. The classifier's
+/// frames stay the single source of truth for geometry and visibility;
+/// observations only contribute identity.
+public enum StatusItemCorrelator {
+
+    /// Two frames must overlap horizontally by at least this fraction of
+    /// the narrower one to be the same item.
+    public static let minOverlapFraction: CGFloat = 0.5
+
+    /// Greedy best-overlap matching: strongest (overlap, then closest
+    /// midX) pairs win; each observation is used at most once. Items with
+    /// no qualifying observation get nil. Frameless observations never
+    /// match (there is nothing to correlate on).
+    public static func correlate(
+        classified: [ClassifiedItem],
+        observed: [ItemObservation]
+    ) -> [(item: ClassifiedItem, observation: ItemObservation?)] {
+        struct Candidate {
+            let itemIndex: Int
+            let observationIndex: Int
+            let overlap: CGFloat
+            let midXDelta: CGFloat
+        }
+
+        var candidates: [Candidate] = []
+        for (itemIndex, item) in classified.enumerated() {
+            for (observationIndex, observation) in observed.enumerated() {
+                guard let frame = observation.frame else { continue }
+                let overlap = min(item.frame.maxX, frame.maxX) - max(item.frame.minX, frame.minX)
+                let narrower = min(item.frame.width, frame.width)
+                guard narrower > 0, overlap >= narrower * minOverlapFraction else { continue }
+                candidates.append(Candidate(
+                    itemIndex: itemIndex,
+                    observationIndex: observationIndex,
+                    overlap: overlap,
+                    midXDelta: abs(item.frame.midX - frame.midX)
+                ))
+            }
+        }
+        candidates.sort {
+            $0.overlap != $1.overlap ? $0.overlap > $1.overlap : $0.midXDelta < $1.midXDelta
+        }
+
+        var observationForItem = [Int: Int]()
+        var usedObservations = Set<Int>()
+        for candidate in candidates {
+            guard observationForItem[candidate.itemIndex] == nil,
+                  !usedObservations.contains(candidate.observationIndex) else { continue }
+            observationForItem[candidate.itemIndex] = candidate.observationIndex
+            usedObservations.insert(candidate.observationIndex)
+        }
+
+        return classified.enumerated().map { index, item in
+            (item: item, observation: observationForItem[index].map { observed[$0] })
+        }
+    }
+}

--- a/Sources/PelmetCore/MenuBarLayoutClassifier.swift
+++ b/Sources/PelmetCore/MenuBarLayoutClassifier.swift
@@ -38,13 +38,32 @@ public enum ItemVisibility: Equatable {
     case suspectedGhost
 }
 
+/// A status-item window as the window server reports it: a frame in AppKit
+/// screen coordinates plus the owning process, when known. On macOS 26
+/// (Tahoe) Control Center re-parents third-party items, so the PID there is
+/// Control Center's — consumers must treat that as "owner unknown".
+public struct RawStatusWindow: Equatable {
+    public let frame: CGRect
+    public let ownerPID: Int32?
+
+    public init(frame: CGRect, ownerPID: Int32? = nil) {
+        self.frame = frame
+        self.ownerPID = ownerPID
+    }
+}
+
 public struct ClassifiedItem: Equatable {
     public let frame: CGRect
     public let visibility: ItemVisibility
+    /// Owner PIDs of every window in this item's overlap-cluster, in order
+    /// of appearance: a real item can be backed by both its app's window and
+    /// a Control Center mirror. Empty when the window server reported none.
+    public let ownerPIDs: [Int32]
 
-    public init(frame: CGRect, visibility: ItemVisibility) {
+    public init(frame: CGRect, visibility: ItemVisibility, ownerPIDs: [Int32] = []) {
         self.frame = frame
         self.visibility = visibility
+        self.ownerPIDs = ownerPIDs
     }
 }
 
@@ -120,7 +139,7 @@ public enum MenuBarLayoutClassifier {
     static let frameMatchTolerance: CGFloat = 1.5
 
     public static func classify(
-        rawItemFrames: [CGRect],
+        rawItems: [RawStatusWindow],
         ownSeparatorFrame: CGRect?,
         ownToggleFrame: CGRect?,
         isCollapsed: Bool,
@@ -129,23 +148,25 @@ public enum MenuBarLayoutClassifier {
         let band = geometry.band
         let ownFrames = [ownSeparatorFrame, ownToggleFrame].compactMap { $0 }
 
-        let candidates = rawItemFrames.filter { frame in
-            band.contains(CGPoint(x: frame.midX, y: frame.midY))
+        let candidates = rawItems.filter { window in
+            let frame = window.frame
+            return band.contains(CGPoint(x: frame.midX, y: frame.midY))
                 && frame.width > 4 && frame.width <= maxPlausibleItemWidth
                 && !ownFrames.contains(where: { matches($0, frame) })
         }
 
         let deduped = dedupe(candidates)
 
-        let items = deduped.map { frame in
+        let items = deduped.map { cluster in
             ClassifiedItem(
-                frame: frame,
+                frame: cluster.frame,
                 visibility: visibility(
-                    of: frame,
+                    of: cluster.frame,
                     isCollapsed: isCollapsed,
                     separatorFrame: ownSeparatorFrame,
                     geometry: geometry
-                )
+                ),
+                ownerPIDs: cluster.ownerPIDs
             )
         }
 
@@ -184,6 +205,18 @@ public enum MenuBarLayoutClassifier {
         if isCollapsed, let sep = separatorFrame, frame.maxX <= sep.minX + 2 {
             return .offscreenLeft
         }
+        if let sep = separatorFrame {
+            // A real item can never overlap Pelmet's own separator window —
+            // the bar lays items out side by side. A frame substantially
+            // inside the separator's span is a stale twin parked at an old
+            // layout position (observed after collapse: twins linger at the
+            // previous EXPANDED positions, in-bar, for minutes — the other
+            // ghost zones don't catch those).
+            let overlap = min(sep.maxX, frame.maxX) - max(sep.minX, frame.minX)
+            if overlap > frame.width * overlapDedupeFraction {
+                return .suspectedGhost
+            }
+        }
         if abs(frame.minX - 0) < 0.5 {
             // Exactly x == 0 is the item-birth position — a stale twin left
             // behind when an item was created and immediately moved. Real
@@ -215,21 +248,27 @@ public enum MenuBarLayoutClassifier {
         abs(a.minX - b.minX) <= frameMatchTolerance && abs(a.width - b.width) <= frameMatchTolerance
     }
 
-    /// Cluster frames whose x-ranges substantially overlap and keep one per
-    /// cluster. Adjacent distinct items never overlap; mirrors overlap fully
-    /// and mid-layout ghosts by half or more.
-    static func dedupe(_ frames: [CGRect]) -> [CGRect] {
-        let sorted = frames.sorted { $0.minX < $1.minX }
-        var result: [CGRect] = []
-        for frame in sorted {
+    /// Cluster windows whose x-ranges substantially overlap and keep one
+    /// frame per cluster, merging the cluster's owner PIDs (a real item can
+    /// be backed by its app's window plus a Control Center mirror). Adjacent
+    /// distinct items never overlap; mirrors overlap fully and mid-layout
+    /// ghosts by half or more.
+    static func dedupe(_ windows: [RawStatusWindow]) -> [(frame: CGRect, ownerPIDs: [Int32])] {
+        let sorted = windows.sorted { $0.frame.minX < $1.frame.minX }
+        var result: [(frame: CGRect, ownerPIDs: [Int32])] = []
+        for window in sorted {
+            let frame = window.frame
             if let last = result.last {
-                let overlap = min(last.maxX, frame.maxX) - max(last.minX, frame.minX)
-                let narrower = min(last.width, frame.width)
+                let overlap = min(last.frame.maxX, frame.maxX) - max(last.frame.minX, frame.minX)
+                let narrower = min(last.frame.width, frame.width)
                 if overlap > narrower * overlapDedupeFraction {
+                    if let pid = window.ownerPID, !last.ownerPIDs.contains(pid) {
+                        result[result.count - 1].ownerPIDs.append(pid)
+                    }
                     continue
                 }
             }
-            result.append(frame)
+            result.append((frame: frame, ownerPIDs: window.ownerPID.map { [$0] } ?? []))
         }
         return result
     }

--- a/Sources/PelmetCore/ScreenCoordinates.swift
+++ b/Sources/PelmetCore/ScreenCoordinates.swift
@@ -1,0 +1,31 @@
+import CoreGraphics
+
+/// Conversions between the two global coordinate systems Pelmet straddles:
+/// CoreGraphics/window-server coordinates (top-left origin, y grows down)
+/// and AppKit screen coordinates (bottom-left origin, y grows up). Both
+/// flips pivot on the primary screen's top edge (`primaryMaxY` in AppKit
+/// coordinates, which equals the CG origin's y).
+public enum ScreenCoordinates {
+
+    public static func appKitRect(fromCG rect: CGRect, primaryMaxY: CGFloat) -> CGRect {
+        CGRect(
+            x: rect.origin.x,
+            y: primaryMaxY - rect.origin.y - rect.height,
+            width: rect.width,
+            height: rect.height
+        )
+    }
+
+    public static func cgRect(fromAppKit rect: CGRect, primaryMaxY: CGFloat) -> CGRect {
+        // The flip is its own inverse.
+        appKitRect(fromCG: rect, primaryMaxY: primaryMaxY)
+    }
+
+    public static func appKitPoint(fromCG point: CGPoint, primaryMaxY: CGFloat) -> CGPoint {
+        CGPoint(x: point.x, y: primaryMaxY - point.y)
+    }
+
+    public static func cgPoint(fromAppKit point: CGPoint, primaryMaxY: CGFloat) -> CGPoint {
+        appKitPoint(fromCG: point, primaryMaxY: primaryMaxY)
+    }
+}

--- a/Sources/PelmetCore/ShelfContent.swift
+++ b/Sources/PelmetCore/ShelfContent.swift
@@ -1,0 +1,196 @@
+import CoreGraphics
+import Foundation
+
+/// Owner metadata the app layer resolves from NSRunningApplication.
+/// Pure value type — no NSImage here; icons stay in the app layer.
+public struct RunningAppInfo: Equatable {
+    public let pid: Int32
+    public let bundleID: String?
+    public let localizedName: String?
+
+    public init(pid: Int32, bundleID: String?, localizedName: String?) {
+        self.pid = pid
+        self.bundleID = bundleID
+        self.localizedName = localizedName
+    }
+}
+
+/// What the Accessibility engine hands the deriver for enrichment — a pure
+/// descriptor of one activatable item. Empty array when the engine is
+/// absent or not authorized.
+public struct EngineItemDescriptor: Equatable {
+    /// Opaque activation handle, engine-owned (a MenuBarItemRecord id).
+    public let token: String
+    /// nil when the engine has no meaningful name for the item — the
+    /// deriver falls back to app name or a numbered "Hidden item N".
+    public let title: String?
+    public let ownerPID: Int32?
+    /// AppKit screen coordinates; nil when the AX position was unavailable.
+    public let frame: CGRect?
+
+    public init(token: String, title: String?, ownerPID: Int32?, frame: CGRect?) {
+        self.token = token
+        self.title = title
+        self.ownerPID = ownerPID
+        self.frame = frame
+    }
+}
+
+/// One row of the Shelf.
+public struct ShelfEntryModel: Equatable, Identifiable {
+    public enum Kind: Equatable {
+        /// Owner resolved without the engine (≤ Sequoia: CGWindow owner).
+        /// `itemCount > 1` means consecutive items of the same app were
+        /// grouped into this one row.
+        case app(pid: Int32, name: String, itemCount: Int)
+        /// Ownership unknown (Tahoe without the engine: every window is
+        /// Control Center's). `ordinal` is 1-based, left to right.
+        case unknown(ordinal: Int)
+        /// Engine-enriched: real title + activation token.
+        case engineItem(token: String, title: String, ownerPID: Int32?)
+    }
+
+    public let id: String
+    public let kind: Kind
+    /// The real menu-bar frame (leftmost member for grouped rows) — the
+    /// left-to-right sort key, and where activation ultimately lands.
+    public let frame: CGRect
+
+    public init(id: String, kind: Kind, frame: CGRect) {
+        self.id = id
+        self.kind = kind
+        self.frame = frame
+    }
+}
+
+/// Pure derivation of Shelf rows from a layout classification.
+///
+/// Source-of-truth rule (badge parity): the rows are exactly the
+/// classification's `.swallowedByNotch` items — the same set the "+N" badge
+/// counts. Engine items only ENRICH rows (title, activation token); they
+/// never add or remove any.
+public enum ShelfContentDeriver {
+
+    /// Engine frames must land within this of a classified item's midX to
+    /// enrich it.
+    public static let frameMatchTolerance: CGFloat = 8
+
+    public static func derive(
+        classification: LayoutClassification,
+        apps: [Int32: RunningAppInfo],
+        controlCenterPID: Int32?,
+        ownPID: Int32,
+        engineItems: [EngineItemDescriptor]
+    ) -> [ShelfEntryModel] {
+        let swallowed = classification.items
+            .filter { $0.visibility == .swallowedByNotch }
+            // Defensively drop Pelmet's own windows if frame exclusion ever
+            // slips — better a missing row than Pelmet listing itself.
+            .filter { !$0.ownerPIDs.contains(ownPID) }
+            .sorted { $0.frame.minX < $1.frame.minX }
+
+        guard !swallowed.isEmpty else { return [] }
+
+        // Owner = first PID that isn't the Control Center mirror. On Tahoe
+        // every window is Control-Center-owned, so this yields nil there —
+        // anonymity is emergent from the data, not an OS version check.
+        let owners: [Int32?] = swallowed.map { item in
+            item.ownerPIDs.first { $0 != controlCenterPID }
+        }
+
+        // Enrichment pass 1: match engine descriptors to items by frame.
+        var descriptorForItem = [Int: EngineItemDescriptor]()
+        var unmatched = engineItems
+        for (index, item) in swallowed.enumerated() {
+            guard let match = unmatched.firstIndex(where: { descriptor in
+                guard let frame = descriptor.frame else { return false }
+                return abs(frame.midX - item.frame.midX) <= frameMatchTolerance
+            }) else { continue }
+            descriptorForItem[index] = unmatched.remove(at: match)
+        }
+        // Pass 2: frameless descriptors match by owner PID when both sides
+        // are unambiguous (exactly one unenriched item and one descriptor
+        // for that PID).
+        for descriptor in unmatched where descriptor.frame == nil {
+            guard let pid = descriptor.ownerPID else { continue }
+            let itemIndices = swallowed.indices.filter {
+                owners[$0] == pid && descriptorForItem[$0] == nil
+            }
+            let twins = engineItems.filter { $0.frame == nil && $0.ownerPID == pid }
+            if itemIndices.count == 1, twins.count == 1 {
+                descriptorForItem[itemIndices[0]] = descriptor
+            }
+        }
+        // Descriptors with no classified counterpart are dropped: badge parity.
+
+        var entries: [ShelfEntryModel] = []
+        var unknownOrdinal = 0
+        for (index, item) in swallowed.enumerated() {
+            if let descriptor = descriptorForItem[index] {
+                // Engine rows still deserve the best available name: real
+                // title → owning app's name → numbered fallback (same
+                // numbering the anonymous tier uses).
+                let ownerPID = descriptor.ownerPID ?? owners[index]
+                let title: String
+                if let real = descriptor.title {
+                    title = real
+                } else if let pid = ownerPID, let info = apps[pid],
+                          let name = info.localizedName ?? info.bundleID {
+                    title = name
+                } else {
+                    unknownOrdinal += 1
+                    title = "Hidden item \(unknownOrdinal)"
+                }
+                entries.append(ShelfEntryModel(
+                    id: "engine-\(descriptor.token)",
+                    kind: .engineItem(
+                        token: descriptor.token,
+                        title: title,
+                        ownerPID: ownerPID
+                    ),
+                    frame: item.frame
+                ))
+                continue
+            }
+            if let pid = owners[index], let info = apps[pid],
+               let name = info.localizedName ?? info.bundleID {
+                entries.append(ShelfEntryModel(
+                    id: "app-\(pid)-\(index)",
+                    kind: .app(pid: pid, name: name, itemCount: 1),
+                    frame: item.frame
+                ))
+                continue
+            }
+            unknownOrdinal += 1
+            entries.append(ShelfEntryModel(
+                id: "unknown-\(unknownOrdinal)",
+                kind: .unknown(ordinal: unknownOrdinal),
+                frame: item.frame
+            ))
+        }
+
+        // Without engine titles, Tier 0 can't distinguish (or individually
+        // activate) two items of the same app — "Dropbox — 2 items" beats
+        // two identical "Dropbox" rows. With the engine, never group.
+        return engineItems.isEmpty ? groupConsecutiveSameApp(entries) : entries
+    }
+
+    private static func groupConsecutiveSameApp(_ entries: [ShelfEntryModel]) -> [ShelfEntryModel] {
+        var result: [ShelfEntryModel] = []
+        for entry in entries {
+            if case .app(let pid, let name, let count) = entry.kind,
+               let last = result.last,
+               case .app(let lastPID, _, let lastCount) = last.kind,
+               pid == lastPID {
+                result[result.count - 1] = ShelfEntryModel(
+                    id: last.id,
+                    kind: .app(pid: pid, name: name, itemCount: lastCount + count),
+                    frame: last.frame
+                )
+            } else {
+                result.append(entry)
+            }
+        }
+        return result
+    }
+}

--- a/Sources/PelmetCore/ShelfPlacement.swift
+++ b/Sources/PelmetCore/ShelfPlacement.swift
@@ -1,0 +1,35 @@
+import CoreGraphics
+
+/// Pure panel-frame math for the Shelf, in AppKit (bottom-left origin)
+/// screen coordinates.
+public enum ShelfPlacement {
+
+    /// Where the Shelf panel goes: just below the menu bar band, centered on
+    /// the toggle when its position is known, else on the notch, else on the
+    /// screen — always clamped inside the screen with a margin.
+    public static func panelFrame(
+        panelSize: CGSize,
+        anchorFrame: CGRect?,     // toggle button's window frame; nil if unknown/swallowed
+        geometry: MenuBarGeometry,
+        edgeMargin: CGFloat = 8,
+        gap: CGFloat = 6
+    ) -> CGRect {
+        let screen = geometry.screenFrame
+        let top = screen.maxY - geometry.menuBarHeight - gap
+
+        let preferredCenterX = anchorFrame?.midX
+            ?? geometry.notchRect?.midX
+            ?? screen.midX
+
+        var minX = preferredCenterX - panelSize.width / 2
+        minX = max(minX, screen.minX + edgeMargin)
+        minX = min(minX, screen.maxX - edgeMargin - panelSize.width)
+
+        return CGRect(
+            x: minX,
+            y: top - panelSize.height,
+            width: panelSize.width,
+            height: panelSize.height
+        )
+    }
+}

--- a/Tests/PelmetCoreTests/ActivationPlannerTests.swift
+++ b/Tests/PelmetCoreTests/ActivationPlannerTests.swift
@@ -1,0 +1,211 @@
+import Testing
+@testable import PelmetCore
+import CoreGraphics
+
+/// Fixture: 14" MacBook Pro — screen 1512×982, notch x∈[663, 848],
+/// band 33pt at y=949 (same as the classifier tests).
+struct ActivationPlannerTests {
+
+    private let geometry = MenuBarGeometry(
+        screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+        notchRect: CGRect(x: 663, y: 950, width: 185, height: 32),
+        menuBarHeight: 33
+    )
+
+    private func bar(_ minX: CGFloat, _ width: CGFloat = 40) -> CGRect {
+        CGRect(x: minX, y: 949, width: width, height: 33)
+    }
+
+    private func record(
+        _ minX: CGFloat,
+        _ width: CGFloat = 40,
+        visibility: ItemVisibility = .visible,
+        pid: Int32? = nil
+    ) -> MenuBarItemRecord {
+        MenuBarItemRecord(
+            frame: bar(minX, width),
+            visibility: visibility,
+            identity: pid.map { ItemIdentity(pid: $0, bundleIdentifier: nil, appName: "App \($0)", axTitle: nil) }
+        )
+    }
+
+    private func plan(
+        target: MenuBarItemRecord,
+        others: [MenuBarItemRecord] = [],
+        ownFrames: [CGRect] = [],
+        hasAXElement: Bool = false
+    ) -> [ActivationStrategy] {
+        ActivationPlanner.plan(
+            target: target,
+            allItems: [target] + others,
+            ownFrames: ownFrames,
+            geometry: geometry,
+            hasAXElement: hasAXElement
+        )
+    }
+
+    @Test func testVisibleTargetIsJustAClick() {
+        let target = record(900)
+        let strategies = plan(target: target)
+        #expect(strategies == [.syntheticClick(at: CGPoint(x: 920, y: 965.5))])
+    }
+
+    @Test func testGhostTargetHasNoPlan() {
+        #expect(plan(target: record(0, visibility: .suspectedGhost)).isEmpty)
+    }
+
+    @Test func testOffscreenLeftTargetExpandsFirst() {
+        let strategies = plan(target: record(-2864, visibility: .offscreenLeft))
+        #expect(strategies == [.expandCollapsedBar])
+    }
+
+    @Test func testSwallowedWithNeighborGetsFullChain() {
+        let target = record(700, visibility: .swallowedByNotch)
+        let neighbor = record(900, pid: 500)
+        let strategies = plan(target: target, others: [neighbor], hasAXElement: true)
+        #expect(strategies.count == 5)
+        #expect(strategies[0] == .syntheticClick(at: CGPoint(x: 720, y: 965.5)))
+        #expect(strategies[1] == .axPress)
+        #expect(strategies[2] == .appMenuClearance)
+        if case .dragToExpose(let dragPlan) = strategies[3] {
+            #expect(dragPlan.neighborFrame == neighbor.frame)
+        } else {
+            Issue.record("expected dragToExpose at index 3, got \(strategies[3])")
+        }
+        #expect(strategies[4] == .clickTargetAfterReflow)
+    }
+
+    @Test func testNoAXElementSkipsAXPress() {
+        let target = record(700, visibility: .swallowedByNotch)
+        let strategies = plan(target: target, others: [record(900, pid: 500)], hasAXElement: false)
+        #expect(!strategies.contains(.axPress))
+        #expect(strategies.contains(.clickTargetAfterReflow))
+    }
+
+    @Test func testNoVisibleNeighborOmitsTheDragPath() {
+        let target = record(700, visibility: .swallowedByNotch)
+        let strategies = plan(target: target, others: [], hasAXElement: true)
+        #expect(strategies == [.syntheticClick(at: CGPoint(x: 720, y: 965.5)), .axPress])
+    }
+}
+
+struct DragPlannerTests {
+
+    private let geometry = MenuBarGeometry(
+        screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+        notchRect: CGRect(x: 663, y: 950, width: 185, height: 32),
+        menuBarHeight: 33
+    )
+
+    private func bar(_ minX: CGFloat, _ width: CGFloat = 40) -> CGRect {
+        CGRect(x: minX, y: 949, width: width, height: 33)
+    }
+
+    private func record(
+        _ minX: CGFloat,
+        _ width: CGFloat = 40,
+        visibility: ItemVisibility = .visible,
+        pid: Int32? = nil
+    ) -> MenuBarItemRecord {
+        MenuBarItemRecord(
+            frame: bar(minX, width),
+            visibility: visibility,
+            identity: pid.map { ItemIdentity(pid: $0, bundleIdentifier: nil, appName: "App \($0)", axTitle: nil) }
+        )
+    }
+
+    private let target = MenuBarItemRecord(
+        frame: CGRect(x: 700, y: 949, width: 40, height: 33),
+        visibility: .swallowedByNotch,
+        identity: nil
+    )
+
+    @Test func testDestinationFullyVacatesTheNotchSide() {
+        // Neighbor 40pt wide at x=900: destination centerX = 663 − 20 − 8 = 635.
+        let dragPlan = DragPlanner.plan(
+            target: target,
+            allItems: [target, record(900, pid: 500)],
+            ownFrames: [],
+            geometry: geometry
+        )
+        #expect(dragPlan?.from == CGPoint(x: 920, y: 965.5))
+        #expect(dragPlan?.to == CGPoint(x: 635, y: 965.5))
+    }
+
+    @Test func testNearestNeighborIsPicked() {
+        let dragPlan = DragPlanner.plan(
+            target: target,
+            allItems: [target, record(1100, pid: 500), record(900, pid: 501), record(1000, pid: 502)],
+            ownFrames: [],
+            geometry: geometry
+        )
+        #expect(dragPlan?.neighborFrame.minX == 900)
+    }
+
+    @Test func testThirdPartyPreferredOverUnidentified() {
+        let dragPlan = DragPlanner.plan(
+            target: target,
+            allItems: [target, record(900), record(1000, pid: 500)],
+            ownFrames: [],
+            geometry: geometry
+        )
+        #expect(dragPlan?.neighborFrame.minX == 1000)
+    }
+
+    @Test func testOwnFramesAndClockClusterAreExcluded() {
+        let ownFrame = bar(900)
+        let clock = record(1480, 30, pid: 600) // ends 2pt from the edge
+        let dragPlan = DragPlanner.plan(
+            target: target,
+            allItems: [target, record(900, pid: 500), clock],
+            ownFrames: [ownFrame],
+            geometry: geometry
+        )
+        #expect(dragPlan == nil)
+    }
+
+    @Test func testSwallowedItemsAreNeverDragCandidates() {
+        let dragPlan = DragPlanner.plan(
+            target: target,
+            allItems: [target, record(750, visibility: .swallowedByNotch, pid: 500)],
+            ownFrames: [],
+            geometry: geometry
+        )
+        #expect(dragPlan == nil)
+    }
+
+    @Test func testNoNotchMeansNoDragPlan() {
+        let flat = MenuBarGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+            notchRect: nil,
+            menuBarHeight: 24
+        )
+        let dragPlan = DragPlanner.plan(
+            target: target,
+            allItems: [target, record(900, pid: 500)],
+            ownFrames: [],
+            geometry: flat
+        )
+        #expect(dragPlan == nil)
+    }
+
+    @Test func testNeighborThatCannotFullyVacateYieldsNil() {
+        // Almost no room left of the notch: the clamp can't place the
+        // 40pt neighbor fully past it (destination 28+20=48 > notch.minX 40).
+        let crampedGeometry = MenuBarGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+            notchRect: CGRect(x: 40, y: 950, width: 185, height: 32),
+            menuBarHeight: 33
+        )
+        let crampedTarget = MenuBarItemRecord(
+            frame: bar(60), visibility: .swallowedByNotch, identity: nil
+        )
+        let dragPlan = DragPlanner.plan(
+            target: crampedTarget,
+            allItems: [crampedTarget, record(300, pid: 500)],
+            ownFrames: [],
+            geometry: crampedGeometry
+        )
+        #expect(dragPlan == nil)
+    }
+}

--- a/Tests/PelmetCoreTests/ActivationSessionTests.swift
+++ b/Tests/PelmetCoreTests/ActivationSessionTests.swift
@@ -1,0 +1,133 @@
+import Testing
+@testable import PelmetCore
+import CoreGraphics
+
+struct ActivationSessionTests {
+
+    private let click = ActivationStrategy.syntheticClick(at: CGPoint(x: 720, y: 965))
+    private let dragPlan = DragPlan(
+        neighborFrame: CGRect(x: 900, y: 949, width: 40, height: 33),
+        from: CGPoint(x: 920, y: 965),
+        to: CGPoint(x: 635, y: 965)
+    )
+
+    private func fullChain() -> [ActivationStrategy] {
+        [click, .axPress, .appMenuClearance, .dragToExpose(dragPlan), .clickTargetAfterReflow]
+    }
+
+    @Test func testVerifiedFirstClickShortCircuits() {
+        var session = ActivationSession(strategies: fullChain(), targetWasSwallowed: true)
+        #expect(session.handle(.begin) == [.perform(click)])
+        #expect(session.handle(.stepCompleted) == [.startVerification(deadline: 0.7)])
+        #expect(session.handle(.verified(.menuOpened)) == [.finish(.activated(.menuOpened))])
+        // Finished: further events are ignored.
+        #expect(session.handle(.verificationTimedOut).isEmpty)
+    }
+
+    @Test func testTimeoutCascadesThroughTheChain() {
+        var session = ActivationSession(strategies: fullChain(), targetWasSwallowed: true)
+        _ = session.handle(.begin)
+        _ = session.handle(.stepCompleted)                          // click posted
+        #expect(session.handle(.verificationTimedOut) == [.perform(.axPress)])
+        #expect(session.handle(.stepCompleted) == [.startVerification(deadline: 1.2)])
+        #expect(session.handle(.verificationTimedOut) == [.perform(.appMenuClearance)])
+        #expect(session.handle(.stepCompleted) == [.perform(.dragToExpose(dragPlan))])
+        #expect(session.handle(.stepCompleted) == [.perform(.clickTargetAfterReflow)])
+        #expect(session.handle(.stepCompleted) == [.startVerification(deadline: 0.7)])
+        // Reflow click verified: menu opened, restore is owed.
+        #expect(session.handle(.verified(.menuOpened)) == [
+            .restoreDrag(dragPlan), .finish(.activated(.menuOpened)),
+        ])
+    }
+
+    @Test func testUnverifiedReflowClickIsSoftSuccess() {
+        var session = ActivationSession(strategies: fullChain(), targetWasSwallowed: true)
+        _ = session.handle(.begin)
+        _ = session.handle(.stepCompleted)
+        _ = session.handle(.verificationTimedOut)   // → axPress
+        _ = session.handle(.stepCompleted)
+        _ = session.handle(.verificationTimedOut)   // → clearance
+        _ = session.handle(.stepCompleted)          // → drag
+        _ = session.handle(.stepCompleted)          // → reflow click
+        _ = session.handle(.stepCompleted)          // → verification
+        // Timed out after the final click, but a drag happened: no retry,
+        // soft success, restore owed.
+        #expect(session.handle(.verificationTimedOut) == [
+            .restoreDrag(dragPlan), .finish(.activated(.unverified)),
+        ])
+    }
+
+    @Test func testExactlyOneRetryWhenNoDragHappened() {
+        var session = ActivationSession(
+            strategies: [click, .axPress], targetWasSwallowed: true
+        )
+        _ = session.handle(.begin)
+        _ = session.handle(.stepCompleted)
+        _ = session.handle(.verificationTimedOut)   // → axPress
+        _ = session.handle(.stepCompleted)
+        // Exhausted → single retry of the first click.
+        #expect(session.handle(.verificationTimedOut) == [.perform(click)])
+        _ = session.handle(.stepCompleted)
+        // Second exhaustion: no second retry. Swallowed target, no reflow
+        // click → honest failure.
+        #expect(session.handle(.verificationTimedOut) == [.finish(.failed(.noRoomToExpose))])
+    }
+
+    @Test func testUnverifiedVisibleTargetIsSoftSuccess() {
+        var session = ActivationSession(strategies: [click], targetWasSwallowed: false)
+        _ = session.handle(.begin)
+        _ = session.handle(.stepCompleted)
+        #expect(session.handle(.verificationTimedOut) == [.perform(click)]) // the one retry
+        _ = session.handle(.stepCompleted)
+        #expect(session.handle(.verificationTimedOut) == [.finish(.activated(.unverified))])
+    }
+
+    @Test func testAbortMidDragReleasesButtonsAndRestores() {
+        var session = ActivationSession(strategies: fullChain(), targetWasSwallowed: true)
+        _ = session.handle(.begin)
+        _ = session.handle(.stepCompleted)
+        _ = session.handle(.verificationTimedOut)
+        _ = session.handle(.stepCompleted)
+        _ = session.handle(.verificationTimedOut)
+        _ = session.handle(.stepCompleted)          // clearance done → drag next
+        _ = session.handle(.stepCompleted)          // drag completed
+        let effects = session.handle(.aborted(.interrupted))
+        #expect(effects == [
+            .releaseMouseButtons,
+            .restoreDrag(dragPlan),
+            .finish(.failed(.interrupted)),
+        ])
+    }
+
+    @Test func testAbortBeforeAnythingReleasesButtonsOnly() {
+        var session = ActivationSession(strategies: [click], targetWasSwallowed: false)
+        _ = session.handle(.begin)
+        #expect(session.handle(.aborted(.userInteracting)) == [
+            .releaseMouseButtons, .finish(.failed(.userInteracting)),
+        ])
+    }
+
+    @Test func testFailedDragEndsTheSessionWithoutReflowClick() {
+        var session = ActivationSession(strategies: fullChain(), targetWasSwallowed: true)
+        _ = session.handle(.begin)
+        _ = session.handle(.stepCompleted)
+        _ = session.handle(.verificationTimedOut)
+        _ = session.handle(.stepCompleted)
+        _ = session.handle(.verificationTimedOut)
+        _ = session.handle(.stepCompleted)          // clearance → drag next
+        #expect(session.handle(.stepFailed) == [.finish(.failed(.noRoomToExpose))])
+    }
+
+    @Test func testFailedAXPressAdvancesToTheNextStrategy() {
+        var session = ActivationSession(strategies: fullChain(), targetWasSwallowed: true)
+        _ = session.handle(.begin)
+        _ = session.handle(.stepCompleted)
+        _ = session.handle(.verificationTimedOut)   // → axPress
+        #expect(session.handle(.stepFailed) == [.perform(.appMenuClearance)])
+    }
+
+    @Test func testEmptyPlanFailsImmediately() {
+        var session = ActivationSession(strategies: [], targetWasSwallowed: false)
+        #expect(session.handle(.begin) == [.finish(.failed(.itemVanished))])
+    }
+}

--- a/Tests/PelmetCoreTests/MenuBarLayoutClassifierTests.swift
+++ b/Tests/PelmetCoreTests/MenuBarLayoutClassifierTests.swift
@@ -17,17 +17,21 @@ struct MenuBarLayoutClassifierTests {
         CGRect(x: minX, y: 949, width: width, height: 33)
     }
 
+    private func win(_ minX: CGFloat, _ width: CGFloat, pid: Int32? = nil) -> RawStatusWindow {
+        RawStatusWindow(frame: bar(minX, width), ownerPID: pid)
+    }
+
     // MARK: - Swallowed detection (expanded)
 
     @Test func testExpandedOverflowCountsUnderAndLeftOfNotch() {
         let raw = [
-            bar(900, 40),   // visible, right of notch
-            bar(1000, 40),  // visible
-            bar(700, 46),   // under the notch
-            bar(472, 46),   // left of the notch
+            win(900, 40),   // visible, right of notch
+            win(1000, 40),  // visible
+            win(700, 46),   // under the notch
+            win(472, 46),   // left of the notch
         ]
         let result = MenuBarLayoutClassifier.classify(
-            rawItemFrames: raw,
+            rawItems: raw,
             ownSeparatorFrame: bar(1170, 26),
             ownToggleFrame: bar(1198, 38),
             isCollapsed: false,
@@ -44,9 +48,9 @@ struct MenuBarLayoutClassifierTests {
     @Test func testExpandedNegativeXWindowsAreGhostsNotSwallowed() {
         // After an ordinary expand, the previous collapse's mirror windows
         // linger past the left screen edge for minutes.
-        let raw = [bar(-926, 45), bar(-444, 31), bar(700, 46)]
+        let raw = [win(-926, 45), win(-444, 31), win(700, 46)]
         let result = MenuBarLayoutClassifier.classify(
-            rawItemFrames: raw,
+            rawItems: raw,
             ownSeparatorFrame: bar(1170, 26),
             ownToggleFrame: bar(1198, 38),
             isCollapsed: false,
@@ -59,9 +63,9 @@ struct MenuBarLayoutClassifierTests {
     @Test func testBirthPositionWindowAtExactlyZeroIsGhost() {
         // Items are born at x == 0 and immediately move to their seeded
         // position; the birth twin can stay behind.
-        let raw = [bar(0, 26), bar(0, 56), bar(700, 46)]
+        let raw = [win(0, 26), win(0, 56), win(700, 46)]
         let result = MenuBarLayoutClassifier.classify(
-            rawItemFrames: raw,
+            rawItems: raw,
             ownSeparatorFrame: bar(1170, 26),
             ownToggleFrame: bar(1198, 38),
             isCollapsed: false,
@@ -73,9 +77,9 @@ struct MenuBarLayoutClassifierTests {
     }
 
     @Test func testAllVisibleWhenBarFits() {
-        let raw = [bar(900, 40), bar(1000, 40), bar(1100, 40)]
+        let raw = [win(900, 40), win(1000, 40), win(1100, 40)]
         let result = MenuBarLayoutClassifier.classify(
-            rawItemFrames: raw,
+            rawItems: raw,
             ownSeparatorFrame: bar(1170, 26),
             ownToggleFrame: bar(1198, 38),
             isCollapsed: false,
@@ -91,11 +95,11 @@ struct MenuBarLayoutClassifierTests {
         // Separator inflated: frame observed at x=-2818, width 4016.
         let separator = CGRect(x: -2818, y: 949, width: 4016, height: 33)
         let raw = [
-            bar(-2864, 46), // managed, pushed past the left edge — expected
-            bar(900, 40),   // always-visible icon
+            win(-2864, 46), // managed, pushed past the left edge — expected
+            win(900, 40),   // always-visible icon
         ]
         let result = MenuBarLayoutClassifier.classify(
-            rawItemFrames: raw,
+            rawItems: raw,
             ownSeparatorFrame: separator,
             ownToggleFrame: bar(1198, 38),
             isCollapsed: true,
@@ -107,13 +111,17 @@ struct MenuBarLayoutClassifierTests {
     }
 
     @Test func testCollapsedStillOverflowingCountsUnmanagedUnderNotch() {
-        let separator = CGRect(x: -2818, y: 949, width: 4016, height: 33)
+        // A layout can only swallow right-of-divider items while collapsed
+        // when the always-visible set is wide enough to push the inflated
+        // separator's END past the left of the notch — items never sit
+        // INSIDE the separator's span (a frame there is a stale twin).
+        let separator = CGRect(x: -3500, y: 949, width: 4016, height: 33) // maxX = 516 < notch
         let raw = [
-            bar(-2864, 46), // managed
-            bar(700, 40),   // unmanaged icon that STILL doesn't fit collapsed
+            win(-3550, 46), // managed, pushed past the separator's left end
+            win(700, 40),   // unmanaged icon that STILL doesn't fit collapsed
         ]
         let result = MenuBarLayoutClassifier.classify(
-            rawItemFrames: raw,
+            rawItems: raw,
             ownSeparatorFrame: separator,
             ownToggleFrame: bar(1198, 38),
             isCollapsed: true,
@@ -128,7 +136,7 @@ struct MenuBarLayoutClassifierTests {
     @Test func testOwnFramesAreExcludedFromTheCount() {
         let separatorFrame = bar(700, 26) // divider itself swallowed
         let result = MenuBarLayoutClassifier.classify(
-            rawItemFrames: [separatorFrame, bar(1198, 38), bar(900, 40)],
+            rawItems: [win(700, 26), win(1198, 38), win(900, 40)],
             ownSeparatorFrame: separatorFrame,
             ownToggleFrame: bar(1198, 38),
             isCollapsed: false,
@@ -140,7 +148,7 @@ struct MenuBarLayoutClassifierTests {
 
     @Test func testToggleUnderNotchReportsNotVisible() {
         let result = MenuBarLayoutClassifier.classify(
-            rawItemFrames: [bar(900, 40)],
+            rawItems: [win(900, 40)],
             ownSeparatorFrame: bar(660, 26),
             ownToggleFrame: bar(700, 38),
             isCollapsed: false,
@@ -154,7 +162,7 @@ struct MenuBarLayoutClassifierTests {
 
     @Test func testExactDuplicateFramesCollapseToOne() {
         let result = MenuBarLayoutClassifier.classify(
-            rawItemFrames: [bar(700, 46), bar(700, 46)],
+            rawItems: [win(700, 46), win(700, 46)],
             ownSeparatorFrame: bar(1170, 26),
             ownToggleFrame: bar(1198, 38),
             isCollapsed: false,
@@ -167,7 +175,7 @@ struct MenuBarLayoutClassifierTests {
         // Observed on Tahoe during layout churn: the same item backed by two
         // windows offset ~13pt ([854,886] and [867,899]).
         let result = MenuBarLayoutClassifier.classify(
-            rawItemFrames: [bar(854, 32), bar(867, 32)],
+            rawItems: [win(854, 32), win(867, 32)],
             ownSeparatorFrame: bar(1170, 26),
             ownToggleFrame: bar(1198, 38),
             isCollapsed: false,
@@ -178,12 +186,94 @@ struct MenuBarLayoutClassifierTests {
 
     @Test func testAdjacentDistinctItemsAreNotMerged() {
         let result = MenuBarLayoutClassifier.classify(
-            rawItemFrames: [bar(854, 32), bar(886, 38)],
+            rawItems: [win(854, 32), win(886, 38)],
             ownSeparatorFrame: bar(1170, 26),
             ownToggleFrame: bar(1198, 38),
             isCollapsed: false,
             geometry: geometry
         )
+        #expect(result.items.count == 2)
+    }
+
+    // MARK: - Owner PIDs (identity plumbing for the Shelf)
+
+    @Test func testMirrorClusterMergesOwnerPIDs() {
+        // A real item backed by its app's window (pid 500) plus an
+        // exact-frame Control Center mirror (pid 300) — one item, both PIDs,
+        // in order of appearance after the minX sort.
+        let result = MenuBarLayoutClassifier.classify(
+            rawItems: [win(700, 46, pid: 500), win(700, 46, pid: 300)],
+            ownSeparatorFrame: bar(1170, 26),
+            ownToggleFrame: bar(1198, 38),
+            isCollapsed: false,
+            geometry: geometry
+        )
+        #expect(result.items.count == 1)
+        #expect(result.items[0].ownerPIDs == [500, 300])
+    }
+
+    @Test func testDuplicatePIDsInAClusterAreNotRepeated() {
+        let result = MenuBarLayoutClassifier.classify(
+            rawItems: [win(854, 32, pid: 500), win(867, 32, pid: 500)],
+            ownSeparatorFrame: bar(1170, 26),
+            ownToggleFrame: bar(1198, 38),
+            isCollapsed: false,
+            geometry: geometry
+        )
+        #expect(result.items.count == 1)
+        #expect(result.items[0].ownerPIDs == [500])
+    }
+
+    @Test func testMissingOwnerPIDsAreTolerated() {
+        let result = MenuBarLayoutClassifier.classify(
+            rawItems: [win(700, 46), win(900, 40, pid: 500)],
+            ownSeparatorFrame: bar(1170, 26),
+            ownToggleFrame: bar(1198, 38),
+            isCollapsed: false,
+            geometry: geometry
+        )
+        #expect(result.items.count == 2)
+        let sorted = result.items.sorted { $0.frame.minX < $1.frame.minX }
+        #expect(sorted[0].ownerPIDs.isEmpty)
+        #expect(sorted[1].ownerPIDs == [500])
+    }
+
+    // MARK: - Stale twins inside the inflated separator's span
+
+    @Test func testCollapsedTwinsAtOldExpandedPositionsAreGhosts() {
+        // Observed live (macOS 26.5): after a collapse, twins linger at the
+        // previous EXPANDED positions — inside the inflated separator's
+        // span, where no real item can be. Two twins sat exactly where the
+        // notch is, faking "swallowed=2" while everything was hidden.
+        let separator = CGRect(x: -384, y: 949, width: 1720, height: 33)
+        let result = MenuBarLayoutClassifier.classify(
+            rawItems: [
+                win(-867, 24),  // genuinely pushed off (left of separator)
+                win(813, 24),   // stale twin under the notch
+                win(837, 24),   // stale twin under the notch
+                win(900, 40),   // stale twin right of the notch
+            ],
+            ownSeparatorFrame: separator,
+            ownToggleFrame: bar(1336, 18),
+            isCollapsed: true,
+            geometry: geometry
+        )
+        #expect(result.swallowedCount == 0)
+        #expect(result.offscreenLeftCount == 1)
+        #expect(result.items.filter { $0.visibility == .suspectedGhost }.count == 3)
+    }
+
+    @Test func testExpandedItemsBesideTheThinSeparatorAreNotGhosts() {
+        // Expanded, the separator is 10pt wide — adjacent items touch but
+        // never substantially overlap it.
+        let result = MenuBarLayoutClassifier.classify(
+            rawItems: [win(1160, 40), win(1210, 40)],
+            ownSeparatorFrame: bar(1200, 10),
+            ownToggleFrame: bar(1250, 38),
+            isCollapsed: false,
+            geometry: geometry
+        )
+        #expect(result.items.filter { $0.visibility == .suspectedGhost }.isEmpty)
         #expect(result.items.count == 2)
     }
 
@@ -193,7 +283,7 @@ struct MenuBarLayoutClassifierTests {
         // Observed on Tahoe: a 450pt-wide clipboard-manager window at the
         // status-item window level.
         let result = MenuBarLayoutClassifier.classify(
-            rawItemFrames: [bar(1062, 450), bar(700, 40)],
+            rawItems: [win(1062, 450), win(700, 40)],
             ownSeparatorFrame: bar(1170, 26),
             ownToggleFrame: bar(1198, 38),
             isCollapsed: false,
@@ -204,9 +294,9 @@ struct MenuBarLayoutClassifierTests {
     }
 
     @Test func testWindowsOutsideTheMenuBarBandAreIgnored() {
-        let floatingPanel = CGRect(x: 700, y: 400, width: 40, height: 33)
+        let floatingPanel = RawStatusWindow(frame: CGRect(x: 700, y: 400, width: 40, height: 33))
         let result = MenuBarLayoutClassifier.classify(
-            rawItemFrames: [floatingPanel],
+            rawItems: [floatingPanel],
             ownSeparatorFrame: bar(1170, 26),
             ownToggleFrame: bar(1198, 38),
             isCollapsed: false,
@@ -223,9 +313,9 @@ struct MenuBarLayoutClassifierTests {
             notchRect: nil,
             menuBarHeight: 24
         )
-        let raw = [CGRect(x: 700, y: 957, width: 40, height: 24)]
+        let raw = [RawStatusWindow(frame: CGRect(x: 700, y: 957, width: 40, height: 24))]
         let result = MenuBarLayoutClassifier.classify(
-            rawItemFrames: raw,
+            rawItems: raw,
             ownSeparatorFrame: CGRect(x: 1170, y: 957, width: 26, height: 24),
             ownToggleFrame: CGRect(x: 1198, y: 957, width: 38, height: 24),
             isCollapsed: false,

--- a/Tests/PelmetCoreTests/ScreenCoordinatesTests.swift
+++ b/Tests/PelmetCoreTests/ScreenCoordinatesTests.swift
@@ -1,0 +1,29 @@
+import Testing
+@testable import PelmetCore
+import CoreGraphics
+
+struct ScreenCoordinatesTests {
+
+    /// The values WindowListSource produces today: a CG rect at the top of a
+    /// 1512×982 primary screen maps to the AppKit menu bar band at y=949.
+    @Test func testCGMenuBarRectMapsToAppKitBand() {
+        let cg = CGRect(x: 700, y: 0, width: 46, height: 33)
+        let appKit = ScreenCoordinates.appKitRect(fromCG: cg, primaryMaxY: 982)
+        #expect(appKit == CGRect(x: 700, y: 949, width: 46, height: 33))
+    }
+
+    @Test func testRectRoundTrip() {
+        let original = CGRect(x: -926, y: 949, width: 45, height: 33)
+        let there = ScreenCoordinates.cgRect(fromAppKit: original, primaryMaxY: 982)
+        let back = ScreenCoordinates.appKitRect(fromCG: there, primaryMaxY: 982)
+        #expect(back == original)
+    }
+
+    @Test func testPointRoundTrip() {
+        let original = CGPoint(x: 723, y: 965.5)
+        let there = ScreenCoordinates.cgPoint(fromAppKit: original, primaryMaxY: 982)
+        #expect(there == CGPoint(x: 723, y: 16.5))
+        let back = ScreenCoordinates.appKitPoint(fromCG: there, primaryMaxY: 982)
+        #expect(back == original)
+    }
+}

--- a/Tests/PelmetCoreTests/ShelfContentDeriverTests.swift
+++ b/Tests/PelmetCoreTests/ShelfContentDeriverTests.swift
@@ -1,0 +1,224 @@
+import Testing
+@testable import PelmetCore
+import CoreGraphics
+
+/// Same fixture geometry as the classifier tests: 14" MacBook Pro,
+/// notch x∈[663, 848], band 33pt at y=949. The deriver consumes classifier
+/// output, so fixtures are built straight from ClassifiedItems.
+struct ShelfContentDeriverTests {
+
+    private let controlCenter: Int32 = 300
+    private let ownPID: Int32 = 999
+
+    private func bar(_ minX: CGFloat, _ width: CGFloat = 40) -> CGRect {
+        CGRect(x: minX, y: 949, width: width, height: 33)
+    }
+
+    private func swallowed(_ minX: CGFloat, pids: [Int32]) -> ClassifiedItem {
+        ClassifiedItem(frame: bar(minX), visibility: .swallowedByNotch, ownerPIDs: pids)
+    }
+
+    private func classification(_ items: [ClassifiedItem]) -> LayoutClassification {
+        LayoutClassification(items: items, separatorHealth: .visible, toggleVisible: true)
+    }
+
+    private let apps: [Int32: RunningAppInfo] = [
+        500: RunningAppInfo(pid: 500, bundleID: "com.example.dropbox", localizedName: "Dropbox"),
+        501: RunningAppInfo(pid: 501, bundleID: "com.example.vpn", localizedName: "TunnelBear"),
+    ]
+
+    private func derive(
+        _ items: [ClassifiedItem],
+        engineItems: [EngineItemDescriptor] = []
+    ) -> [ShelfEntryModel] {
+        ShelfContentDeriver.derive(
+            classification: classification(items),
+            apps: apps,
+            controlCenterPID: controlCenter,
+            ownPID: ownPID,
+            engineItems: engineItems
+        )
+    }
+
+    // MARK: - Tier 0 with owners (≤ Sequoia)
+
+    @Test func testDistinctOwnersBecomeNamedEntriesSortedLeftToRight() {
+        let entries = derive([
+            swallowed(700, pids: [501, controlCenter]),
+            swallowed(472, pids: [500]),
+        ])
+        #expect(entries.count == 2)
+        #expect(entries[0].kind == .app(pid: 500, name: "Dropbox", itemCount: 1))
+        #expect(entries[1].kind == .app(pid: 501, name: "TunnelBear", itemCount: 1))
+        #expect(entries[0].frame.minX < entries[1].frame.minX)
+    }
+
+    @Test func testMixedClusterPrefersNonControlCenterPID() {
+        let entries = derive([swallowed(700, pids: [controlCenter, 500])])
+        #expect(entries.count == 1)
+        #expect(entries[0].kind == .app(pid: 500, name: "Dropbox", itemCount: 1))
+    }
+
+    @Test func testConsecutiveSameOwnerItemsAreGrouped() {
+        let entries = derive([
+            swallowed(472, pids: [500]),
+            swallowed(520, pids: [500]),
+            swallowed(700, pids: [501]),
+        ])
+        #expect(entries.count == 2)
+        #expect(entries[0].kind == .app(pid: 500, name: "Dropbox", itemCount: 2))
+        #expect(entries[0].frame == bar(472)) // leftmost member's frame
+        #expect(entries[1].kind == .app(pid: 501, name: "TunnelBear", itemCount: 1))
+    }
+
+    @Test func testNonConsecutiveSameOwnerItemsAreNotGrouped() {
+        let entries = derive([
+            swallowed(472, pids: [500]),
+            swallowed(520, pids: [501]),
+            swallowed(700, pids: [500]),
+        ])
+        #expect(entries.count == 3)
+    }
+
+    // MARK: - Tier 0 anonymous (Tahoe: everything Control-Center-owned)
+
+    @Test func testAllControlCenterOwnersBecomeUnknownOrdinals() {
+        let entries = derive([
+            swallowed(472, pids: [controlCenter]),
+            swallowed(700, pids: [controlCenter]),
+        ])
+        #expect(entries.count == 2)
+        #expect(entries[0].kind == .unknown(ordinal: 1))
+        #expect(entries[1].kind == .unknown(ordinal: 2))
+    }
+
+    @Test func testDeadPIDDegradesToUnknownWithoutDisturbingNeighbors() {
+        let entries = derive([
+            swallowed(472, pids: [500]),
+            swallowed(700, pids: [777]), // not in `apps` — process died
+        ])
+        #expect(entries.count == 2)
+        #expect(entries[0].kind == .app(pid: 500, name: "Dropbox", itemCount: 1))
+        #expect(entries[1].kind == .unknown(ordinal: 1))
+    }
+
+    @Test func testEmptyOwnerListIsUnknown() {
+        let entries = derive([swallowed(700, pids: [])])
+        #expect(entries.count == 1)
+        #expect(entries[0].kind == .unknown(ordinal: 1))
+    }
+
+    // MARK: - Exclusions (badge parity with what the badge counts)
+
+    @Test func testOwnWindowsAreDropped() {
+        let entries = derive([
+            swallowed(472, pids: [ownPID]),
+            swallowed(700, pids: [500]),
+        ])
+        #expect(entries.count == 1)
+        #expect(entries[0].kind == .app(pid: 500, name: "Dropbox", itemCount: 1))
+    }
+
+    @Test func testGhostsAndOffscreenLeftAreExcluded() {
+        let items = [
+            ClassifiedItem(frame: bar(-2864), visibility: .offscreenLeft, ownerPIDs: [500]),
+            ClassifiedItem(frame: bar(0), visibility: .suspectedGhost, ownerPIDs: [501]),
+            ClassifiedItem(frame: bar(900), visibility: .visible, ownerPIDs: [500]),
+            swallowed(700, pids: [501]),
+        ]
+        let entries = derive(items)
+        #expect(entries.count == 1)
+        #expect(entries[0].kind == .app(pid: 501, name: "TunnelBear", itemCount: 1))
+    }
+
+    @Test func testEmptyClassificationYieldsNoEntries() {
+        #expect(derive([]).isEmpty)
+    }
+
+    // MARK: - Engine enrichment
+
+    @Test func testEngineItemMatchesByFrameWithinTolerance() {
+        let descriptor = EngineItemDescriptor(
+            token: "t1", title: "Dropbox — Syncing", ownerPID: 500,
+            frame: bar(700 + ShelfContentDeriver.frameMatchTolerance) // midX off by exactly the tolerance
+        )
+        let entries = derive([swallowed(700, pids: [controlCenter])], engineItems: [descriptor])
+        #expect(entries.count == 1)
+        #expect(entries[0].kind == .engineItem(token: "t1", title: "Dropbox — Syncing", ownerPID: 500))
+    }
+
+    @Test func testEngineItemBeyondToleranceDoesNotMatch() {
+        let descriptor = EngineItemDescriptor(
+            token: "t1", title: "Dropbox", ownerPID: 500,
+            frame: bar(700 + ShelfContentDeriver.frameMatchTolerance + 1)
+        )
+        let entries = derive([swallowed(700, pids: [controlCenter])], engineItems: [descriptor])
+        #expect(entries.count == 1)
+        // Falls back to an anonymous row; the unmatched descriptor is dropped.
+        #expect(entries[0].kind == .unknown(ordinal: 1))
+    }
+
+    @Test func testFramelessEngineItemMatchesByUniqueOwnerPID() {
+        let descriptor = EngineItemDescriptor(token: "t2", title: "TunnelBear", ownerPID: 501, frame: nil)
+        let entries = derive([swallowed(700, pids: [501])], engineItems: [descriptor])
+        #expect(entries.count == 1)
+        #expect(entries[0].kind == .engineItem(token: "t2", title: "TunnelBear", ownerPID: 501))
+    }
+
+    @Test func testFramelessEngineItemWithAmbiguousPIDDoesNotMatch() {
+        let descriptor = EngineItemDescriptor(token: "t3", title: "Dropbox", ownerPID: 500, frame: nil)
+        let entries = derive(
+            [swallowed(472, pids: [500]), swallowed(700, pids: [500])],
+            engineItems: [descriptor]
+        )
+        // Two candidate items for one descriptor — no guess. And with the
+        // engine present, same-app rows are never grouped.
+        #expect(entries.count == 2)
+        #expect(entries.allSatisfy {
+            $0.kind == .app(pid: 500, name: "Dropbox", itemCount: 1)
+        })
+    }
+
+    @Test func testEngineItemWithNoClassifiedCounterpartIsIgnored() {
+        // Badge parity: the engine can never add rows the badge didn't count.
+        let descriptor = EngineItemDescriptor(token: "t4", title: "Phantom", ownerPID: 502, frame: bar(1100))
+        let entries = derive([swallowed(700, pids: [500])], engineItems: [descriptor])
+        #expect(entries.count == 1)
+        #expect(entries[0].kind == .app(pid: 500, name: "Dropbox", itemCount: 1))
+    }
+
+    @Test func testTitlelessDescriptorFallsBackToAppName() {
+        let descriptor = EngineItemDescriptor(token: "t6", title: nil, ownerPID: 500, frame: bar(700))
+        let entries = derive([swallowed(700, pids: [controlCenter])], engineItems: [descriptor])
+        #expect(entries.count == 1)
+        #expect(entries[0].kind == .engineItem(token: "t6", title: "Dropbox", ownerPID: 500))
+    }
+
+    @Test func testTitlelessOwnerlessDescriptorGetsNumberedFallback() {
+        // The user-visible bug: engine granted but identity unresolved must
+        // still render numbered rows, never identical "Hidden item" twins.
+        let descriptors = [
+            EngineItemDescriptor(token: "t7", title: nil, ownerPID: nil, frame: bar(472)),
+            EngineItemDescriptor(token: "t8", title: nil, ownerPID: nil, frame: bar(700)),
+        ]
+        let entries = derive(
+            [swallowed(472, pids: [controlCenter]), swallowed(700, pids: [controlCenter])],
+            engineItems: descriptors
+        )
+        #expect(entries.count == 2)
+        #expect(entries[0].kind == .engineItem(token: "t7", title: "Hidden item 1", ownerPID: nil))
+        #expect(entries[1].kind == .engineItem(token: "t8", title: "Hidden item 2", ownerPID: nil))
+    }
+
+    @Test func testEachDescriptorEnrichesOnlyOneItem() {
+        let descriptor = EngineItemDescriptor(token: "t5", title: "Dropbox", ownerPID: 500, frame: bar(472))
+        let entries = derive(
+            [swallowed(472, pids: [500]), swallowed(476, pids: [500])],
+            engineItems: [descriptor]
+        )
+        #expect(entries.count == 2)
+        #expect(entries.filter {
+            if case .engineItem = $0.kind { return true } else { return false }
+        }.count == 1)
+    }
+}

--- a/Tests/PelmetCoreTests/ShelfPlacementTests.swift
+++ b/Tests/PelmetCoreTests/ShelfPlacementTests.swift
@@ -1,0 +1,65 @@
+import Testing
+@testable import PelmetCore
+import CoreGraphics
+
+struct ShelfPlacementTests {
+
+    private let geometry = MenuBarGeometry(
+        screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+        notchRect: CGRect(x: 663, y: 950, width: 185, height: 32),
+        menuBarHeight: 33
+    )
+    private let panelSize = CGSize(width: 320, height: 180)
+
+    @Test func testCenteredOnAnchorAndBelowTheMenuBarBand() {
+        let anchor = CGRect(x: 1198, y: 949, width: 38, height: 33)
+        let frame = ShelfPlacement.panelFrame(panelSize: panelSize, anchorFrame: anchor, geometry: geometry)
+        let expectedMaxY: CGFloat = 982 - 33 - 6 // screen top − menu bar − gap
+        #expect(frame.midX == anchor.midX)
+        #expect(frame.maxY == expectedMaxY)
+        #expect(frame.size == panelSize)
+    }
+
+    @Test func testClampedAtTheRightEdge() {
+        // Toggle near the right edge on a 14": centering would overflow.
+        let anchor = CGRect(x: 1460, y: 949, width: 38, height: 33)
+        let frame = ShelfPlacement.panelFrame(panelSize: panelSize, anchorFrame: anchor, geometry: geometry)
+        let expectedMaxX: CGFloat = 1512 - 8
+        #expect(frame.maxX == expectedMaxX)
+        #expect(frame.minX >= 8)
+    }
+
+    @Test func testClampedAtTheLeftEdge() {
+        let anchor = CGRect(x: 10, y: 949, width: 38, height: 33)
+        let frame = ShelfPlacement.panelFrame(panelSize: panelSize, anchorFrame: anchor, geometry: geometry)
+        #expect(frame.minX == 8)
+    }
+
+    @Test func testNoAnchorFallsBackToNotchCenter() {
+        let frame = ShelfPlacement.panelFrame(panelSize: panelSize, anchorFrame: nil, geometry: geometry)
+        #expect(frame.midX == geometry.notchRect!.midX)
+    }
+
+    @Test func testNoAnchorNoNotchFallsBackToScreenCenter() {
+        let flat = MenuBarGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+            notchRect: nil,
+            menuBarHeight: 24
+        )
+        let frame = ShelfPlacement.panelFrame(panelSize: panelSize, anchorFrame: nil, geometry: flat)
+        #expect(frame.midX == 756)
+    }
+
+    @Test func testSecondaryDisplayOriginIsRespected() {
+        // A display left of the primary: negative-x screen frame.
+        let external = MenuBarGeometry(
+            screenFrame: CGRect(x: -1920, y: 100, width: 1920, height: 1080),
+            notchRect: nil,
+            menuBarHeight: 24
+        )
+        let anchor = CGRect(x: -100, y: 1150, width: 38, height: 24)
+        let frame = ShelfPlacement.panelFrame(panelSize: panelSize, anchorFrame: anchor, geometry: external)
+        #expect(frame.maxX <= -8)
+        #expect(frame.maxY == external.screenFrame.maxY - 24 - 6)
+    }
+}

--- a/Tests/PelmetCoreTests/StatusItemCorrelatorTests.swift
+++ b/Tests/PelmetCoreTests/StatusItemCorrelatorTests.swift
@@ -1,0 +1,132 @@
+import Testing
+@testable import PelmetCore
+import CoreGraphics
+
+/// Fixture values mirror the classifier tests: band 33pt at y=949.
+struct StatusItemCorrelatorTests {
+
+    private func bar(_ minX: CGFloat, _ width: CGFloat = 40) -> CGRect {
+        CGRect(x: minX, y: 949, width: width, height: 33)
+    }
+
+    private func item(_ minX: CGFloat, _ width: CGFloat = 40) -> ClassifiedItem {
+        ClassifiedItem(frame: bar(minX, width), visibility: .visible)
+    }
+
+    @Test func testExactFrameObservationMatches() {
+        let result = StatusItemCorrelator.correlate(
+            classified: [item(700, 46)],
+            observed: [ItemObservation(pid: 500, title: "VPN", frame: bar(700, 46))]
+        )
+        #expect(result[0].observation?.pid == 500)
+    }
+
+    @Test func testSmallOffsetStillMatches() {
+        let result = StatusItemCorrelator.correlate(
+            classified: [item(700, 46)],
+            observed: [ItemObservation(pid: 500, title: nil, frame: bar(703, 46))]
+        )
+        #expect(result[0].observation?.pid == 500)
+    }
+
+    @Test func testAdjacentItemsNeverCrossMatch() {
+        // Real adjacent frames [854,886] and [886,924]: zero overlap.
+        let result = StatusItemCorrelator.correlate(
+            classified: [item(854, 32), item(886, 38)],
+            observed: [
+                ItemObservation(pid: 500, title: nil, frame: bar(854, 32)),
+                ItemObservation(pid: 501, title: nil, frame: bar(886, 38)),
+            ]
+        )
+        #expect(result[0].observation?.pid == 500)
+        #expect(result[1].observation?.pid == 501)
+    }
+
+    @Test func testItemWithoutObservationGetsNil() {
+        let result = StatusItemCorrelator.correlate(
+            classified: [item(700), item(900)],
+            observed: [ItemObservation(pid: 500, title: nil, frame: bar(700))]
+        )
+        #expect(result[0].observation != nil)
+        #expect(result[1].observation == nil)
+    }
+
+    @Test func testTwoObservationsOverOneFrameBestOverlapWins() {
+        let result = StatusItemCorrelator.correlate(
+            classified: [item(700, 40)],
+            observed: [
+                ItemObservation(pid: 500, title: nil, frame: bar(715, 40)), // 25pt overlap
+                ItemObservation(pid: 501, title: nil, frame: bar(702, 40)), // 38pt overlap
+            ]
+        )
+        #expect(result[0].observation?.pid == 501)
+    }
+
+    @Test func testEachObservationUsedAtMostOnce() {
+        // One observation overlapping two near-duplicate frames: only the
+        // stronger match gets it.
+        let result = StatusItemCorrelator.correlate(
+            classified: [item(700, 40), item(706, 40)],
+            observed: [ItemObservation(pid: 500, title: nil, frame: bar(700, 40))]
+        )
+        #expect(result[0].observation?.pid == 500)
+        #expect(result[1].observation == nil)
+    }
+
+    @Test func testFramelessObservationNeverMatches() {
+        let result = StatusItemCorrelator.correlate(
+            classified: [item(700)],
+            observed: [ItemObservation(pid: 500, title: "Ghost", frame: nil)]
+        )
+        #expect(result[0].observation == nil)
+    }
+
+    @Test func testBelowMinimumOverlapDoesNotMatch() {
+        // 15pt overlap of a 40pt-wide pair is under the 50% threshold.
+        let result = StatusItemCorrelator.correlate(
+            classified: [item(700, 40)],
+            observed: [ItemObservation(pid: 500, title: nil, frame: bar(725, 40))]
+        )
+        #expect(result[0].observation == nil)
+    }
+
+    @Test func testTieBrokenByMidXDistance() {
+        // Two same-width observations with equal overlap against one item;
+        // the one whose center is closer wins.
+        let result = StatusItemCorrelator.correlate(
+            classified: [item(700, 40)],
+            observed: [
+                ItemObservation(pid: 500, title: nil, frame: bar(680, 60)), // wider, same 40pt overlap
+                ItemObservation(pid: 501, title: nil, frame: bar(700, 40)), // exact
+            ]
+        )
+        #expect(result[0].observation?.pid == 501)
+    }
+}
+
+struct TitleHygieneTests {
+
+    @Test func testMeaningfulTitlePasses() {
+        #expect(TitleHygiene.meaningfulTitle("Syncing 3 files", appName: "Dropbox", bundleID: "com.dropbox.app") == "Syncing 3 files")
+    }
+
+    @Test func testJunkIsRejected() {
+        #expect(TitleHygiene.meaningfulTitle("menubaricon_v3", appName: "App", bundleID: nil) == nil)
+        #expect(TitleHygiene.meaningfulTitle("com.dropbox.app.statusitem", appName: "Dropbox", bundleID: "com.dropbox.app") == nil)
+        #expect(TitleHygiene.meaningfulTitle("", appName: "App", bundleID: nil) == nil)
+        #expect(TitleHygiene.meaningfulTitle("   ", appName: "App", bundleID: nil) == nil)
+        #expect(TitleHygiene.meaningfulTitle("12345", appName: "App", bundleID: nil) == nil)
+        #expect(TitleHygiene.meaningfulTitle(String(repeating: "x", count: 41), appName: "App", bundleID: nil) == nil)
+        #expect(TitleHygiene.meaningfulTitle(nil, appName: "App", bundleID: nil) == nil)
+    }
+
+    @Test func testAppNameEchoIsRejected() {
+        #expect(TitleHygiene.meaningfulTitle("Dropbox", appName: "Dropbox", bundleID: nil) == nil)
+        #expect(TitleHygiene.meaningfulTitle("dropbox", appName: "Dropbox", bundleID: nil) == nil)
+    }
+
+    @Test func testSingleDotSurvives() {
+        #expect(TitleHygiene.meaningfulTitle("Backing up…", appName: "Arq", bundleID: nil) == "Backing up…")
+        #expect(TitleHygiene.meaningfulTitle("v2.1 ready", appName: "App", bundleID: nil) == "v2.1 ready")
+    }
+}

--- a/docs/shelf-verification.md
+++ b/docs/shelf-verification.md
@@ -1,0 +1,78 @@
+# Manual verification — The Shelf & one-click access
+
+The AppKit plumbing (panel, click matrix, activation) is verified by hand.
+The pure logic (`ShelfContentDeriver`, `ShelfPlacement`, `StatusItemCorrelator`,
+`ActivationPlanner`, `DragPlanner`, `ActivationSession`, `ScreenCoordinates`)
+is covered by the Swift Testing suite — run `swift test` (see CONTRIBUTING for
+the Command-Line-Tools framework flags).
+
+> **TCC needs a bundled build.** The Accessibility permission is keyed to the
+> app's code signature/path. Grant/revoke testing (steps 8–11) must use the
+> bundled `.app`, not `swift run` — grants under `swift run` are unreliable
+> across rebuilds. Steps 1–7 work under `swift run`.
+
+## Tier 0 — permission-free (no Accessibility grant)
+
+On a notched Mac:
+
+1. **Trigger the badge.** Add menu bar apps until the chevron shows `+N`.
+   Confirm the count.
+2. **Open on click.** Left-click the chevron → the Shelf fades in below the
+   notch, frosted and rounded. The row count matches `N` (grouped rows sum to
+   `N`).
+3. **Identity tier.** On macOS ≤ 15 (Sequoia): rows show correct app icons and
+   names — cross-check against which icons are visibly missing. On macOS 26
+   (Tahoe): rows read "Hidden item 1…N" with the "macOS 26 hides which apps…"
+   header (Control Center owns every window there).
+4. **Tier-0 click.** Click a named row → its app comes forward and an inline
+   callout explains one-click access is opt-in. (No engine yet, so no menu
+   opens — that's expected.)
+5. **Dismiss paths.** Reopen, then: press Esc → closes; reopen, click the
+   desktop → closes; reopen, click the chevron again → closes.
+6. **Space / display.** Reopen, switch Spaces (ctrl-→) → closes instantly.
+   Reopen, unplug/replug an external display → closes, badge re-settles.
+7. **Hotkey & empty state.** ⌥⌘N opens the Shelf, including over a fullscreen
+   app. With nothing swallowed, ⌥⌘N shows "Everything fits".
+8. **Pref off.** Settings → turn off "Open the Shelf when clicking the count".
+   Now a chevron click collapses/expands as before; the right-click menu's
+   "See What's Hidden…" and ⌥⌘N still open the Shelf.
+9. **⌥⌘B unchanged.** ⌥⌘B always collapses/expands regardless of Shelf state.
+10. **Auto-rehide paused.** Expand, open the Shelf, wait past the rehide delay
+    → no collapse. Close the Shelf → collapse after a fresh full delay.
+
+## Tier 1 — opt-in Accessibility (bundled build)
+
+11. **Enable.** Settings → "Open hidden icons with one click" → the system
+    Accessibility prompt appears once, Pelmet is listed under Privacy &
+    Security → Accessibility. Grant it → "Accessibility permission: Granted"
+    within ~2s of returning to Pelmet.
+12. **Identity everywhere.** With `PELMET_DEBUG_ACTIVATION=verbose`, reopen the
+    Shelf — rows now carry real app identity even on Tahoe (AX sweep).
+13. **Visible-item click.** Click a row whose item is visible → its menu opens
+    under the item, cursor returns to where it was.
+14. **Swallowed-item click.** Click a row whose item is behind the notch →
+    watch the strategy chain (speculative click → AXPress → drag-to-expose).
+    The item's menu opens; after you close it, the moved neighbor returns to
+    its slot (menu bar order preserved).
+15. **Revoke mid-use.** With the Shelf open, revoke Accessibility in System
+    Settings → availability flips to "Not granted"; clicking a row reports the
+    permission failure inline; the core hide/show is untouched.
+
+## Safety rails
+
+16. **Hung app.** `kill -STOP <pid>` a menu bar app, then open the Shelf → the
+    AX sweep finishes within ~3s, no beachball (`kill -CONT` afterwards).
+17. **User race.** Start an activation, then immediately move the physical
+    mouse / press a button → the session aborts cleanly, no stuck synthetic
+    button (verify with a manual click afterwards).
+18. **Kill switch.** `PELMET_DISABLE_ACTIVATION=1 ./Pelmet` → clicks report the
+    permission failure and never post synthetic events.
+
+## Accessibility
+
+19. VoiceOver announces each row as a button with the app name; arrow keys
+    move the selection; Return activates; Esc closes.
+20. System Settings → Accessibility: Reduce Motion → the Shelf appears with no
+    slide/fade. Reduce Transparency → the panel draws opaque.
+21. `PELMET_DEBUG_LAYOUT=verbose swift run` → no repeating republish loop from
+    PID-only churn (the digest ignores owner changes).


### PR DESCRIPTION
## What & why

On notched MacBooks, macOS silently hides menu bar icons that don't fit — no indicator, no way to reach them (the gap PROJECT.md's Phase 2 targets). Clicking the chevron's "+N" count (or ⌥⌘N) now opens the Shelf: a frosted panel below the notch listing exactly the swallowed icons as app icon + name — never screen captures, so the zero-permission core stays intact. An opt-in Accessibility engine adds one-click opening of the real items (synthetic click → AXPress → drag-to-expose with restore) and item identity on macOS 26 Tahoe, where Control Center re-parents every status window; everything degrades honestly when the permission is declined or revoked. PROJECT.md's Shelf spec is revised from ScreenCaptureKit to this Accessibility-first design (research-backed: capture APIs are obsoleted and Screen Recording brings recurring prompts plus the purple indicator).

## How I tested it

82 Swift Testing unit tests over the pure core (content deriver, panel placement, item correlator, activation planner/session state machine, classifier). Live-verified on a notched MacBook running macOS 26 via `PELMET_DEBUG_LAYOUT`/`PELMET_DEBUG_ACTIVATION` traces: swallowed icons resolve to their apps (Cursor, Okta Verify) and identity survives collapse/expand transitions; full manual checklist in docs/shelf-verification.md (one-click activation needs a bundled .app for TCC).