### PR TITLE
Prompt for Accessibility on first run and harden onboarding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,10 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore: ['**/*.md', 'docs/**', 'LICENSE', '.github/ISSUE_TEMPLATE/**', '.github/FUNDING.yml', '.github/CODEOWNERS']
   pull_request:
     branches: [main]
+    paths-ignore: ['**/*.md', 'docs/**', 'LICENSE', '.github/ISSUE_TEMPLATE/**', '.github/FUNDING.yml', '.github/CODEOWNERS']
 
 # Least privilege: CI only ever needs to read the repo.
 permissions:
@@ -16,16 +18,22 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Fast loop: the SwiftPM build plus the PelmetCore test suite.
-  build-and-test:
-    name: swift build & test
+  # Fast loop: the PelmetCore test suite. `swift test` builds what it needs;
+  # the xcode-build job below is the authoritative "the app compiles" check.
+  test:
+    name: swift test
     runs-on: macos-15
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
+      - name: Cache SwiftPM build
+        uses: actions/cache@v4
+        with:
+          path: .build
+          key: spm-${{ runner.os }}-${{ hashFiles('Package.resolved', 'Package.swift', 'Sources/**', 'Tests/**') }}
+          restore-keys: spm-${{ runner.os }}-
       - name: Toolchain versions
         run: swift --version
-      - name: Build
-        run: swift build
       - name: Test
         run: swift test
 
@@ -34,6 +42,10 @@ jobs:
   xcode-build:
     name: xcodegen & xcodebuild
     runs-on: macos-15
+    timeout-minutes: 20
+    env:
+      HOMEBREW_NO_AUTO_UPDATE: 1
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
     steps:
       - uses: actions/checkout@v4
       - name: Install XcodeGen

--- a/Sources/Pelmet/Activation/AXPermissionMonitor.swift
+++ b/Sources/Pelmet/Activation/AXPermissionMonitor.swift
@@ -47,6 +47,16 @@ final class AXPermissionMonitor {
         recompute()
     }
 
+    /// Deep-links to the Accessibility pane. The single home for this URL —
+    /// needed because `AXIsProcessTrustedWithOptions` will not re-show the OS
+    /// modal once the app is already listed (even if toggled off), so every
+    /// opt-in surface must be able to fall back to System Settings.
+    static func openSystemSettings() {
+        let url = URL(string:
+            "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!
+        NSWorkspace.shared.open(url)
+    }
+
     func recompute() {
         let trusted = AXIsProcessTrusted()
         guard trusted != lastKnownTrusted else { return }

--- a/Sources/Pelmet/Activation/StatusItemActivationEngine.swift
+++ b/Sources/Pelmet/Activation/StatusItemActivationEngine.swift
@@ -31,6 +31,12 @@ protocol StatusItemActivating: AnyObject {
 
     func setEnabled(_ enabled: Bool)
     func requestAccess()
+    /// Route any "enable one-click access" affordance to the right outcome:
+    /// fire the system prompt, deep-link to System Settings when the OS won't
+    /// re-show it, or just enable when already trusted. `proactive` = the
+    /// passive first-run auto-prompt (keep the engine OFF until the grant
+    /// lands); an explicit user tap passes `false` and enables immediately.
+    func offerOneClick(proactive: Bool)
     func refreshDirectory(reason: String)
     func activate(recordID: String, completion: @escaping (ActivationResult) -> Void)
 }
@@ -176,10 +182,12 @@ final class StatusItemActivationEngine: StatusItemActivating {
             }),
         ]
         AXPermissionMonitor.shared.onChange = { [weak self] in
-            self?.recomputeAvailability()
+            self?.handleAXChange()
         }
         AXPermissionMonitor.shared.startObserving()
