### PR TITLE
Add an About settings pane showing the app version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **About settings pane**: a new About pane shows Pelmet's version and build,
+  a button to copy the version for bug reports, and links to the GitHub repo,
+  release notes, and issue tracker, alongside the MIT license. The chevron's
+  right-click menu also shows the current version. A plain `swift run` dev
+  build (which has no bundle) reads "Development build".
+
 ## [0.2.0] - 2026-07-13
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,3 +64,6 @@ SwiftUI settings windows. Sandbox is intentionally OFF, hardened runtime ON, and
   bundle build; both must stay green.
 - No AI attribution in commits or PRs — no `Co-Authored-By` trailers, no
   "Generated with" footers.
+- Don't write em-dashes (`—`) in prose you add: code comments, docs,
+  `CHANGELOG.md`, commit messages, and PRs. Use a colon, comma, parentheses, or
+  a period instead. (Existing em-dashes stay; only what you add follows this.)

--- a/Sources/Pelmet/AppVersionInfo.swift
+++ b/Sources/Pelmet/AppVersionInfo.swift
@@ -1,0 +1,35 @@
+import AppKit
+import PelmetCore
+
+/// Reads `Bundle.main`'s version/copyright keys and hands them to the pure
+/// `AppVersion` formatter. Every key is nil under `swift run` (the SPM
+/// executable has no Info.plist), so `AppVersion` collapses to its
+/// "Development build" state. No `#if` needed here, the reads just return nil.
+enum AppVersionInfo {
+
+    /// The current version, formatted for display. Routed through here (never
+    /// raw `Bundle` keys) so the `swift run` fallback lives in one place.
+    static var current: AppVersion {
+        let info = Bundle.main.infoDictionary
+        return AppVersion(
+            shortVersion: info?["CFBundleShortVersionString"] as? String,
+            build: info?["CFBundleVersion"] as? String
+        )
+    }
+
+    /// `NSHumanReadableCopyright` ("MIT License" in the bundle), falling back to
+    /// the same literal under `swift run`: Pelmet is MIT-licensed in every build.
+    static var copyright: String {
+        let raw = (Bundle.main.infoDictionary?["NSHumanReadableCopyright"] as? String)?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return (raw?.isEmpty == false ? raw : nil) ?? "MIT License"
+    }
+}
+
+/// Open-source destinations for the About pane. The owner casing matches the
+/// compare links already in `CHANGELOG.md`; GitHub is case-insensitive on it.
+enum AppLinks {
+    static let repo = URL(string: "https://github.com/ismatBabirli/pelmet")!
+    static let releases = URL(string: "https://github.com/ismatBabirli/pelmet/releases")!
+    static let issues = URL(string: "https://github.com/ismatBabirli/pelmet/issues/new")!
+}

