### PR TITLE
Add a lean CLAUDE.md and refresh the docs it points to

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+<!-- Keep this file lean: pointers, not prose. The backticked doc paths below are
+     deliberately NOT `@path` imports — imports load eagerly at launch and defeat
+     the read-on-demand design. Read the referenced doc when the task touches its area. -->
+
+# Pelmet
+
+Open-source macOS menu-bar manager (menu-bar-only app, macOS 13+). AppKit app plus
+SwiftUI settings windows. Sandbox is intentionally OFF, hardened runtime ON, and
+`Sources/Pelmet/Pelmet.entitlements` is intentionally an empty dict.
+
+## Commands
+
+- Dev loop: `swift run` (SPM — fast, but not a real .app bundle). Tests: `swift test`.
+- Real .app bundle (required for Sparkle, launch-at-login, and Accessibility/TCC
+  testing): `xcodegen generate`, then
+  `xcodebuild build -project Pelmet.xcodeproj -scheme Pelmet -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`
+- Format before PRs: `swiftformat .` (conservative allowlist in `.swiftformat`; not CI-enforced).
+- Release = push a `vX.Y.Z` tag — read `docs/RELEASING.md` first (runbook, secrets, dry-run).
+
+## Architecture in 30 seconds
+
+- `Sources/PelmetCore` — pure, unit-testable geometry/classification, no UI imports.
+  Put genuinely testable logic here.
+- `Sources/Pelmet` — the AppKit app: singleton managers (`MenuBarManager.shared`, …),
+  SwiftUI settings panes, entry point `main.swift`.
+- Full code map: `CONTRIBUTING.md` § "Map of the code". Collapse mechanism and
+  hotkeys (⌥⌘B / ⌥⌘N): `README.md` § "How it works" and § "Usage".
+
+## Testing
+
+- Swift Testing (`@Test` / `#expect`), NOT XCTest. Unit tests cover `PelmetCore` only
+  (`Tests/PelmetCoreTests`); the AppKit layer is manual-QA only — don't scaffold UI tests.
+- On Command Line Tools-only machines `swift test` needs extra framework flags:
+  `CONTRIBUTING.md` § "Testing".
+- Manual QA matrix and debug env vars (`PELMET_DEBUG_ACTIVATION`, `PELMET_DEBUG_LAYOUT`,
+  `PELMET_DISABLE_ACTIVATION`): `docs/shelf-verification.md`.
+
+## Gotchas — deliberate, do not "fix"
+
+- Swift 6 toolchain but Swift 5 **language mode** (`swiftLanguageModes: [.v5]` in
+  `Package.swift`). Never migrate to the v6 language mode.
+- `Pelmet.xcodeproj` and `Sources/Pelmet/Info.plist` are generated from `project.yml`
+  and gitignored — never hand-edit them. Version numbers come from the git tag at
+  release time — never hand-bump them.
+- macOS TCC keys Accessibility grants to the code signature: test the opt-in
+  Activation features from a bundled .app, never via `swift run`.
+- Sparkle exists only in the XcodeGen build, behind `#if canImport(Sparkle)` — the
+  plain SPM build must keep working without it.
+
+## Product invariants (hard rules)
+
+- The zero-permission core is sacred: the default experience must never require
+  Screen Recording or Accessibility; permissioned features are strictly opt-in.
+- No analytics, no accounts, no network calls — Sparkle update checks are the sole
+  exception. No new dependencies (Sparkle is the only one).
+- Rationale and full list: `PROJECT.md` § "5. Non-Goals" and § "6. Technical Foundation".
+
+## Etiquette
+
+- User-visible changes get a `CHANGELOG.md` entry under `[Unreleased]` (Keep a Changelog).
+- PRs follow `.github/PULL_REQUEST_TEMPLATE.md`; run the manual smoke test in
+  `CONTRIBUTING.md` § "Testing" first.
+- CI (`.github/workflows/ci.yml`) runs `swift test` plus the xcodegen/xcodebuild
+  bundle build; both must stay green.
+- No AI attribution in commits or PRs — no `Co-Authored-By` trailers, no
+  "Generated with" footers.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,8 +22,8 @@ swift run
 ```
 
 That's the whole fast loop — the toggle and divider appear in your menu bar
-immediately. The only thing `swift run` can't do is launch-at-login (it needs
-a real .app bundle). To test that:
+immediately. The only things `swift run` can't do are launch-at-login and
+Sparkle auto-updates (both need a real .app bundle). To test those:
 
 ```bash
 brew install xcodegen
@@ -55,14 +55,21 @@ geometry lives in `Sources/PelmetCore/`.
 | `Settings/SettingsPane.swift` | Pane descriptors: titles, icons, notch-gated availability |
 | `Settings/*PaneView.swift` | The panes: General, Menu Bar Space, One-Click Access |
 | `Settings/SettingsWindowController.swift` | Hosts the settings window from an accessory app |
+| `Shelf/` | The blurred "+N hidden icons" panel: panel, controller, SwiftUI rows, owner resolution |
+| `Activation/` | Opt-in Accessibility engine: one-click activation of real status items (AX reader, synthetic events, permission monitor) |
+| `Updates/UpdaterController.swift` | Sparkle facade — real under `#if canImport(Sparkle)` (XcodeGen build), inert stub in plain SPM |
 | `../PelmetCore/MenuBarLayoutClassifier.swift` | Pure geometry: which icons is macOS hiding at the notch |
