### PR TITLE
Fix deprecated depends_on macos string form in cask

### DIFF
--- a/packaging/homebrew/pelmet.rb
+++ b/packaging/homebrew/pelmet.rb
@@ -21,7 +21,7 @@ cask "pelmet" do
     strategy :github_latest
   end
 
-  depends_on macos: ">= :ventura"
+  depends_on macos: :ventura
 
   app "Pelmet.app"
 


### PR DESCRIPTION
Homebrew deprecated the string comparison form. `depends_on macos: ">= :ventura"` → `depends_on macos: :ventura` (same meaning: Ventura+). Tap copy already patched directly; this keeps the canonical source and future re-seeds correct.