### PR TITLE
Stop activation fighting the user's open menu

### DIFF
--- a/Sources/Pelmet/Activation/ActivationExecutor.swift
+++ b/Sources/Pelmet/Activation/ActivationExecutor.swift
@@ -34,6 +34,23 @@ final class ActivationExecutor {
     private var activeEngine: StatusItemActivationEngine?
     private var activeCompletion: ((ActivationResult) -> Void)?
     private var activeGeometry: MenuBarGeometry?
+    /// Menu-level window IDs present when the session began, BEFORE any
+    /// click — the shared reference for verification, the session's menu
+    /// gate, and post-finish quiescence.
+    private var sessionBaseline: Set<Int> = []
+    /// Restore drag owed after the session (a neighbor was moved to make
+    /// room) — discharged only once the user is quiescent.
+    private var owedRestoreDrag: DragPlan?
+    /// True from a finish that may have left a menu in the user's hands
+    /// until quiescence releases. Blocks the next activation ONLY while
+    /// real obligations are owed (restore drag, focus give-back) — an
+    /// obligation-free hold just guards auto-rehide and yields to the next
+    /// activation instead of failing it `.busy`.
+    private var quiescing = false
+    /// Bumped whenever quiescence starts or is cancelled — stale poll
+    /// closures and drag completions check it and bail, so a cancelled
+    /// hold can't double-release the rehide surface.
+    private var quiescenceGeneration = 0
     /// Frontmost app before appMenuClearance activated Finder — restored
     /// when the session finishes so activation never steals focus for good.
     private var previousFrontmost: NSRunningApplication?
@@ -63,6 +80,16 @@ final class ActivationExecutor {
         guard !isDisabledByEnv else { return completion(.failed(.permissionDenied)) }
         guard engine.canActivate else { return completion(.failed(.permissionDenied)) }
         guard !isActivating else { return completion(.failed(.busy)) }
+        if quiescing {
+            // A pending restore drag or focus give-back would collide with
+            // a new session — honest `.busy` until they discharge. A hold
+            // with nothing owed only pauses auto-rehide; the new activation
+            // takes that duty over, so cancel it and proceed.
+            guard owedRestoreDrag == nil, previousFrontmost == nil else {
+                return completion(.failed(.busy))
+            }
+            cancelQuiescence()
+        }
         guard Date().timeIntervalSince(lastActivation) >= Self.minActivationInterval else {
             return completion(.failed(.busy))
         }
@@ -96,10 +123,10 @@ final class ActivationExecutor {
         isActivating = true
         aborted = false
         lastActivation = Date()
-        lastOpenedMenuID = nil
         activeGeometry = geometry
         previousFrontmost = nil
         preDragRightOfNotchFrames = nil
+        owedRestoreDrag = nil
         installAbortObservers()
 
         session = ActivationSession(
@@ -109,6 +136,9 @@ final class ActivationExecutor {
         activeTarget = target
         activeEngine = engine
         activeCompletion = completion
+        // Captured BEFORE any click (the detector's documented contract):
+        // anything at the menu level beyond this set was opened by us.
+        sessionBaseline = detector.baselineWindowIDs()
         dispatch(session!.handle(.begin))
     }
 
@@ -131,9 +161,23 @@ final class ActivationExecutor {
                 }
                 return // async; the callback re-enters via advance()
 
-            case .startVerification(let deadline):
-                startVerification(near: pendingVerificationPoint, deadline: deadline) { [weak self] event in
+            case .startVerification(let deadline, let persistence):
+                startVerification(
+                    near: pendingVerificationPoint, deadline: deadline, persistence: persistence
+                ) { [weak self] event in
                     self?.advance(event)
+                }
+                return
+
+            case .checkMenuOpen:
+                // The session gate: did anything open since the baseline?
+                let open = detector.newMenuWindowID(
+                    near: pendingVerificationPoint, baseline: sessionBaseline
+                ) != nil
+                // Async hop — the callback re-enters via advance(), same as
+                // the other effect callbacks.
+                DispatchQueue.main.async { [weak self] in
+                    self?.advance(.menuCheck(open: open))
                 }
                 return
 
@@ -141,7 +185,9 @@ final class ActivationExecutor {
                 poster.releaseMouseButtons()
 
             case .restoreDrag(let plan):
-                scheduleRestore(plan)
+                // Discharged by the post-finish quiescence loop, never here —
+                // the menu the session opened is likely still in use.
+                owedRestoreDrag = plan
 
             case .finish(let result):
                 finish(result)
@@ -253,15 +299,31 @@ final class ActivationExecutor {
     private func startVerification(
         near point: CGPoint,
         deadline: TimeInterval,
+        persistence: TimeInterval?,
         report: @escaping (ActivationSession.Event) -> Void
     ) {
-        let baseline = detector.baselineWindowIDs()
+        // The session baseline predates the click, so a menu that opened
+        // faster than the first poll is still detected.
+        let baseline = sessionBaseline
         let start = Date()
         func poll() {
             if aborted { return report(.aborted(.interrupted)) }
             if let id = detector.newMenuWindowID(near: point, baseline: baseline) {
-                lastOpenedMenuID = id
-                return report(.verified(.menuOpened))
+                guard let persistence else { return report(.verified(.menuOpened)) }
+                // Ghost-menu rule: an AXPress "menu" that collapses within
+                // ~1.1s doesn't count — the window must survive the interval.
+                DispatchQueue.main.asyncAfter(deadline: .now() + persistence) { [weak self] in
+                    guard let self else { return }
+                    if self.aborted { return report(.aborted(.interrupted)) }
+                    if self.detector.isWindowPresent(id) {
+                        return report(.verified(.menuOpened))
+                    }
+                    if Date().timeIntervalSince(start) >= deadline {
+                        return report(.verificationTimedOut)
+                    }
+                    poll()
+                }
+                return
             }
             if Date().timeIntervalSince(start) >= deadline {
                 return report(.verificationTimedOut)
@@ -271,8 +333,6 @@ final class ActivationExecutor {
         // Give the click a beat to open the menu before the first poll.
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.1) { poll() }
     }
-
-    private var lastOpenedMenuID: Int?
 
     /// The reflow moved the target; find where it landed. Runs on `ioQueue`.
     ///
@@ -315,43 +375,119 @@ final class ActivationExecutor {
         return nil
     }
 
-    private func scheduleRestore(_ plan: DragPlan) {
-        // Restore only after the opened menu closes, so we don't yank the
-        // bar out from under an open menu. Bounded wait.
-        let menuID = lastOpenedMenuID
-        let deadline = Date().addingTimeInterval(30)
-        func waitAndRestore() {
-            let menuClosed = menuID.map { !detector.isWindowPresent($0) } ?? true
-            if menuClosed || Date() > deadline {
-                guard NSEvent.pressedMouseButtons == 0 else {
-                    // User is interacting; don't fight them. Leave the order
-                    // as-is rather than risk a tug of war.
-                    return
-                }
-                let restorePoint = CGPoint(x: plan.neighborFrame.midX, y: plan.neighborFrame.midY)
-                poster.commandDrag(fromAppKit: plan.to, toAppKit: restorePoint)
-                return
-            }
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { waitAndRestore() }
-        }
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { waitAndRestore() }
-    }
-
     private func finish(_ result: ActivationResult) {
         isActivating = false
         removeAbortObservers()
         StatusItemActivationEngine.debugTrace { "activation finished: \(result)" }
-        // Clearance borrowed focus for Finder; give it back.
-        if let previousFrontmost, !previousFrontmost.isTerminated {
-            previousFrontmost.activate(options: [])
-        }
-        previousFrontmost = nil
         let completion = activeCompletion
         session = nil
         activeTarget = nil
         activeEngine = nil
         activeCompletion = nil
+
+        // A success means a menu may be in the user's hands right now; a
+        // moved neighbor or Finder's borrowed focus are obligations that
+        // must wait for the user to be done either way.
+        let activated: Bool
+        if case .activated = result { activated = true } else { activated = false }
+        if activated || owedRestoreDrag != nil || previousFrontmost != nil {
+            // Hold the auto-rehide open BEFORE the completion hides the
+            // Shelf — openSurfaces must never touch zero (arming the
+            // collapse timer) while the user may be in the menu.
+            UIActivityTracker.shared.surfaceOpened()
+            beginQuiescence()
+        }
         completion?(result)
+    }
+
+    // MARK: - Post-finish quiescence
+
+    /// One mechanism for everything owed after a session: wait until no
+    /// menu beyond the session baseline is open AND the user is idle, then
+    /// restore the dragged neighbor, give Finder's borrowed focus back, and
+    /// release the auto-rehide hold. `QuiescencePolicy` holds the rules.
+    private func beginQuiescence() {
+        quiescing = true
+        quiescenceGeneration += 1
+        let generation = quiescenceGeneration
+        let baseline = sessionBaseline
+        let start = Date()
+        var closedStreak = 0
+        func poll() {
+            guard generation == quiescenceGeneration else { return }
+            let menusOpen = detector.hasNewMenuWindows(baseline: baseline)
+            closedStreak = menusOpen ? 0 : closedStreak + 1
+            let decision = QuiescencePolicy.decide(
+                menusOpen: menusOpen,
+                closedStreak: closedStreak,
+                buttonsDown: NSEvent.pressedMouseButtons != 0,
+                secondsSinceLastInput: Self.secondsSinceLastUserInput(),
+                elapsed: Date().timeIntervalSince(start)
+            )
+            switch decision {
+            case .wait:
+                DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { poll() }
+            case .proceed:
+                endQuiescence(discharge: true, generation: generation)
+            case .giveUp:
+                // Never drag or refocus under a still-open menu — leave the
+                // bar as the user sees it and only release the rehide hold.
+                endQuiescence(discharge: false, generation: generation)
+            }
+        }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.3) { poll() }
+    }
+
+    /// A hold with nothing owed, yielding to a fresh activation (which
+    /// re-opens its own rehide hold at finish).
+    private func cancelQuiescence() {
+        quiescenceGeneration += 1
+        quiescing = false
+        UIActivityTracker.shared.surfaceClosed()
+    }
+
+    private func endQuiescence(discharge: Bool, generation: Int) {
+        let plan = discharge ? owedRestoreDrag : nil
+        let refocus = discharge ? previousFrontmost : nil
+        if !discharge {
+            owedRestoreDrag = nil
+            previousFrontmost = nil
+        }
+        // On discharge the obligations stay set until the drag lands, so a
+        // new activate() keeps answering `.busy` instead of interleaving
+        // synthetic events with the in-flight restore.
+        let giveFocusBackAndRelease = { [weak self] in
+            guard let self, generation == self.quiescenceGeneration else { return }
+            // Give Finder's borrowed focus back — unless the user's menu
+            // choice already moved focus somewhere else; don't fight that.
+            if let refocus, !refocus.isTerminated,
+               NSWorkspace.shared.frontmostApplication?.bundleIdentifier == "com.apple.finder" {
+                refocus.activate(options: [])
+            }
+            self.owedRestoreDrag = nil
+            self.previousFrontmost = nil
+            self.quiescing = false
+            UIActivityTracker.shared.surfaceClosed()
+        }
+        guard let plan else { return giveFocusBackAndRelease() }
+        lastDrag = Date()
+        let restorePoint = CGPoint(x: plan.neighborFrame.midX, y: plan.neighborFrame.midY)
+        ioQueue.async { [weak self] in
+            self?.poster.commandDrag(fromAppKit: plan.to, toAppKit: restorePoint)
+            DispatchQueue.main.async(execute: giveFocusBackAndRelease)
+        }
+    }
+
+    /// Seconds since the user last clicked or released the mouse —
+    /// permission-free, session-wide (synthetic events count too, but none
+    /// are posted while quiescence runs).
+    private static func secondsSinceLastUserInput() -> TimeInterval {
+        let types: [CGEventType] = [.leftMouseDown, .leftMouseUp, .rightMouseDown]
+        return types
+            .map {
+                CGEventSource.secondsSinceLastEventType(.combinedSessionState, eventType: $0)
+            }
+            .min() ?? .greatestFiniteMagnitude
     }
 
     // MARK: - Abort rails

--- a/Sources/Pelmet/Activation/MenuOpenDetector.swift
+++ b/Sources/Pelmet/Activation/MenuOpenDetector.swift
@@ -45,6 +45,14 @@ final class MenuOpenDetector {
         menuWindows().contains { $0.id == id }
     }
 
+    /// Any menu-level window beyond `baseline` — the user may be browsing a
+    /// menu we opened, or a submenu that replaced its window. Robust to that
+    /// churn, unlike single-ID tracking; deliberately X-agnostic, since
+    /// submenus extend far from the item.
+    func hasNewMenuWindows(baseline: Set<Int>) -> Bool {
+        menuWindows().contains { !baseline.contains($0.id) }
+    }
+
     // MARK: - Window snapshot
 
     private struct MenuWindow {

--- a/Sources/Pelmet/Shelf/ShelfPanelController.swift
+++ b/Sources/Pelmet/Shelf/ShelfPanelController.swift
@@ -180,11 +180,14 @@ final class ShelfPanelController {
         // toggle's mouseUp handler reopen the shelf it just closed.
         globalMouseMonitor = NSEvent.addGlobalMonitorForEvents(
             matching: [.leftMouseDown, .rightMouseDown]
-        ) { [weak self] _ in
+        ) { [weak self] event in
             guard let self else { return }
-            // Our own Tier-1 activation posts a synthetic click into another
-            // app; a global monitor sees it. Never treat that as a dismiss.
+            // Our own synthetic events (activation clicks, the post-session
+            // restore drag) land in other apps and a global monitor sees
+            // them. Never treat those as a dismiss — they carry the poster's
+            // source tag, and mid-activation nothing dismisses at all.
             if ActivationExecutor.shared.isActivating { return }
+            if Self.isPelmetSynthetic(event) { return }
             if let toggleWindow = self.anchorButton?.window,
                toggleWindow.frame.contains(NSEvent.mouseLocation) { return }
             self.hide()
@@ -194,6 +197,7 @@ final class ShelfPanelController {
         ) { [weak self] event in
             guard let self else { return event }
             if ActivationExecutor.shared.isActivating { return event }
+            if Self.isPelmetSynthetic(event) { return event }
             if event.window !== self.panelIfLoaded {
                 if let toggleWindow = self.anchorButton?.window, event.window === toggleWindow {
                     return event
@@ -217,6 +221,12 @@ final class ShelfPanelController {
                 self?.hide(animated: false)
             }),
         ]
+    }
+
+    /// Events posted by `SyntheticEventPoster` carry its source tag.
+    private static func isPelmetSynthetic(_ event: NSEvent) -> Bool {
+        event.cgEvent?.getIntegerValueField(.eventSourceUserData)
+            == SyntheticEventPoster.sourceUserData
     }
 
     private func removeDismissMonitors() {

--- a/Sources/PelmetCore/Activation/ActivationSession.swift
+++ b/Sources/PelmetCore/Activation/ActivationSession.swift
@@ -10,7 +10,12 @@ import Foundation
 ///  - strategies run in planner order; each click-ish step gets one
 ///    verification window (0.7s clicks, 1.2s AXPress — an AXPress "menu"
 ///    that collapses before ~1.1s is the known ghost-menu failure, so its
-///    verification uses persistence, which the executor implements);
+///    verification requires the window to persist, which the executor
+///    implements);
+///  - once ANY click was posted, a menu may already be open even though
+///    verification missed it (detection is heuristic); every later step
+///    is gated on a menu check, and an open menu finishes the session
+///    successfully — never perform another step over the user's menu;
 ///  - exactly ONE retry total: the first strategy re-runs once after all
 ///    strategies exhaust, and only if no drag was performed;
 ///  - the drag path never retries; a failed drag ends the session;
@@ -31,14 +36,22 @@ public struct ActivationSession {
         case stepFailed
         case verified(ActivationVerification)
         case verificationTimedOut
+        /// Result of `Effect.checkMenuOpen`.
+        case menuCheck(open: Bool)
         case aborted(ActivationFailure)
     }
 
     public enum Effect: Equatable {
         case perform(ActivationStrategy)
         /// Start polling for a newly opened menu window; feed back
-        /// `.verified` or `.verificationTimedOut`.
-        case startVerification(deadline: TimeInterval)
+        /// `.verified` or `.verificationTimedOut`. A non-nil `persistence`
+        /// means a match only counts if the window is still present that
+        /// much later (the AXPress ghost-menu rule).
+        case startVerification(deadline: TimeInterval, persistence: TimeInterval?)
+        /// One detector scan against the session baseline near the last
+        /// click: did a menu open since the session began? Feed back
+        /// `.menuCheck(open:)`.
+        case checkMenuOpen
         /// Post a balanced mouse-up if any synthetic button might be down.
         case releaseMouseButtons
         /// After the session finishes and the opened menu closes: drag the
@@ -49,6 +62,9 @@ public struct ActivationSession {
 
     public static let clickVerification: TimeInterval = 0.7
     public static let axPressVerification: TimeInterval = 1.2
+    /// An AXPress "menu" that collapses before ~1.1s is the known
+    /// ghost-menu failure — a match must survive this long to count.
+    public static let axPressMenuPersistence: TimeInterval = 1.1
 
     private let strategies: [ActivationStrategy]
     private let targetWasSwallowed: Bool
@@ -57,6 +73,9 @@ public struct ActivationSession {
     /// True while the single first-strategy retry is in flight — the chain
     /// does NOT continue past it.
     private var retrying = false
+    /// True between emitting `.checkMenuOpen` and receiving `.menuCheck` —
+    /// any other `.menuCheck` is spurious and ignored.
+    private var awaitingMenuGate = false
     private var dragPerformed: DragPlan?
     private var reflowClickHappened = false
     private var anyClickPosted = false
@@ -80,13 +99,16 @@ public struct ActivationSession {
             switch current {
             case .syntheticClick:
                 anyClickPosted = true
-                return [.startVerification(deadline: Self.clickVerification)]
+                return [.startVerification(deadline: Self.clickVerification, persistence: nil)]
             case .clickTargetAfterReflow:
                 anyClickPosted = true
                 reflowClickHappened = true
-                return [.startVerification(deadline: Self.clickVerification)]
+                return [.startVerification(deadline: Self.clickVerification, persistence: nil)]
             case .axPress:
-                return [.startVerification(deadline: Self.axPressVerification)]
+                return [.startVerification(
+                    deadline: Self.axPressVerification,
+                    persistence: Self.axPressMenuPersistence
+                )]
             case .appMenuClearance, .expandCollapsedBar:
                 return advance()
             case .dragToExpose(let plan):
@@ -111,6 +133,15 @@ public struct ActivationSession {
         case .verificationTimedOut:
             return advance()
 
+        case .menuCheck(let open):
+            guard awaitingMenuGate else { return [] }
+            awaitingMenuGate = false
+            // An open menu is the success we were after — finishing here is
+            // what keeps every remaining step from closing it under the user.
+            if open { return finish(.activated(.menuOpened)) }
+            guard let step = current else { return advance() }
+            return [.perform(step)]
+
         case .aborted(let failure):
             var effects: [Effect] = [.releaseMouseButtons]
             effects.append(contentsOf: finish(.failed(failure)))
@@ -129,7 +160,7 @@ public struct ActivationSession {
         if !retrying {
             index += 1
             if let next = current {
-                return [.perform(next)]
+                return gatedPerform(next)
             }
             // Exhausted. One retry of the FIRST strategy only, unless the
             // bar was already rearranged by a drag.
@@ -137,13 +168,22 @@ public struct ActivationSession {
                case .syntheticClick = first {
                 didRetry = true
                 retrying = true
-                return [.perform(first)]
+                return gatedPerform(first)
             }
         }
         if anyClickPosted, reflowClickHappened || !targetWasSwallowed {
             return finish(.activated(.unverified))
         }
         return finish(.failed(targetWasSwallowed ? .noRoomToExpose : .timedOut))
+    }
+
+    /// A posted click may have opened a menu the verification window missed
+    /// — check before performing anything else over it. Before the first
+    /// click nothing could be open, so perform directly.
+    private mutating func gatedPerform(_ step: ActivationStrategy) -> [Effect] {
+        guard anyClickPosted else { return [.perform(step)] }
+        awaitingMenuGate = true
+        return [.checkMenuOpen]
     }
 
     private mutating func finish(_ result: ActivationResult) -> [Effect] {

--- a/Sources/PelmetCore/Activation/QuiescencePolicy.swift
+++ b/Sources/PelmetCore/Activation/QuiescencePolicy.swift
@@ -1,0 +1,40 @@
+import Foundation
+
+/// Decides when the executor may discharge its post-activation obligations
+/// (restore drag, focus give-back, auto-rehide re-arm) without fighting the
+/// user. Pure so the rules are unit-testable: the executor samples the
+/// world every poll and feeds the facts in.
+public enum QuiescencePolicy {
+
+    public enum Decision: Equatable {
+        /// Something is (or may be) in the user's hands — poll again.
+        case wait
+        /// The coast is clear: restore the bar, give focus back, re-arm.
+        case proceed
+        /// Hard cap hit — discharge NOTHING (never drag or refocus under a
+        /// still-open menu); just release state so rehide can re-arm.
+        case giveUp
+    }
+
+    /// Act only this long AFTER the user's last input — the restore drag
+    /// must never hijack the cursor the instant a menu entry is picked.
+    public static let idleGrace: TimeInterval = 1.0
+    /// Consecutive "no menu open" polls required — submenu churn replaces
+    /// menu windows, so single observations flicker.
+    public static let requiredClosedPolls = 2
+    public static let hardCap: TimeInterval = 90
+
+    public static func decide(
+        menusOpen: Bool,
+        closedStreak: Int,
+        buttonsDown: Bool,
+        secondsSinceLastInput: TimeInterval,
+        elapsed: TimeInterval
+    ) -> Decision {
+        if elapsed >= hardCap { return .giveUp }
+        if menusOpen { return .wait }
+        if closedStreak < requiredClosedPolls { return .wait }
+        if buttonsDown || secondsSinceLastInput < idleGrace { return .wait }
+        return .proceed
+    }
+}

--- a/Tests/PelmetCoreTests/ActivationSessionTests.swift
+++ b/Tests/PelmetCoreTests/ActivationSessionTests.swift
@@ -18,7 +18,7 @@ struct ActivationSessionTests {
     @Test func testVerifiedFirstClickShortCircuits() {
         var session = ActivationSession(strategies: fullChain(), targetWasSwallowed: true)
         #expect(session.handle(.begin) == [.perform(click)])
-        #expect(session.handle(.stepCompleted) == [.startVerification(deadline: 0.7)])
+        #expect(session.handle(.stepCompleted) == [.startVerification(deadline: 0.7, persistence: nil)])
         #expect(session.handle(.verified(.menuOpened)) == [.finish(.activated(.menuOpened))])
         // Finished: further events are ignored.
         #expect(session.handle(.verificationTimedOut).isEmpty)
@@ -28,12 +28,19 @@ struct ActivationSessionTests {
         var session = ActivationSession(strategies: fullChain(), targetWasSwallowed: true)
         _ = session.handle(.begin)
         _ = session.handle(.stepCompleted)                          // click posted
-        #expect(session.handle(.verificationTimedOut) == [.perform(.axPress)])
-        #expect(session.handle(.stepCompleted) == [.startVerification(deadline: 1.2)])
-        #expect(session.handle(.verificationTimedOut) == [.perform(.appMenuClearance)])
-        #expect(session.handle(.stepCompleted) == [.perform(.dragToExpose(dragPlan))])
-        #expect(session.handle(.stepCompleted) == [.perform(.clickTargetAfterReflow)])
-        #expect(session.handle(.stepCompleted) == [.startVerification(deadline: 0.7)])
+        // Every post-click step is gated on "did that click open a menu?"
+        #expect(session.handle(.verificationTimedOut) == [.checkMenuOpen])
+        #expect(session.handle(.menuCheck(open: false)) == [.perform(.axPress)])
+        #expect(session.handle(.stepCompleted) == [
+            .startVerification(deadline: 1.2, persistence: 1.1),
+        ])
+        #expect(session.handle(.verificationTimedOut) == [.checkMenuOpen])
+        #expect(session.handle(.menuCheck(open: false)) == [.perform(.appMenuClearance)])
+        #expect(session.handle(.stepCompleted) == [.checkMenuOpen])
+        #expect(session.handle(.menuCheck(open: false)) == [.perform(.dragToExpose(dragPlan))])
+        #expect(session.handle(.stepCompleted) == [.checkMenuOpen])
+        #expect(session.handle(.menuCheck(open: false)) == [.perform(.clickTargetAfterReflow)])
+        #expect(session.handle(.stepCompleted) == [.startVerification(deadline: 0.7, persistence: nil)])
         // Reflow click verified: menu opened, restore is owed.
         #expect(session.handle(.verified(.menuOpened)) == [
             .restoreDrag(dragPlan), .finish(.activated(.menuOpened)),
@@ -44,12 +51,16 @@ struct ActivationSessionTests {
         var session = ActivationSession(strategies: fullChain(), targetWasSwallowed: true)
         _ = session.handle(.begin)
         _ = session.handle(.stepCompleted)
-        _ = session.handle(.verificationTimedOut)   // → axPress
+        _ = session.handle(.verificationTimedOut)
+        _ = session.handle(.menuCheck(open: false))     // → axPress
         _ = session.handle(.stepCompleted)
-        _ = session.handle(.verificationTimedOut)   // → clearance
-        _ = session.handle(.stepCompleted)          // → drag
-        _ = session.handle(.stepCompleted)          // → reflow click
-        _ = session.handle(.stepCompleted)          // → verification
+        _ = session.handle(.verificationTimedOut)
+        _ = session.handle(.menuCheck(open: false))     // → clearance
+        _ = session.handle(.stepCompleted)
+        _ = session.handle(.menuCheck(open: false))     // → drag
+        _ = session.handle(.stepCompleted)
+        _ = session.handle(.menuCheck(open: false))     // → reflow click
+        _ = session.handle(.stepCompleted)              // → verification
         // Timed out after the final click, but a drag happened: no retry,
         // soft success, restore owed.
         #expect(session.handle(.verificationTimedOut) == [
@@ -63,10 +74,13 @@ struct ActivationSessionTests {
         )
         _ = session.handle(.begin)
         _ = session.handle(.stepCompleted)
-        _ = session.handle(.verificationTimedOut)   // → axPress
+        _ = session.handle(.verificationTimedOut)
+        _ = session.handle(.menuCheck(open: false))     // → axPress
         _ = session.handle(.stepCompleted)
-        // Exhausted → single retry of the first click.
-        #expect(session.handle(.verificationTimedOut) == [.perform(click)])
+        // Exhausted → single retry of the first click, gated like any
+        // other post-click step.
+        #expect(session.handle(.verificationTimedOut) == [.checkMenuOpen])
+        #expect(session.handle(.menuCheck(open: false)) == [.perform(click)])
         _ = session.handle(.stepCompleted)
         // Second exhaustion: no second retry. Swallowed target, no reflow
         // click → honest failure.
@@ -77,7 +91,8 @@ struct ActivationSessionTests {
         var session = ActivationSession(strategies: [click], targetWasSwallowed: false)
         _ = session.handle(.begin)
         _ = session.handle(.stepCompleted)
-        #expect(session.handle(.verificationTimedOut) == [.perform(click)]) // the one retry
+        #expect(session.handle(.verificationTimedOut) == [.checkMenuOpen])
+        #expect(session.handle(.menuCheck(open: false)) == [.perform(click)]) // the one retry
         _ = session.handle(.stepCompleted)
         #expect(session.handle(.verificationTimedOut) == [.finish(.activated(.unverified))])
     }
@@ -87,10 +102,13 @@ struct ActivationSessionTests {
         _ = session.handle(.begin)
         _ = session.handle(.stepCompleted)
         _ = session.handle(.verificationTimedOut)
+        _ = session.handle(.menuCheck(open: false))
         _ = session.handle(.stepCompleted)
         _ = session.handle(.verificationTimedOut)
-        _ = session.handle(.stepCompleted)          // clearance done → drag next
-        _ = session.handle(.stepCompleted)          // drag completed
+        _ = session.handle(.menuCheck(open: false))
+        _ = session.handle(.stepCompleted)              // clearance done
+        _ = session.handle(.menuCheck(open: false))     // → drag
+        _ = session.handle(.stepCompleted)              // drag completed
         let effects = session.handle(.aborted(.interrupted))
         #expect(effects == [
             .releaseMouseButtons,
@@ -112,9 +130,12 @@ struct ActivationSessionTests {
         _ = session.handle(.begin)
         _ = session.handle(.stepCompleted)
         _ = session.handle(.verificationTimedOut)
+        _ = session.handle(.menuCheck(open: false))
         _ = session.handle(.stepCompleted)
         _ = session.handle(.verificationTimedOut)
-        _ = session.handle(.stepCompleted)          // clearance → drag next
+        _ = session.handle(.menuCheck(open: false))
+        _ = session.handle(.stepCompleted)              // clearance done
+        _ = session.handle(.menuCheck(open: false))     // → drag
         #expect(session.handle(.stepFailed) == [.finish(.failed(.noRoomToExpose))])
     }
 
@@ -122,12 +143,77 @@ struct ActivationSessionTests {
         var session = ActivationSession(strategies: fullChain(), targetWasSwallowed: true)
         _ = session.handle(.begin)
         _ = session.handle(.stepCompleted)
-        _ = session.handle(.verificationTimedOut)   // → axPress
-        #expect(session.handle(.stepFailed) == [.perform(.appMenuClearance)])
+        _ = session.handle(.verificationTimedOut)
+        _ = session.handle(.menuCheck(open: false))     // → axPress
+        #expect(session.handle(.stepFailed) == [.checkMenuOpen])
+        #expect(session.handle(.menuCheck(open: false)) == [.perform(.appMenuClearance)])
     }
 
     @Test func testEmptyPlanFailsImmediately() {
         var session = ActivationSession(strategies: [], targetWasSwallowed: false)
         #expect(session.handle(.begin) == [.finish(.failed(.itemVanished))])
+    }
+
+    // MARK: - Menu gate
+
+    @Test func testMenuGateOpenBeforeAXPressFinishesWithoutTouchingIt() {
+        var session = ActivationSession(strategies: fullChain(), targetWasSwallowed: true)
+        _ = session.handle(.begin)
+        _ = session.handle(.stepCompleted)
+        _ = session.handle(.verificationTimedOut)
+        // Verification missed the menu but the gate sees it: success, no
+        // AXPress toggle-close, no clearance, no drag.
+        #expect(session.handle(.menuCheck(open: true)) == [.finish(.activated(.menuOpened))])
+        #expect(session.handle(.stepCompleted).isEmpty)
+    }
+
+    @Test func testMenuGateOpenAfterDragOwesRestore() {
+        var session = ActivationSession(strategies: fullChain(), targetWasSwallowed: true)
+        _ = session.handle(.begin)
+        _ = session.handle(.stepCompleted)
+        _ = session.handle(.verificationTimedOut)
+        _ = session.handle(.menuCheck(open: false))
+        _ = session.handle(.stepCompleted)
+        _ = session.handle(.verificationTimedOut)
+        _ = session.handle(.menuCheck(open: false))
+        _ = session.handle(.stepCompleted)              // clearance done
+        _ = session.handle(.menuCheck(open: false))     // → drag
+        _ = session.handle(.stepCompleted)              // drag completed
+        #expect(session.handle(.menuCheck(open: true)) == [
+            .restoreDrag(dragPlan), .finish(.activated(.menuOpened)),
+        ])
+    }
+
+    @Test func testMenuGateGuardsTheRetry() {
+        var session = ActivationSession(strategies: [click], targetWasSwallowed: false)
+        _ = session.handle(.begin)
+        _ = session.handle(.stepCompleted)
+        #expect(session.handle(.verificationTimedOut) == [.checkMenuOpen])
+        // The menu the first click opened is found before the retry can
+        // toggle it closed.
+        #expect(session.handle(.menuCheck(open: true)) == [.finish(.activated(.menuOpened))])
+    }
+
+    @Test func testNoGateWhenNoClickWasPosted() {
+        var session = ActivationSession(strategies: fullChain(), targetWasSwallowed: true)
+        _ = session.handle(.begin)
+        // The click could not even be posted — nothing can be open yet.
+        #expect(session.handle(.stepFailed) == [.perform(.axPress)])
+    }
+
+    @Test func testSpuriousMenuCheckIsIgnored() {
+        var session = ActivationSession(strategies: fullChain(), targetWasSwallowed: true)
+        _ = session.handle(.begin)
+        #expect(session.handle(.menuCheck(open: true)).isEmpty)
+    }
+
+    @Test func testAbortWhileAwaitingGateReleasesButtons() {
+        var session = ActivationSession(strategies: [click, .axPress], targetWasSwallowed: true)
+        _ = session.handle(.begin)
+        _ = session.handle(.stepCompleted)
+        _ = session.handle(.verificationTimedOut)       // → checkMenuOpen pending
+        #expect(session.handle(.aborted(.interrupted)) == [
+            .releaseMouseButtons, .finish(.failed(.interrupted)),
+        ])
     }
 }

--- a/Tests/PelmetCoreTests/QuiescencePolicyTests.swift
+++ b/Tests/PelmetCoreTests/QuiescencePolicyTests.swift
@@ -1,0 +1,55 @@
+import Testing
+@testable import PelmetCore
+
+struct QuiescencePolicyTests {
+
+    private func decide(
+        menusOpen: Bool = false,
+        closedStreak: Int = QuiescencePolicy.requiredClosedPolls,
+        buttonsDown: Bool = false,
+        secondsSinceLastInput: Double = QuiescencePolicy.idleGrace,
+        elapsed: Double = 5
+    ) -> QuiescencePolicy.Decision {
+        QuiescencePolicy.decide(
+            menusOpen: menusOpen,
+            closedStreak: closedStreak,
+            buttonsDown: buttonsDown,
+            secondsSinceLastInput: secondsSinceLastInput,
+            elapsed: elapsed
+        )
+    }
+
+    @Test func testOpenMenuWaits() {
+        #expect(decide(menusOpen: true, closedStreak: 0) == .wait)
+    }
+
+    @Test func testSingleClosedObservationWaits() {
+        // Submenu window churn: one "closed" poll isn't proof.
+        #expect(decide(closedStreak: 1) == .wait)
+    }
+
+    @Test func testClosedStreakWithIdleUserProceeds() {
+        #expect(decide() == .proceed)
+    }
+
+    @Test func testPressedButtonWaits() {
+        #expect(decide(buttonsDown: true) == .wait)
+    }
+
+    @Test func testRecentInputWaits() {
+        // The user just clicked a menu entry — don't hijack the cursor yet.
+        #expect(decide(secondsSinceLastInput: 0.4) == .wait)
+    }
+
+    @Test func testIdleGraceBoundaryProceeds() {
+        #expect(decide(secondsSinceLastInput: QuiescencePolicy.idleGrace) == .proceed)
+    }
+
+    @Test func testHardCapGivesUpEvenWithMenuOpen() {
+        #expect(decide(menusOpen: true, closedStreak: 0, elapsed: QuiescencePolicy.hardCap) == .giveUp)
+    }
+
+    @Test func testJustUnderTheCapStillWaits() {
+        #expect(decide(menusOpen: true, closedStreak: 0, elapsed: QuiescencePolicy.hardCap - 1) == .wait)
+    }
+}


### PR DESCRIPTION
## What & why

Clicking a Shelf row could open a hidden item's menu and then fight the user: verification captured its window baseline after the click so fast menus were never detected, timed-out fallbacks (AXPress, Finder clearance, cursor-warping drags, retry clicks) fired over the open menu, the restore drag hijacked the cursor 0.3s after finish, and auto-rehide collapsed the bar mid-browse. The pure `ActivationSession` now gates every post-click step on a menu check (an open menu finishes the session successfully), AXPress verification enforces the promised ghost-menu persistence, and the executor captures the window baseline at session start. All post-finish obligations — restore drag, Finder focus give-back, auto-rehide re-arm — go through one `QuiescencePolicy`-driven loop that acts only when no menu is open and the user is idle, and obligation-free holds yield to the next activation instead of failing it `.busy`. Shelf dismiss monitors now ignore Pelmet-tagged synthetic events so the restore drag can't close the panel.

## How I tested it

`swift test` (96 tests, including new menu-gate session tests and `QuiescencePolicyTests`); `swift run` on a notched MacBook — activated hidden items from the Shelf, browsed the opened menus incl. submenus and picked entries without the menu closing, cursor warping, or shake-to-locate firing, and confirmed back-to-back activations no longer report Busy.