### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-07-13
+
 ### Added
 
 - **Sparkle auto-updates** — Pelmet now checks for new versions in-app via
@@ -61,5 +63,6 @@ First public release — the working MVP.
 - Requires **macOS 13 Ventura** or later.
 - The core hide/show experience needs **zero special permissions**.
 
-[Unreleased]: https://github.com/ismatBabirli/pelmet/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/ismatBabirli/pelmet/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/ismatBabirli/pelmet/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/ismatBabirli/pelmet/releases/tag/v0.1.0


### PR DESCRIPTION
Promote `Unreleased` → `0.2.0` in CHANGELOG (Sparkle auto-updates, Settings sidebar, onboarding fixes).

Merging this, then pushing the `v0.2.0` tag, triggers the Release workflow (build → sign → notarize → GitHub Release → Sparkle appcast → Homebrew cask). First release delivered via Sparkle.