--- a/Sources/Pelmet/MenuBarManager.swift
+++ b/Sources/Pelmet/MenuBarManager.swift
@@ -568,6 +568,12 @@ final class MenuBarManager: NSObject {
         settingsEntry.target = self
         menu.addItem(settingsEntry)
 
+        // Current version, non-actionable. autoenablesItems is off, so a
+        // nil-action item must be explicitly disabled to render grayed.
+        let versionEntry = NSMenuItem(title: AppVersionInfo.current.labeled(), action: nil, keyEquivalent: "")
+        versionEntry.isEnabled = false
+        menu.addItem(versionEntry)
+
         menu.addItem(.separator())
 
         let quitEntry = NSMenuItem(title: "Quit Pelmet", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")

--- a/Sources/Pelmet/Settings/AboutPaneView.swift
+++ b/Sources/Pelmet/Settings/AboutPaneView.swift
@@ -1,0 +1,65 @@
+import SwiftUI
+
+/// About pane: the app's identity, its version (with a copy-for-bug-reports
+/// button), the open-source links, and the license. A menu-bar-only app has no
+/// app menu, so this pane is the stand-in for the "About Pelmet" item that
+/// would normally live there.
+struct AboutPaneView: View {
+
+    private let version = AppVersionInfo.current
+    @State private var didCopy = false
+
+    var body: some View {
+        Form {
+            Section {
+                VStack(spacing: 6) {
+                    // The real AppIcon in the bundled `.app`; the generic app
+                    // icon under `swift run` (no bundle icon); honest, never a
+                    // crash.
+                    Image(nsImage: NSApp.applicationIconImage)
+                        .resizable()
+                        .frame(width: 64, height: 64)
+                    Text("Pelmet")
+                        .font(.title3.bold())
+                    Text("Menu-bar manager for macOS")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, 4)
+            }
+
+            Section {
+                LabeledContent("Version") {
+                    HStack(spacing: 6) {
+                        Text(version.displayValue)
+                            .foregroundStyle(.secondary)
+                            .textSelection(.enabled)
+                        Button(action: copyVersion) {
+                            Image(systemName: didCopy ? "checkmark" : "doc.on.doc")
+                        }
+                        .buttonStyle(.borderless)
+                        .help("Copy version for bug reports")
+                    }
+                }
+            }
+
+            Section {
+                Link("View on GitHub", destination: AppLinks.repo)
+                Link("Release Notes", destination: AppLinks.releases)
+                Link("Report an Issue…", destination: AppLinks.issues)
+            } footer: {
+                Text("\(AppVersionInfo.copyright) · Open source")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .formStyle(.grouped)
+    }
+
+    private func copyVersion() {
+        NSPasteboard.general.clearContents()
+        NSPasteboard.general.setString(version.labeled(), forType: .string)
+        didCopy = true
+    }
+}

--- a/Sources/Pelmet/Settings/SettingsPane.swift
+++ b/Sources/Pelmet/Settings/SettingsPane.swift
@@ -6,6 +6,7 @@ enum SettingsPane: String, CaseIterable, Identifiable {
     case general
     case menuBarSpace
     case oneClickAccess
+    case about
 
     var id: String { rawValue }
 
@@ -20,7 +21,7 @@ enum SettingsPane: String, CaseIterable, Identifiable {
     /// context-menu entry in MenuBarManager: One-Click Access only exists
     /// where the notch makes it relevant.
     static func available(hasNotchedDisplay: Bool) -> [SettingsPane] {
-        hasNotchedDisplay ? allCases : [.general, .menuBarSpace]
+        hasNotchedDisplay ? allCases : [.general, .menuBarSpace, .about]
     }
 
     var title: String {
@@ -28,6 +29,7 @@ enum SettingsPane: String, CaseIterable, Identifiable {
         case .general: return "General"
         case .menuBarSpace: return "Menu Bar Space"
         case .oneClickAccess: return "One-Click Access"
+        case .about: return "About"
         }
     }
 
@@ -36,6 +38,7 @@ enum SettingsPane: String, CaseIterable, Identifiable {
         case .general: return "gearshape"
         case .menuBarSpace: return "menubar.rectangle"
         case .oneClickAccess: return "cursorarrow.click"
+        case .about: return "info.circle"
         }
     }
 
@@ -45,6 +48,7 @@ enum SettingsPane: String, CaseIterable, Identifiable {
         case .general: return .gray
         case .menuBarSpace: return .blue
         case .oneClickAccess: return .purple
+        case .about: return .teal
         }
     }
 }

--- a/Sources/Pelmet/Settings/SettingsRootView.swift
+++ b/Sources/Pelmet/Settings/SettingsRootView.swift
@@ -83,6 +83,7 @@ struct SettingsRootView: View {
         case .general: GeneralPaneView()
         case .menuBarSpace: MenuBarSpacePaneView()
         case .oneClickAccess: OneClickAccessPaneView()
+        case .about: AboutPaneView()
         }
     }
 }

--- a/Sources/PelmetCore/AppVersion.swift
+++ b/Sources/PelmetCore/AppVersion.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Formats the bundle's version numbers into user-facing strings, with an
+/// honest fallback when they're absent. `CFBundleShortVersionString` and
+/// `CFBundleVersion` are populated only in the xcodegen/xcodebuild `.app`;
+/// under `swift run` there is no Info.plist, so both read back nil, the same
+/// way the updater and launch-at-login degrade without a bundle. Kept here
+/// (pure, no AppKit) so the formatting is unit-testable; the bundle read lives
+/// in `AppVersionInfo` in the app target.
+public struct AppVersion: Equatable {
+
+    /// Shown in place of a version number when there's no marketing version:
+    /// the `swift run` case.
+    public static let developmentBuild = "Development build"
+
+    /// Marketing version (`CFBundleShortVersionString`), e.g. "0.2.0".
+    /// Normalized: nil when the raw value is missing or blank.
+    public let shortVersion: String?
+    /// Build number (`CFBundleVersion`), e.g. "123". Normalized like above.
+    public let build: String?
+
+    public init(shortVersion: String?, build: String?) {
+        self.shortVersion = AppVersion.normalized(shortVersion)
+        self.build = AppVersion.normalized(build)
+    }
+
+    /// True when there's no marketing version to show. A lone build number is
+    /// meaningless to a user, so it keys on `shortVersion` alone.
+    public var isDevelopmentBuild: Bool { shortVersion == nil }
+
+    /// The value text without the word "Version"; pairs with
+    /// `LabeledContent("Version", value:)`. "0.2.0 (123)" when both are
+    /// present, "0.2.0" with no build, `developmentBuild` otherwise.
+    public var displayValue: String {
+        guard let shortVersion else { return AppVersion.developmentBuild }
+        guard let build else { return shortVersion }
+        return "\(shortVersion) (\(build))"
+    }
+
+    /// A one-line, name-prefixed label for the menu bar and the
+    /// copy-for-bug-report button: "Pelmet 0.2.0 (123)", or
+    /// "Pelmet (Development build)" when there's no version.
+    public func labeled(name: String = "Pelmet") -> String {
+        isDevelopmentBuild
+            ? "\(name) (\(displayValue))"
+            : "\(name) \(displayValue)"
+    }
+
+    private static func normalized(_ raw: String?) -> String? {
+        guard let trimmed = raw?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty
+        else { return nil }
+        return trimmed
+    }
+}

--- a/Tests/PelmetCoreTests/AppVersionTests.swift
+++ b/Tests/PelmetCoreTests/AppVersionTests.swift
@@ -1,0 +1,44 @@
+import Testing
+@testable import PelmetCore
+
+struct AppVersionTests {
+
+    @Test func testShortAndBuild() {
+        let version = AppVersion(shortVersion: "0.2.0", build: "123")
+        #expect(version.displayValue == "0.2.0 (123)")
+        #expect(version.labeled() == "Pelmet 0.2.0 (123)")
+        #expect(version.isDevelopmentBuild == false)
+    }
+
+    @Test func testShortOnly() {
+        let version = AppVersion(shortVersion: "0.2.0", build: nil)
+        #expect(version.displayValue == "0.2.0")
+        #expect(version.labeled() == "Pelmet 0.2.0")
+    }
+
+    @Test func testNoShortVersionIsDevelopmentBuild() {
+        let version = AppVersion(shortVersion: nil, build: nil)
+        #expect(version.isDevelopmentBuild)
+        #expect(version.displayValue == AppVersion.developmentBuild)
+        #expect(version.labeled() == "Pelmet (Development build)")
+    }
+
+    @Test func testBuildWithoutShortStillDevelopmentBuild() {
+        // A build number with no marketing version is meaningless to a user.
+        let version = AppVersion(shortVersion: nil, build: "123")
+        #expect(version.isDevelopmentBuild)
+        #expect(version.displayValue == AppVersion.developmentBuild)
+    }
+
+    @Test func testBlankInputsNormalizeToNil() {
+        let version = AppVersion(shortVersion: "  ", build: "\n")
+        #expect(version.shortVersion == nil)
+        #expect(version.build == nil)
+        #expect(version.isDevelopmentBuild)
+    }
+
+    @Test func testCustomNameInLabel() {
+        let version = AppVersion(shortVersion: "1.0.0", build: "7")
+        #expect(version.labeled(name: "Pelmet Beta") == "Pelmet Beta 1.0.0 (7)")
+    }
+}


### PR DESCRIPTION
## What & why

Pelmet never surfaced its own version anywhere. This adds a dedicated **About** settings pane (version + build, a copy-for-bug-reports button, GitHub / release-notes / issue links, and the MIT license) plus a disabled version line in the chevron's right-click menu. Version formatting lives in a pure, unit-tested `AppVersion` type in `PelmetCore`, fed by a thin `AppVersionInfo` bundle reader, so the `swift run` case (no Info.plist, nil keys) degrades to "Development build" in one place. Also adds a `CLAUDE.md` etiquette rule against em-dashes in newly written prose.

## How I tested it

`swift test` (108 pass, incl. 6 new `AppVersion` cases) and `swiftformat --lint` clean; the bundled build (`xcodegen generate` + `xcodebuild`) succeeds with the Sparkle path compiling, and the built app's Info.plist reads `0.1.0 (1)` / `MIT License`, so the pane and menu show the real version (generic-folder icon only appears under `swift run`).