-        recomputeAvailability()
+        // handleAXChange (not just recompute) so a grant made while awaiting —
+        // including one granted before this launch — flips the engine on.
+        handleAXChange()
         Self.debugTrace {
             "start: enabled=\(Preferences.activationEngineEnabled) "
                 + "trusted=\(AXIsProcessTrusted()) availability=\(availability)"
@@ -198,6 +206,29 @@ final class StatusItemActivationEngine: StatusItemActivating {
         recomputeAvailability()
     }
 
+    func offerOneClick(proactive: Bool) {
+        // Already trusted at the system level: just turn the feature on.
+        if AXIsProcessTrusted() {
+            Preferences.awaitingOneClickGrant = false
+            Preferences.activationEngineEnabled = true
+            recomputeAvailability()
+            return
+        }
+        // Not proactive means an explicit tap — honor the intent to enable now;
+        // the passive first-run offer keeps the engine off until the grant.
+        if !proactive { Preferences.activationEngineEnabled = true }
+        // Arm the enable-on-grant latch either way.
+        Preferences.awaitingOneClickGrant = true
+        if Preferences.didPromptForAccessibility {
+            // The OS modal won't reappear once we're already listed — send the
+            // user straight to the Accessibility pane instead of no-op'ing.
+            AXPermissionMonitor.openSystemSettings()
+        } else {
+            AXPermissionMonitor.shared.requestWithPrompt()
+        }
+        recomputeAvailability()
+    }
+
     func refreshDirectory(reason: String) {
         _ = reason
         rebuildDirectory()
@@ -208,6 +239,19 @@ final class StatusItemActivationEngine: StatusItemActivating {
     }
 
     // MARK: - Availability
+
+    /// Fired whenever the Accessibility trust state may have changed. If we
+    /// asked on the user's behalf (`awaitingOneClickGrant`) and the grant has
+    /// now landed, turn one-click on — this is the only place the passive
+    /// first-run flow enables the engine, since `recomputeAvailability` reports
+    /// `.notDetermined` while the engine is still off.
+    private func handleAXChange() {
+        if Preferences.awaitingOneClickGrant, AXIsProcessTrusted() {
+            Preferences.awaitingOneClickGrant = false
+            Preferences.activationEngineEnabled = true
+        }
+        recomputeAvailability()
+    }
 
     func recomputeAvailability() {
         let wasGranted = availability == .granted
@@ -479,7 +523,7 @@ final class StatusItemActivationEngine: StatusItemActivating {
                     let found = results.filter { !$0.value.isEmpty }
                     return "AX sweep: attempted \(results.count)/\(ordered.count) apps, "
                         + "\(found.count) with extras (\(found.values.map(\.count).reduce(0, +)) items)"
-                        + (attemptedAll ? "" : " — continuing")
+                        + (attemptedAll ? "" : " (continuing)")
                 }
 
                 // Route back through rebuildDirectory: it refreshes cached

--- a/Sources/Pelmet/AppDelegate.swift
+++ b/Sources/Pelmet/AppDelegate.swift
@@ -11,7 +11,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // items off-screen so every chevron looks dead. The lock is released
         // automatically when this process exits. See acquireSingleInstanceLock.
         guard Self.acquireSingleInstanceLock() else {
-            print("Another copy of Pelmet is already running — quitting this one.")
+            print("Another copy of Pelmet is already running. Quitting this one.")
             fflush(stdout)
             NSApp.terminate(nil)
             return
@@ -72,8 +72,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             "  sits just left of the chevron.",
             hotkeys.toggle
                 ? "  • Click the chevron or press ⌥⌘B to hide/show icons."
-                : "  • Click the chevron to hide/show icons. (⌥⌘B is unavailable — another app claimed it.)",
-            "  • Pelmet hides everything LEFT of ╱ — ⌘-drag icons you always",
+                : "  • Click the chevron to hide/show icons. (⌥⌘B is unavailable; another app claimed it.)",
+            "  • Pelmet hides everything LEFT of ╱. ⌘-drag icons you always",
             "    want visible to its RIGHT, next to the clock.",
         ]
         if Preferences.autoRehide {
@@ -81,7 +81,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
         lines.append(contentsOf: [
             "  • A number next to the chevron (like +3) means that many icons don't fit",
-            "    beside the notch — click the chevron to see them on the Shelf"
+            "    beside the notch. Click the chevron to see them on the Shelf"
                 + (hotkeys.shelf ? " (or press ⌥⌘N)." : "."),
             "  • Can't find Pelmet in the bar? Launching it again opens its Settings window.",
             "  • Ctrl-C here (or closing this terminal) quits Pelmet.",

--- a/Sources/Pelmet/MakeRoom/MakeRoomWindowController.swift
+++ b/Sources/Pelmet/MakeRoom/MakeRoomWindowController.swift
@@ -66,7 +66,7 @@ struct MakeRoomView: View {
                 symbol: "arrow.left.and.right",
                 title: "Tighten icon spacing",
                 text: "macOS spaces menu bar icons generously. Reducing the spacing fits more icons "
-                    + "beside the notch. No permissions involved — the change takes effect the next "
+                    + "beside the notch. No permissions involved; the change takes effect the next "
                     + "time you log in."
             ) {
                 VStack(alignment: .leading, spacing: 6) {

--- a/Sources/Pelmet/MenuBarManager.swift
+++ b/Sources/Pelmet/MenuBarManager.swift
@@ -54,6 +54,10 @@ final class MenuBarManager: NSObject {
     private var toggleRescueAttempts = 0
     private var lastToggleRescue = Date.distantPast
 
+    /// One-shot fallback so first-run onboarding isn't hostage to a confirmed
+    /// layout that a busy bar may never produce.
+    private var firstRunWelcomeTimer: Timer?
+
     /// The Shelf's seam to the opt-in activation machinery. Always present;
     /// degrades honestly when the Accessibility grant is absent.
     var shelfEngine: StatusItemActivating { StatusItemActivationEngine.shared }
@@ -133,6 +137,21 @@ final class MenuBarManager: NSObject {
         }
 
         NotchLayoutMonitor.shared.requestMeasurement(reason: .launch)
+        armFirstRunWelcomeFallback()
+    }
+
+    /// If the layout never settles into a confirmed classification, `apply()`
+    /// never fires and onboarding would never run. After a short delay, drive
+    /// the checks directly — `maybeShowLaunchTips`/`maybeOfferOneClick` are
+    /// layout-independent and the `didShowToggleTip`/`didOfferOneClick` gates
+    /// keep this idempotent with the confirmed path.
+    private func armFirstRunWelcomeFallback() {
+        guard !Preferences.didShowToggleTip else { return }
+        firstRunWelcomeTimer = Timer.scheduledTimer(
+            withTimeInterval: 4, repeats: false
+        ) { [weak self] _ in
+            self?.reapplyOnboardingChecks()
+        }
     }
 
     /// macOS stores each status item's position in UserDefaults under
@@ -178,7 +197,7 @@ final class MenuBarManager: NSObject {
         guard let button = item.button else { return }
         button.image = separatorImage()
         button.appearsDisabled = true
-        button.toolTip = "Pelmet hides everything left of this divider — ⌘-drag icons you always want visible to its right."
+        button.toolTip = "Pelmet hides everything left of this divider. ⌘-drag icons you always want visible to its right."
         button.setAccessibilityLabel("Pelmet divider")
     }
 
@@ -264,20 +283,28 @@ final class MenuBarManager: NSObject {
     /// Called on every confirmed snapshot and again when a tip closes (the
     /// tips chain: divider → toggle → count education).
     func reapplyOnboardingChecks() {
-        guard let classification = latestClassification, !isCollapsed else { return }
+        guard !isCollapsed else { return }
+        // The welcome and the one-click offer are layout-independent, so they
+        // still run before any classification confirms (a busy just-logged-in
+        // bar may never settle). Swallowed-education needs a real count.
+        let classification = latestClassification
         OnboardingController.shared.maybeShowLaunchTips(
             separator: separatorItem,
             toggle: toggleItem,
-            separatorVisible: classification.separatorHealth == .visible
+            separatorVisible: classification?.separatorHealth == .visible,
+            toggleVisible: classification?.toggleVisible ?? true
         )
-        OnboardingController.shared.maybeShowSwallowedEducation(
-            count: classification.swallowedCount,
-            toggle: toggleItem
-        )
-        OnboardingController.shared.maybeShowShelfTip(
-            count: classification.swallowedCount,
-            toggle: toggleItem
-        )
+        if let classification {
+            OnboardingController.shared.maybeShowSwallowedEducation(
+                count: classification.swallowedCount,
+                toggle: toggleItem
+            )
+            OnboardingController.shared.maybeShowShelfTip(
+                count: classification.swallowedCount,
+                toggle: toggleItem
+            )
+        }
+        OnboardingController.shared.maybeOfferOneClick(toggle: toggleItem)
     }
 
     /// The toggle is the escape hatch — if it ever gets swallowed the user
@@ -396,11 +423,11 @@ final class MenuBarManager: NSObject {
         let tooltip: String
         let accessibilityValue: String
         if isCollapsed {
-            tooltip = "Pelmet — show hidden icons (⌥⌘B)"
+            tooltip = "Pelmet: show hidden icons (⌥⌘B)"
             accessibilityValue = "Icons hidden"
         } else if separatorSwallowed {
-            tooltip = "The menu bar is full — Pelmet's divider is hidden by the notch. Right-click for options."
-            accessibilityValue = "Icons shown. The divider is hidden — the menu bar is full."
+            tooltip = "The menu bar is full. Pelmet's divider is hidden by the notch. Right-click for options."
+            accessibilityValue = "Icons shown. The divider is hidden; the menu bar is full."
         } else if swallowedCount > 0 {
             // "Click to see them" only when a click actually opens the Shelf
             // — i.e. the badge is visible (showCount) and the Shelf is on.
@@ -412,7 +439,7 @@ final class MenuBarManager: NSObject {
                 accessibilityValue = "Icons shown. \(countPhrase(swallowedCount)) by the notch."
             }
         } else {
-            tooltip = "Pelmet — hide icons (⌥⌘B)"
+            tooltip = "Pelmet: hide icons (⌥⌘B)"
             accessibilityValue = "Icons shown"
         }
         button.toolTip = tooltip
@@ -437,14 +464,14 @@ final class MenuBarManager: NSObject {
         // (disabled informational rows, the Wi-Fi-menu pattern).
         var statusLines: [String] = []
         if separatorSwallowed {
-            statusLines.append("Pelmet's divider is hidden — the menu bar is full")
+            statusLines.append("Pelmet's divider is hidden; the menu bar is full")
         }
         if swallowedCount > 0 {
             let fitPhrase = swallowedCount == 1 ? "1 icon doesn't fit" : "\(swallowedCount) icons don't fit"
             statusLines.append(
                 isCollapsed
                     ? "\(fitPhrase) even while collapsed"
-                    : "\(fitPhrase) — hidden by the notch"
+                    : "\(fitPhrase), hidden by the notch"
             )
         }
         if !statusLines.isEmpty {
@@ -504,6 +531,19 @@ final class MenuBarManager: NSObject {
         resetEntry.target = self
         menu.addItem(resetEntry)
 
+        // A permanent path to enable one-click open — survives a dismissed or
+        // never-seen onboarding popover. Only where it's relevant (notched Mac,
+        // not yet granted).
+        if LayoutStatus.shared.hasNotchedDisplay, shelfEngine.availability != .granted {
+            let oneClickEntry = NSMenuItem(
+                title: "Open Hidden Icons with One Click…",
+                action: #selector(enableOneClickFromMenu),
+                keyEquivalent: ""
+            )
+            oneClickEntry.target = self
+            menu.addItem(oneClickEntry)
+        }
+
         let settingsEntry = NSMenuItem(title: "Settings…", action: #selector(openSettings), keyEquivalent: ",")
         settingsEntry.target = self
         menu.addItem(settingsEntry)
@@ -523,6 +563,10 @@ final class MenuBarManager: NSObject {
     }
 
     @objc private func menuToggle() { toggle() }
+
+    @objc private func enableOneClickFromMenu() {
+        shelfEngine.offerOneClick(proactive: false)
+    }
 
     /// Escape hatch for a divider ⌘-dragged somewhere invisible (under the
     /// notch, or off among icons the user can't find): recreate it in the

--- a/Sources/Pelmet/MenuBarSpacing.swift
+++ b/Sources/Pelmet/MenuBarSpacing.swift
@@ -28,8 +28,8 @@ enum MenuBarSpacing {
         var label: String {
             switch self {
             case .systemDefault: return "System default"
-            case .reduced: return "Reduced — subtle change"
-            case .compact: return "Compact — fits the most icons"
+            case .reduced: return "Reduced (subtle change)"
+            case .compact: return "Compact (fits the most icons)"
             }
         }
     }

--- a/Sources/Pelmet/Onboarding/OnboardingController.swift
+++ b/Sources/Pelmet/Onboarding/OnboardingController.swift
@@ -13,34 +13,43 @@ final class OnboardingController: NSObject, NSPopoverDelegate {
 
     // MARK: - Entry points (called on confirmed layout snapshots)
 
-    /// First-launch teaching, gated on the divider actually being visible —
-    /// a divider born behind the notch gets its tip when it first appears.
-    func maybeShowLaunchTips(separator: NSStatusItem, toggle: NSStatusItem, separatorVisible: Bool) {
+    /// First-launch teaching. The welcome anchors on the TOGGLE — always
+    /// present and auto-rescued — so a divider born behind the notch can no
+    /// longer stall onboarding. The divider spotlight is a second, opportunistic
+    /// tip that waits for the ╱ to actually surface and blocks nothing.
+    func maybeShowLaunchTips(
+        separator: NSStatusItem, toggle: NSStatusItem,
+        separatorVisible: Bool, toggleVisible: Bool
+    ) {
         guard activePopover == nil else { return }
 
-        if !Preferences.didShowDividerTip {
-            guard separatorVisible, let button = separator.button else { return }
-            Preferences.didShowDividerTip = true
+        // 1. Welcome (on the toggle): teaches the ╱ concept AND click-to-hide.
+        if !Preferences.didShowToggleTip {
+            guard toggleVisible, let button = toggle.button else { return }
+            Preferences.didShowToggleTip = true
+            let delay = Int(Preferences.rehideDelay)
             show(
-                title: "Meet your divider",
-                message: "When you collapse, Pelmet hides everything to the left of this ╱ divider. "
-                    + "Hold ⌘ and drag the icons you always want visible to its right, next to the clock.",
+                title: "Welcome to Pelmet",
+                message: "This ‹/› chevron hides everything to the left of the ╱ divider. "
+                    + "Click it (or press ⌥⌘B) to clear the clutter, click again to bring it back. "
+                    + "⌘-drag the icons you always want visible to the divider's right, next to the "
+                    + "clock. Revealed icons re-hide after \(delay) seconds; change that in Settings.",
                 buttonTitle: "Got It",
                 on: button
             )
             return
         }
 
-        if !Preferences.didShowToggleTip {
-            guard let button = toggle.button else { return }
-            Preferences.didShowToggleTip = true
-            let delay = Int(Preferences.rehideDelay)
+        // 2. Divider spotlight (on the separator): opportunistic — only once the
+        //    ╱ is genuinely visible; otherwise retried on a later snapshot.
+        if !Preferences.didShowDividerTip {
+            guard separatorVisible, let button = separator.button else { return }
+            Preferences.didShowDividerTip = true
             show(
-                title: "Hide the clutter",
-                message: "Click this chevron (or press ⌥⌘B) to hide everything left of ╱ — "
-                    + "click again to bring it back. Revealed icons re-hide after \(delay) seconds; "
-                    + "change that in Settings.",
-                buttonTitle: "Done",
+                title: "This is your divider",
+                message: "Pelmet hides everything to the left of this ╱. ⌘-drag icons to its "
+                    + "right to keep them next to the clock, always visible.",
+                buttonTitle: "Got It",
                 on: button
             )
         }
@@ -52,7 +61,7 @@ final class OnboardingController: NSObject, NSPopoverDelegate {
     func maybeShowSwallowedEducation(count: Int, toggle: NSStatusItem) {
         guard activePopover == nil,
               !Preferences.didShowSwallowedEducation,
-              Preferences.didShowDividerTip, Preferences.didShowToggleTip,
+              Preferences.didShowToggleTip,
               count > 0,
               let button = toggle.button else { return }
         Preferences.didShowSwallowedEducation = true
@@ -60,7 +69,7 @@ final class OnboardingController: NSObject, NSPopoverDelegate {
         let phrase = count == 1 ? "1 icon doesn't fit" : "\(count) icons don't fit"
         show(
             title: phrase,
-            message: "The notch hides menu bar icons that run out of room — macOS gives no warning. "
+            message: "The notch hides menu bar icons that run out of room, and macOS gives no warning. "
                 + "Pelmet shows a count beside its chevron whenever that happens. "
                 + "Click the chevron to open the Shelf and see exactly what's hidden; "
                 + "right-click for ways to make room.",
@@ -81,11 +90,46 @@ final class OnboardingController: NSObject, NSPopoverDelegate {
         Preferences.didShowShelfTip = true
         show(
             title: "See what's hidden",
-            message: "New: when the chevron shows +\(count), click it to open the Shelf — "
+            message: "New: when the chevron shows +\(count), click it to open the Shelf, "
                 + "a panel listing the icons the notch hid. ⌥⌘N works too.",
             buttonTitle: "Got It",
             on: button
         )
+    }
+
+    /// Offers the opt-in "one-click access" feature once, on notched Macs where
+    /// it matters. On the genuine first run it PROACTIVELY fires the system
+    /// Accessibility prompt (context popover first, OS dialog a beat later); on
+    /// a replay it only shows the pitch and waits for the button. Either way the
+    /// engine stays off until the grant lands (see `offerOneClick`).
+    func maybeOfferOneClick(toggle: NSStatusItem) {
+        guard activePopover == nil,
+              !Preferences.didOfferOneClick,
+              LayoutStatus.shared.hasNotchedDisplay,
+              !Preferences.activationEngineEnabled,
+              StatusItemActivationEngine.shared.availability != .granted,
+              let button = toggle.button else { return }
+        Preferences.didOfferOneClick = true
+
+        let autoPrompt = !Preferences.didAutoPromptAccessibility
+        if autoPrompt { Preferences.didAutoPromptAccessibility = true }
+
+        show(
+            title: "Open hidden icons with one click",
+            message: "Turn on One-Click Access and Pelmet can open the icons the notch hides "
+                + "with a single click. It reads which app owns each icon and simulates a click. "
+                + "It never reads your screen, and you can turn it off any time in Settings.",
+            buttonTitle: autoPrompt ? "Got It" : "Enable One-Click Access…",
+            on: button,
+            action: autoPrompt ? nil : { StatusItemActivationEngine.shared.offerOneClick(proactive: false) }
+        )
+
+        if autoPrompt {
+            // Context first, system dialog second — never a bare OS modal.
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.6) {
+                StatusItemActivationEngine.shared.offerOneClick(proactive: true)
+            }
+        }
     }
 
     /// Settings → "Show Welcome Tips Again".
@@ -96,13 +140,17 @@ final class OnboardingController: NSObject, NSPopoverDelegate {
 
     // MARK: - Popover plumbing
 
-    private func show(title: String, message: String, buttonTitle: String, on button: NSStatusBarButton) {
+    private func show(
+        title: String, message: String, buttonTitle: String,
+        on button: NSStatusBarButton, action: (() -> Void)? = nil
+    ) {
         let popover = NSPopover()
         popover.behavior = .semitransient
         popover.animates = !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
         popover.delegate = self
         popover.contentViewController = NSHostingController(
             rootView: TipView(title: title, message: message, buttonTitle: buttonTitle) { [weak popover] in
+                action?()
                 popover?.performClose(nil)
             }
         )

--- a/Sources/Pelmet/Preferences.swift
+++ b/Sources/Pelmet/Preferences.swift
@@ -18,6 +18,9 @@ enum Preferences {
         static let didShowShelfTip = "didShowShelfTip"
         static let activationEngineEnabled = "activationEngineEnabled"
         static let didPromptForAccessibility = "didPromptForAccessibility"
+        static let didOfferOneClick = "didOfferOneClick"
+        static let didAutoPromptAccessibility = "didAutoPromptAccessibility"
+        static let awaitingOneClickGrant = "awaitingOneClickGrant"
     }
 
     /// Last collapse state, restored at launch. Defaults to expanded so a
@@ -66,6 +69,29 @@ enum Preferences {
         set { UserDefaults.standard.set(newValue, forKey: Keys.didPromptForAccessibility) }
     }
 
+    /// One-shot gate for the first-run "one-click access" pitch popover. Reset
+    /// by `resetOnboardingFlags()` so "Show Welcome Tips Again" re-offers it.
+    static var didOfferOneClick: Bool {
+        get { UserDefaults.standard.bool(forKey: Keys.didOfferOneClick) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.didOfferOneClick) }
+    }
+
+    /// Ensures the system Accessibility prompt is auto-fired at most once ever
+    /// (first run only). Never reset — a replay re-offers the pitch but must
+    /// not auto-fire the OS dialog again.
+    static var didAutoPromptAccessibility: Bool {
+        get { UserDefaults.standard.bool(forKey: Keys.didAutoPromptAccessibility) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.didAutoPromptAccessibility) }
+    }
+
+    /// Armed when we ask for Accessibility on the user's behalf; when the grant
+    /// lands the engine turns itself on. Persisted so a grant made after the
+    /// poll window (or on a later launch) still enables one-click.
+    static var awaitingOneClickGrant: Bool {
+        get { UserDefaults.standard.bool(forKey: Keys.awaitingOneClickGrant) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.awaitingOneClickGrant) }
+    }
+
     // MARK: - One-time onboarding flags
 
     static var didShowDividerTip: Bool {
@@ -100,5 +126,9 @@ enum Preferences {
         didShowToggleTip = false
         didShowSwallowedEducation = false
         didShowShelfTip = false
+        didOfferOneClick = false
+        // NOTE: didAutoPromptAccessibility, awaitingOneClickGrant,
+        // didPromptForAccessibility and activationEngineEnabled are system /
+        // opt-in facts, not onboarding — never reset here.
     }
 }

--- a/Sources/Pelmet/Settings/SettingsView.swift
+++ b/Sources/Pelmet/Settings/SettingsView.swift
@@ -52,7 +52,7 @@ struct SettingsView: View {
                     VStack(alignment: .leading, spacing: 4) {
                         Toggle("Open the Shelf when clicking the count", isOn: $shelfEnabled)
                         Text("The Shelf is a panel under the notch listing the icons macOS hid. "
-                            + "Turned off, a click always hides/shows icons instead — the Shelf stays "
+                            + "Turned off, a click always hides/shows icons instead; the Shelf stays "
                             + "one right-click (or ⌥⌘N) away.")
                             .font(.caption)
                             .foregroundStyle(.secondary)
@@ -112,7 +112,7 @@ struct SettingsView: View {
             } else {
                 Section("Menu Bar Space") {
                     Label {
-                        Text("This Mac has no camera notch — icons rarely run out of room.")
+                        Text("This Mac has no camera notch, so icons rarely run out of room.")
                     } icon: {
                         Image(systemName: "info.circle")
                     }
@@ -152,8 +152,7 @@ struct SettingsView: View {
     }
 
     private func openAccessibilitySettings() {
-        let url = URL(string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility")!
-        NSWorkspace.shared.open(url)
+        AXPermissionMonitor.openSystemSettings()
     }
 
     private func updateLaunchAtLogin(_ enabled: Bool) {

--- a/Sources/Pelmet/Shelf/ShelfView.swift
+++ b/Sources/Pelmet/Shelf/ShelfView.swift
@@ -53,7 +53,7 @@ struct ShelfView: View {
                 .strokeBorder(Color.primary.opacity(0.12), lineWidth: 0.5)
         )
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("Pelmet Shelf — icons hidden by the notch")
+        .accessibilityLabel("Pelmet Shelf: icons hidden by the notch")
     }
 
     // MARK: - Sections
@@ -70,7 +70,7 @@ struct ShelfView: View {
         case .owners, .engine:
             return "Hidden by the notch"
         case .anonymous:
-            return "Hidden by the notch — macOS 26 hides which apps these belong to"
+            return "Hidden by the notch. macOS 26 hides which apps these belong to"
         }
     }
 
@@ -79,7 +79,7 @@ struct ShelfView: View {
             Image(systemName: "checkmark.circle")
                 .font(.title2)
                 .foregroundStyle(.secondary)
-            Text("Everything fits — nothing is hidden by the notch.")
+            Text("Everything fits. Nothing is hidden by the notch.")
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)
@@ -169,10 +169,15 @@ struct ShelfView: View {
                 .foregroundStyle(.secondary)
                 .fixedSize(horizontal: false, vertical: true)
             if model.canOfferEngineOptIn {
-                Button("Enable one-click access…") {
-                    model.requestEngineOptIn()
+                Button(model.optInIsBlocked ? "Open System Settings…" : "Enable one-click access…") {
+                    model.offerOptIn()
                 }
                 .font(.caption)
+                if model.optInIsBlocked {
+                    Text("Pelmet is waiting for the Accessibility permission.")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
             }
         }
         .padding(10)
@@ -186,7 +191,7 @@ struct ShelfView: View {
     private func explanationText(for row: ShelfRow) -> String {
         switch row.model.kind {
         case .app(_, let name, _):
-            return "macOS won't let Pelmet open \(name)'s menu without the Accessibility permission — one-click access is opt-in and never reads your screen."
+            return "macOS won't let Pelmet open \(name)'s menu without the Accessibility permission. One-click access is opt-in and never reads your screen."
         default:
             return "Enable one-click access to identify these items and open them with a single click. It uses the Accessibility permission and never reads your screen."
         }
@@ -214,8 +219,8 @@ struct ShelfView: View {
             .font(.caption)
             Spacer()
             if model.canOfferEngineOptIn, !model.rows.isEmpty {
-                Button("Enable one-click access…") {
-                    model.requestEngineOptIn()
+                Button(model.optInIsBlocked ? "Open System Settings…" : "Enable one-click access…") {
+                    model.offerOptIn()
                 }
                 .font(.caption)
             }

--- a/Sources/Pelmet/Shelf/ShelfViewModel.swift
+++ b/Sources/Pelmet/Shelf/ShelfViewModel.swift
@@ -48,6 +48,14 @@ final class ShelfViewModel: ObservableObject {
         tier != .engine && engineAvailability != .granted
     }
 
+    /// We asked for Accessibility before but still aren't granted: the OS won't
+    /// re-show its modal, so the button must deep-link to System Settings
+    /// instead of silently no-op'ing. (`engineAvailability` reads
+    /// `.notDetermined` while the engine is off, so lean on the prompt flag.)
+    var optInIsBlocked: Bool {
+        engineAvailability != .granted && Preferences.didPromptForAccessibility
+    }
+
     func update(entries: [ShelfEntryModel]) {
         rows = entries.map { entry in
             ShelfRow(model: entry, icon: icon(for: entry))
@@ -113,9 +121,10 @@ final class ShelfViewModel: ObservableObject {
         }
     }
 
-    func requestEngineOptIn() {
-        engine.setEnabled(true)
-        engine.requestAccess()
+    func offerOptIn() {
+        // Explicit tap → enable now; routes to the OS prompt, or to System
+        // Settings when the modal won't reappear (see `offerOneClick`).
+        engine.offerOneClick(proactive: false)
     }
 
     static func failureMessage(_ failure: ActivationFailure) -> String {
@@ -123,13 +132,13 @@ final class ShelfViewModel: ObservableObject {
         case .permissionDenied:
             return "Pelmet needs the Accessibility permission to open items."
         case .itemVanished:
-            return "That icon just disappeared — it may have been closed."
+            return "That icon just disappeared. It may have been closed."
         case .blockedByNotch, .noRoomToExpose:
-            return "Couldn't open it — the bar is too full. Try Make Room."
+            return "Couldn't open it. The bar is too full. Try Make Room."
         case .busy, .userInteracting:
-            return "Busy — try again in a moment."
+            return "Busy. Try again in a moment."
         case .interrupted, .timedOut:
-            return "Couldn't open it — try again."
+            return "Couldn't open it. Try again."
         }
     }
 


### PR DESCRIPTION
## What & why

Fresh installs never prompted for Accessibility, so one-click "open hidden icons" stayed dark, and onboarding tips could stall whenever the notch swallowed the divider. This proactively offers one-click access on first run and auto-fires the system prompt (the engine stays off until the grant lands, then enables itself), anchors the welcome tip on the always-visible toggle with a launch fallback, adds a permanent right-click menu entry, and fixes the silent Shelf opt-in dead-button in the denied state by deep-linking to System Settings. It also removes em-dashes from all user-facing text and trims the macOS CI (skip doc-only runs, cache SwiftPM, drop the redundant swift build, faster brew, job timeouts).

## How I tested it

`swift build` and `swift test` (96 tests) pass, and the Xcode release path (`xcodegen generate` plus an unsigned `xcodebuild`) builds clean; the first-run prompt, grant-enables-engine, and denied deep-link paths were traced by hand.