+| `../PelmetCore/ShelfContent.swift`, `ShelfPlacement.swift`, `TipPlacement.swift`, `ScreenCoordinates.swift` | Pure Shelf/tip content derivation and placement geometry |
+| `../PelmetCore/Activation/` | Pure activation planning: `ActivationPlanner`, `ActivationSession`, `StatusItemCorrelator`, `QuiescencePolicy` |
 
 Two ground rules:
 
 1. **The zero-permission core is sacred.** The default experience must never
    require Screen Recording or Accessibility. Features that need a permission
-   (like the planned notch panel) are opt-in only.
-2. **No dependencies so far.** Think twice before adding one.
+   (like one-click access) are opt-in only.
+2. **Sparkle is the only dependency** — and only in the XcodeGen app bundle,
+   behind `#if canImport(Sparkle)`; the plain SPM build stays dependency-free.
+   Think twice before adding another.
 
 ## Code style
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -37,8 +37,8 @@ Pelmet occupies a deliberate position in that landscape:
 ```
 
 - **The divider (╱):** everything the user ⌘-drags to its left is managed by Pelmet.
-- **Collapse mechanism:** the divider inflates to ~10,000 pt, pushing managed items past the screen edge. Battle-tested (Hidden Bar, Dozer), permission-free.
-- **The Shelf (phase 2):** a floating, blurred panel below the notch that shows hidden icons live and forwards clicks — so items are usable *without* rearranging the menu bar.
+- **Collapse mechanism:** the divider inflates to ~4,000 pt (macOS caps status-item windows near 5,000 pt), pushing managed items past the screen edge. Battle-tested (Hidden Bar, Dozer), permission-free.
+- **The Shelf (phase 2, shipped in 0.1.0):** a floating, blurred panel below the notch that shows hidden icons live and forwards clicks — so items are usable *without* rearranging the menu bar.
 
 ## 4. Feature Plan by Phase
 
@@ -52,19 +52,19 @@ Pelmet occupies a deliberate position in that landscape:
 - Runs via `swift run`, XcodeGen, or manual Xcode project
 - Zero permissions required
 
-### 🔨 Phase 1 — Polish & Distribution
+### 🔨 Phase 1 — Polish & Distribution (partially shipped)
 
 *Goal: something people can install and love in under a minute.*
 
 - **Fluid animations** for expand/collapse (the "Vanilla moment" — icons glide, not blink)
 - **Show on hover / scroll:** reveal hidden items when the pointer touches the menu bar or the user scrolls on it
 - **Custom hotkey recorder** (replace hardcoded ⌥⌘B)
-- **Onboarding:** first-launch walkthrough teaching the ⌘-drag gesture
-- **App icon & identity:** pelmet/curtain metaphor, warm and crafted
-- **Distribution pipeline:** GitHub Actions → build, codesign, notarize → GitHub Releases + Homebrew cask (`brew install --cask pelmet`) + Sparkle auto-updates
+- ✅ **Onboarding:** first-launch walkthrough teaching the ⌘-drag gesture (shipped in 0.1.0)
+- ✅ **App icon & identity:** pelmet/curtain metaphor, warm and crafted (shipped in 0.1.0)
+- ✅ **Distribution pipeline:** GitHub Actions → build, codesign, notarize → GitHub Releases + Homebrew cask (`brew install --cask pelmet`) — shipped in 0.1.0; Sparkle auto-updates shipped in 0.2.0
 - Multi-display awareness and menu bar changes across Spaces
 
-### 🌟 Phase 2 — The Shelf (flagship feature)
+### ✅ Phase 2 — The Shelf (flagship feature, shipped in 0.1.0)
 
 *Goal: the beautiful, actionable answer to the notch.*
 

--- a/README.md
+++ b/README.md
@@ -18,8 +18,9 @@ This one hides your menu bar clutter, so nothing disappears behind the MacBook n
 </div>
 
 > [!NOTE]
-> **Status: working MVP.** Hide/show works today with zero special permissions.
-> The notch-aware floating panel is on the [roadmap](#roadmap).
+> **Status: shipping.** Hide/show works with zero special permissions, and the
+> notch-aware Shelf panel and opt-in one-click access have shipped. Show-on-hover
+> and profiles are next on the [roadmap](#roadmap).
 
 ## Why
 


### PR DESCRIPTION
## What & why

Adds a root `CLAUDE.md` so coding agents get the project's non-inferable facts up front — following the official guidance to keep it short and pointer-style. Exact commands and deliberate traps (Swift 5 language mode on a Swift 6 toolchain, generated `Info.plist`/`.xcodeproj`, TCC-keyed Accessibility testing, SPM-vs-XcodeGen split) live inline; everything else is a plain backticked reference to the doc that owns it, read on demand — deliberately not `@imports`, which load eagerly at session start.

Since CLAUDE.md points at existing docs, this also refreshes the stale spots those pointers land on:

- **CONTRIBUTING.md** — the code map gains the shipped `Shelf/`, `Activation/`, and `Updates/` subsystems plus the newer PelmetCore files; the ground rules and the `swift run` note now acknowledge Sparkle (XcodeGen build only)
- **PROJECT.md** — divider inflation corrected to ~4,000 pt to match `MenuBarManager.swift` (was ~10,000 pt); phase statuses updated for what 0.1.0/0.2.0 actually shipped
- **README.md** — the status note no longer claims the Shelf is still on the roadmap

## How I tested it

Docs-only change (CI skips `**/*.md` by design). Verified every path and section heading referenced from CLAUDE.md resolves against the current tree, the file stays at 66 lines, it contains no eager `@path` imports, and the corrected divider figure matches the constant in `MenuBarManager.swift:35`.