### PR TITLE
Add opt-out anonymous usage telemetry and local crash reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -17,6 +17,14 @@ body:
         1. …
         2. …
   - type: input
+    id: version
+    attributes:
+      label: Pelmet version
+      description: Settings > About shows this; the "Report a Problem" button fills it in.
+      placeholder: e.g. 0.3.0 (123)
+    validations:
+      required: true
+  - type: input
     id: environment
     attributes:
       label: macOS version and Mac model

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   right-click menu also shows the current version. A plain `swift run` dev
   build (which has no bundle) reads "Development build".
 
+### Fixed
+
+- The crash follow-up no longer reveals an old, unrelated crash report. An
+  unclean exit that leaves no fresh report (a Force Quit or `SIGKILL`) used to
+  surface the newest Pelmet report of any age; it now only reveals a report from
+  the last day.
+- The "Report a Problem" prefill no longer sends a `labels` query parameter,
+  which could make the prefilled GitHub issue fail to open for users without
+  repo triage access. The label is still applied by the issue template.
+- Overlapping daily heartbeat checks (for example a launch check and a wake
+  check) can no longer send two pings for the same day.
+
 ## [0.2.0] - 2026-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-19
+
 ### Added
 
 - **Anonymous usage statistics (opt-out)**: Pelmet now sends one tiny anonymous
@@ -97,6 +99,7 @@ First public release — the working MVP.
 - Requires **macOS 13 Ventura** or later.
 - The core hide/show experience needs **zero special permissions**.
 
-[Unreleased]: https://github.com/ismatBabirli/pelmet/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/ismatBabirli/pelmet/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/ismatBabirli/pelmet/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/ismatBabirli/pelmet/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/ismatBabirli/pelmet/releases/tag/v0.1.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Anonymous usage statistics (opt-out)**: Pelmet now sends one tiny anonymous
   event per day (app version, macOS version, chip type, and which Pelmet features
-  are on) to an EU-hosted PostHog instance, so we finally know how many installs
+  are on) to a US-hosted PostHog instance, so we finally know how many installs
   exist and which features matter. Nothing is sent until an in-app notice has told
   you about it, and the first ping waits at least until the next launch or 24
   hours, whichever comes first. Turn it off any time in Settings, with

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Anonymous usage statistics (opt-out)**: Pelmet now sends one tiny anonymous
+  event per day (app version, macOS version, chip type, and which Pelmet features
+  are on) to an EU-hosted PostHog instance, so we finally know how many installs
+  exist and which features matter. Nothing is sent until an in-app notice has told
+  you about it, and the first ping waits at least until the next launch or 24
+  hours, whichever comes first. Turn it off any time in Settings, with
+  `defaults write com.ismatbabirli.Pelmet telemetryEnabled -bool NO`, or by setting
+  `DO_NOT_TRACK=1`. IP addresses are discarded, there are no names, no menu bar
+  contents, and never anything about the other apps you run. Every field is
+  documented in `docs/TELEMETRY.md`, which also links the public dashboard and the
+  one file of sending code.
+- **Crash follow-up, local only**: if Pelmet quit unexpectedly, the next launch
+  offers to open a prefilled GitHub issue with your Pelmet and macOS versions.
+  Crash reports stay on your Mac; you review and attach them yourself. A "Report a
+  Problem" button also lives in Settings > About.
 - **About settings pane**: a new About pane shows Pelmet's version and build,
   a button to copy the version for bug reports, and links to the GitHub repo,
   release notes, and issue tracker, alongside the MIT license. The chevron's

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `defaults write com.ismatbabirli.Pelmet telemetryEnabled -bool NO`, or by setting
   `DO_NOT_TRACK=1`. IP addresses are discarded, there are no names, no menu bar
   contents, and never anything about the other apps you run. Every field is
-  documented in `docs/TELEMETRY.md`, which also links the public dashboard and the
-  one file of sending code.
+  documented in `docs/TELEMETRY.md`, alongside the one file of sending code.
 - **Crash follow-up, local only**: if Pelmet quit unexpectedly, the next launch
   offers to open a prefilled GitHub issue with your Pelmet and macOS versions.
   Crash reports stay on your Mac; you review and attach them yourself. A "Report a

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,8 +51,12 @@ SwiftUI settings windows. Sandbox is intentionally OFF, hardened runtime ON, and
 
 - The zero-permission core is sacred: the default experience must never require
   Screen Recording or Accessibility; permissioned features are strictly opt-in.
-- No analytics, no accounts, no network calls — Sparkle update checks are the sole
-  exception. No new dependencies (Sparkle is the only one).
+- Network calls are limited to exactly two endpoints: Sparkle update checks and the
+  anonymous daily telemetry ping (`Sources/Pelmet/Telemetry/`, opt-out, schema frozen in
+  `docs/TELEMETRY.md`). Adding or changing any telemetry field requires updating
+  `docs/TELEMETRY.md` and `CHANGELOG.md` in the same PR. No accounts, no tracking SDKs,
+  no new dependencies (Sparkle is the only one; telemetry is raw `URLSession`). Crash
+  reports stay local: Pelmet only opens a prefilled GitHub issue the user submits.
 - Rationale and full list: `PROJECT.md` § "5. Non-Goals" and § "6. Technical Foundation".
 
 ## Etiquette

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,14 +62,21 @@ geometry lives in `Sources/PelmetCore/`.
 | `../PelmetCore/ShelfContent.swift`, `ShelfPlacement.swift`, `TipPlacement.swift`, `ScreenCoordinates.swift` | Pure Shelf/tip content derivation and placement geometry |
 | `../PelmetCore/Activation/` | Pure activation planning: `ActivationPlanner`, `ActivationSession`, `StatusItemCorrelator`, `QuiescencePolicy` |
 
-Two ground rules:
+Three ground rules:
 
 1. **The zero-permission core is sacred.** The default experience must never
    require Screen Recording or Accessibility. Features that need a permission
    (like one-click access) are opt-in only.
 2. **Sparkle is the only dependency** — and only in the XcodeGen app bundle,
    behind `#if canImport(Sparkle)`; the plain SPM build stays dependency-free.
-   Think twice before adding another.
+   Think twice before adding another. (Telemetry is raw `URLSession`, not a new
+   dependency.)
+3. **Telemetry is frozen by documentation.** The daily ping sends the fields in
+   [docs/TELEMETRY.md](docs/TELEMETRY.md), nothing more. Any PR that adds or
+   changes a field must update that document and `CHANGELOG.md`, and must update
+   the schema test in `Tests/PelmetCoreTests` deliberately. Nothing from the
+   Shelf's app directory (other apps' names, icons, counts) may ever reach the
+   telemetry module.
 
 ## Code style
 

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -132,7 +132,7 @@ gracefully:
 - **No menu bar "styling"** (tints, borders) in early phases — Ice does this well; we stay focused
 - **No Screen Recording, ever** — the Shelf renders app icons/names, not captured pixels; the purple indicator and re-approval nags are exactly what users flee
 - **No Mac App Store initially** — the sandbox is incompatible with the Shelf; direct + Homebrew distribution instead
-- **No analytics, no accounts, no network calls** except Sparkle update checks
+- **No accounts, no tracking SDKs, no hidden network calls.** Pelmet talks to exactly two endpoints: Sparkle update checks and an optional anonymous daily usage ping (opt-out, announced in-app before the first send, every field documented in [docs/TELEMETRY.md](docs/TELEMETRY.md)). Crash reports never leave the Mac unless the user files one.
 
 ## 6. Technical Foundation
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,25 @@ Pelmet places two items in your menu bar:
   window-geometry metadata — nothing that prompts for permissions or lights
   the screen-recording indicator.
 
+## Privacy
+
+Pelmet needs zero special permissions, has no accounts, and embeds no tracking
+SDKs. It makes two kinds of network calls, both under your control:
+
+- **Update checks** (Sparkle): asks you once before checking automatically.
+- **Anonymous usage ping**: one tiny event per day (app version, macOS version,
+  chip type, which Pelmet features are on) so we know how many people use Pelmet
+  and what to prioritize. No personal data, no menu bar contents, never anything
+  about the other apps you run; IP addresses are discarded on arrival. An in-app
+  notice appears before the first ping is ever sent. Turn it off in Settings,
+  with `defaults write com.ismatbabirli.Pelmet telemetryEnabled -bool NO`, or
+  with `DO_NOT_TRACK=1`.
+
+Every field is documented in [docs/TELEMETRY.md](docs/TELEMETRY.md), the sending
+code is one small file, and the aggregate numbers are public. Crash reports never
+leave your Mac: after a crash, Pelmet offers to open a prefilled GitHub issue
+that you review and submit yourself.
+
 ## Usage
 
 | Action | How |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,8 +1,10 @@
 # Security Policy
 
-Pelmet runs entirely locally, makes no network calls, and requires no special
-permissions — but if you find a security issue, please report it privately
-instead of opening a public issue.
+Pelmet runs locally and requires no special permissions. Its only network calls
+are Sparkle update checks and an optional anonymous usage ping (documented field
+by field in [docs/TELEMETRY.md](docs/TELEMETRY.md)); crash reports never leave
+your Mac. If you find a security issue, please report it privately instead of
+opening a public issue.
 
 **Report privately:** [github.com/ismatBabirli/pelmet/security/advisories/new](https://github.com/ismatBabirli/pelmet/security/advisories/new)
 

--- a/Sources/Pelmet/AppDelegate.swift
+++ b/Sources/Pelmet/AppDelegate.swift
@@ -24,6 +24,15 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // until they opt in. Inert under `swift run` (no bundle, no Sparkle).
         _ = UpdaterController.shared
 
+        // Local-only crash follow-up: captures the clean-exit sentinel first,
+        // then (if the last session crashed) offers a prefilled GitHub issue.
+        // No trace is ever uploaded.
+        CrashReportMonitor.shared.checkOnLaunch()
+
+        // Anonymous daily usage ping. Schedules only; sends nothing until the
+        // first-run notice is shown, and stays inert under `swift run`/DEBUG.
+        TelemetryManager.shared.start()
+
         // Global hotkeys: ⌥⌘B toggles hidden items, ⌥⌘N opens the Shelf.
         HotkeyManager.shared.onToggle = {
             MenuBarManager.shared.toggle()
@@ -38,6 +47,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {
         true
+    }
+
+    /// Record a clean shutdown so the next launch doesn't mistake this quit for
+    /// a crash. SIGINT/SIGTERM are handled separately in CrashReportMonitor.
+    func applicationWillTerminate(_ notification: Notification) {
+        CrashReportMonitor.shared.markCleanExit()
     }
 
     /// HIG: "avoid relying on the presence of menu bar extras." If the user

--- a/Sources/Pelmet/AppVersionInfo.swift
+++ b/Sources/Pelmet/AppVersionInfo.swift
@@ -32,4 +32,7 @@ enum AppLinks {
     static let repo = URL(string: "https://github.com/ismatBabirli/pelmet")!
     static let releases = URL(string: "https://github.com/ismatBabirli/pelmet/releases")!
     static let issues = URL(string: "https://github.com/ismatBabirli/pelmet/issues/new")!
+    /// Full field-by-field telemetry disclosure. Linked from the first-run
+    /// notice and the Settings Privacy section.
+    static let telemetryDoc = URL(string: "https://github.com/ismatBabirli/pelmet/blob/main/docs/TELEMETRY.md")!
 }

--- a/Sources/Pelmet/MenuBarManager.swift
+++ b/Sources/Pelmet/MenuBarManager.swift
@@ -308,6 +308,11 @@ final class MenuBarManager: NSObject {
             )
         }
         if toggleOK {
+            // After the welcome, before the one-click pitch: the privacy notice
+            // is the next thing a new user sees. Each call is gated on
+            // activePopover == nil and its own one-shot flag, so only one shows
+            // per pass; the chain re-fires when a popover closes.
+            OnboardingController.shared.maybeShowTelemetryNotice(toggle: toggleItem)
             OnboardingController.shared.maybeOfferOneClick(toggle: toggleItem)
         }
     }

--- a/Sources/Pelmet/Onboarding/OnboardingController.swift
+++ b/Sources/Pelmet/Onboarding/OnboardingController.swift
@@ -143,6 +143,29 @@ final class OnboardingController: NSObject, NSPopoverDelegate {
         }
     }
 
+    /// One-time, informational (opt-out) notice that Pelmet sends an anonymous
+    /// daily usage ping. Shown after the welcome tip so a new user meets the
+    /// core concept first, and guarded so it never stacks on Sparkle's own
+    /// first-launch prompt. `needsFirstRunNotice` already screens out dev/debug
+    /// builds, DO_NOT_TRACK, and users who opted out. Burns on successful show,
+    /// like the other tips; the reporter's cooling-off gives the real opt-out
+    /// window before the first send.
+    func maybeShowTelemetryNotice(toggle: NSStatusItem) {
+        guard activePopover == nil,
+              Preferences.didShowToggleTip,
+              TelemetryManager.shared.needsFirstRunNotice,
+              NSApp.modalWindow == nil,
+              let button = toggle.button else { return }
+
+        guard present(on: button, content: { dismiss in
+            TelemetryNoticeView(
+                onTurnOff: { TelemetryManager.shared.setEnabled(false); dismiss() },
+                onOK: dismiss
+            )
+        }) else { return }
+        TelemetryManager.shared.recordNoticeShown()
+    }
+
     /// Settings → "Show Welcome Tips Again".
     func replayTips() {
         Preferences.resetOnboardingFlags()
@@ -190,16 +213,30 @@ final class OnboardingController: NSObject, NSPopoverDelegate {
         title: String, message: String, buttonTitle: String,
         on button: NSStatusBarButton, action: (() -> Void)? = nil
     ) -> Bool {
+        present(on: button) { dismiss in
+            TipView(title: title, message: message, buttonTitle: buttonTitle) {
+                action?()
+                dismiss()
+            }
+        }
+    }
+
+    /// Shared popover plumbing behind `show` and the telemetry notice. `content`
+    /// receives a `dismiss` closure that closes the popover. Returns false
+    /// (leaving the caller's once-only flag unburned for a retry on a later
+    /// confirmed snapshot) when the button can't anchor a popover or AppKit
+    /// declines.
+    private func present(
+        on button: NSStatusBarButton,
+        @ViewBuilder content: (@escaping () -> Void) -> some View
+    ) -> Bool {
         guard canAnchor(button) else { return false }
         let popover = NSPopover()
         popover.behavior = .semitransient
         popover.animates = !NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
         popover.delegate = self
         popover.contentViewController = NSHostingController(
-            rootView: TipView(title: title, message: message, buttonTitle: buttonTitle) { [weak popover] in
-                action?()
-                popover?.performClose(nil)
-            }
+            rootView: content { [weak popover] in popover?.performClose(nil) }
         )
         // Assigned before show(): with animates off, popoverDidShow (and the
         // placement fix-up, which reads these) fires synchronously inside it.
@@ -285,6 +322,36 @@ private struct TipView: View {
             HStack {
                 Spacer()
                 Button(buttonTitle, action: dismiss)
+                    .keyboardShortcut(.defaultAction)
+            }
+        }
+        .padding(16)
+        .frame(width: 320)
+    }
+}
+
+/// The first-run telemetry notice: two actions (Turn Off / OK) and a link to
+/// the full disclosure. Wider body than a tip because honesty needs room.
+private struct TelemetryNoticeView: View {
+    let onTurnOff: () -> Void
+    let onOK: () -> Void
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Anonymous usage statistics")
+                .font(.headline)
+            Text("Pelmet counts its installs by sending one tiny anonymous ping per day: "
+                + "app version, macOS version, chip type, and which Pelmet features are "
+                + "switched on. No names, no menu bar contents, and never anything about the "
+                + "other apps you run. IP addresses are discarded on arrival.")
+                .font(.callout)
+                .fixedSize(horizontal: false, vertical: true)
+            Link("See every field and the sending code", destination: AppLinks.telemetryDoc)
+                .font(.caption)
+            HStack {
+                Button("Turn Off", action: onTurnOff)
+                Spacer()
+                Button("OK", action: onOK)
                     .keyboardShortcut(.defaultAction)
             }
         }

--- a/Sources/Pelmet/Preferences.swift
+++ b/Sources/Pelmet/Preferences.swift
@@ -22,6 +22,13 @@ enum Preferences {
         static let didAutoPromptAccessibility = "didAutoPromptAccessibility"
         static let awaitingOneClickGrant = "awaitingOneClickGrant"
         static let settingsPane = "settingsPane"
+        static let telemetryEnabled = "telemetryEnabled"
+        static let didShowTelemetryNotice = "didShowTelemetryNotice"
+        static let telemetryNoticeShownAt = "telemetryNoticeShownAt"
+        static let telemetryInstallID = "telemetryInstallID"
+        static let telemetryLastHeartbeatDay = "telemetryLastHeartbeatDay"
+        static let lastSessionCleanExit = "lastSessionCleanExit"
+        static let crashPromptDisabled = "crashPromptDisabled"
     }
 
     /// Last collapse state, restored at launch. Defaults to expanded so a
@@ -99,6 +106,64 @@ enum Preferences {
     static var awaitingOneClickGrant: Bool {
         get { UserDefaults.standard.bool(forKey: Keys.awaitingOneClickGrant) }
         set { UserDefaults.standard.set(newValue, forKey: Keys.awaitingOneClickGrant) }
+    }
+
+    // MARK: - Telemetry (anonymous daily usage ping)
+
+    /// Opt-out: absent means true, so a fresh install shares stats after the
+    /// first-run notice. Nothing is sent until `didShowTelemetryNotice` is set,
+    /// so the default-true value stays inert until the user has been told. Set
+    /// only via `TelemetryManager.setEnabled`, never written from a view.
+    static var telemetryEnabled: Bool {
+        get { UserDefaults.standard.object(forKey: Keys.telemetryEnabled) as? Bool ?? true }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.telemetryEnabled) }
+    }
+
+    /// The send gate's second factor: nothing is ever sent while this is false.
+    /// A consent fact, not onboarding, so `resetOnboardingFlags()` leaves it be.
+    static var didShowTelemetryNotice: Bool {
+        get { UserDefaults.standard.bool(forKey: Keys.didShowTelemetryNotice) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.didShowTelemetryNotice) }
+    }
+
+    /// When the notice was shown, for the "24h or next launch" cooling-off
+    /// before the very first send. nil until the notice is shown.
+    static var telemetryNoticeShownAt: Date? {
+        get { UserDefaults.standard.object(forKey: Keys.telemetryNoticeShownAt) as? Date }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.telemetryNoticeShownAt) }
+    }
+
+    /// Random per-install UUID (PostHog `distinct_id`). Created lazily at the
+    /// first actual send, so a user who opts out at the notice never gets one.
+    /// Cleared on opt-out, regenerated on re-enable (a severable identity).
+    static var telemetryInstallID: String? {
+        get { UserDefaults.standard.string(forKey: Keys.telemetryInstallID) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.telemetryInstallID) }
+    }
+
+    /// UTC "yyyy-MM-dd" of the last successful heartbeat; nil until the first.
+    /// Idempotency across relaunches (one send per day).
+    static var telemetryLastHeartbeatDay: String? {
+        get { UserDefaults.standard.string(forKey: Keys.telemetryLastHeartbeatDay) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.telemetryLastHeartbeatDay) }
+    }
+
+    // MARK: - Crash reporting (local only)
+
+    /// Clean-exit sentinel: set false at launch, true in
+    /// `applicationWillTerminate`. Read at the next launch, a false value means
+    /// the previous session ended uncleanly. Absent means true so a brand-new
+    /// install is never treated as a crash.
+    static var lastSessionCleanExit: Bool {
+        get { UserDefaults.standard.object(forKey: Keys.lastSessionCleanExit) as? Bool ?? true }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.lastSessionCleanExit) }
+    }
+
+    /// User asked (via the post-crash alert's checkbox) never to be prompted
+    /// after future crashes. Crash detection still feeds the heartbeat boolean.
+    static var crashPromptDisabled: Bool {
+        get { UserDefaults.standard.bool(forKey: Keys.crashPromptDisabled) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.crashPromptDisabled) }
     }
 
     // MARK: - One-time onboarding flags

--- a/Sources/Pelmet/Settings/AboutPaneView.swift
+++ b/Sources/Pelmet/Settings/AboutPaneView.swift
@@ -47,7 +47,11 @@ struct AboutPaneView: View {
             Section {
                 Link("View on GitHub", destination: AppLinks.repo)
                 Link("Release Notes", destination: AppLinks.releases)
-                Link("Report an Issue…", destination: AppLinks.issues)
+                // Opens a GitHub issue prefilled with the version and
+                // environment; the user writes and submits it themselves.
+                Button("Report a Problem…") {
+                    CrashReportMonitor.shared.reportProblem()
+                }
             } footer: {
                 Text("\(AppVersionInfo.copyright) · Open source")
                     .font(.caption)

--- a/Sources/Pelmet/Settings/GeneralPaneView.swift
+++ b/Sources/Pelmet/Settings/GeneralPaneView.swift
@@ -1,5 +1,6 @@
-import SwiftUI
+import PelmetCore
 import ServiceManagement
+import SwiftUI
 
 /// General pane: the core mental model, re-hide behavior, startup and
 /// shortcuts. This is the landing pane — Settings doubles as the escape
@@ -11,6 +12,12 @@ struct GeneralPaneView: View {
     @State private var launchAtLogin = (SMAppService.mainApp.status == .enabled)
     @State private var launchAtLoginError: String?
     @State private var autoCheckUpdates = UpdaterController.shared.automaticallyChecksForUpdates
+    @State private var telemetryEnabled = Preferences.telemetryEnabled
+    @State private var didResetInstallID = false
+    /// When set in the environment, DO_NOT_TRACK wins over the toggle.
+    private let doNotTrack = TelemetryGate.envFlagSet(
+        ProcessInfo.processInfo.environment["DO_NOT_TRACK"]
+    )
 
     var body: some View {
         Form {
@@ -66,6 +73,46 @@ struct GeneralPaneView: View {
                         UpdaterController.shared.checkForUpdates(nil)
                     }
                 }
+            }
+
+            // Always shown (honest even under `swift run`, where the send gate
+            // keeps it inert). The toggle routes through TelemetryManager so
+            // opting out also forgets the install ID.
+            Section {
+                Toggle("Share anonymous usage statistics", isOn: Binding(
+                    get: { telemetryEnabled && !doNotTrack },
+                    set: { enabled in
+                        telemetryEnabled = enabled
+                        TelemetryManager.shared.setEnabled(enabled)
+                    }
+                ))
+                .disabled(doNotTrack)
+
+                DisclosureGroup("What exactly is sent?") {
+                    // Rendered from the same builder used on the wire, so the
+                    // preview cannot drift from reality.
+                    Text(TelemetryManager.shared.currentPreviewJSON())
+                        .font(.system(.caption, design: .monospaced))
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    Link("Full documentation", destination: AppLinks.telemetryDoc)
+                    Button(didResetInstallID ? "Install ID reset" : "Reset Install ID") {
+                        TelemetryManager.shared.resetInstallID()
+                        didResetInstallID = true
+                    }
+                    .disabled(didResetInstallID)
+                }
+            } header: {
+                Text("Privacy")
+            } footer: {
+                Text(doNotTrack
+                    ? "Disabled by the DO_NOT_TRACK environment variable."
+                    : "One anonymous ping per day: app version, macOS version, chip type, and "
+                        + "which Pelmet features are on. Never your menu bar contents or other "
+                        + "apps' names. IP addresses are discarded.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
             }
 
             Section {

--- a/Sources/Pelmet/Settings/SettingsPane.swift
+++ b/Sources/Pelmet/Settings/SettingsPane.swift
@@ -15,7 +15,7 @@ enum SettingsPane: String, CaseIterable, Identifiable {
     static let detailWidth: CGFloat = 420
     /// Total window content height — sized so the tallest pane (General)
     /// fits scroll-free; panes scroll if they ever outgrow it.
-    static let contentHeight: CGFloat = 480
+    static let contentHeight: CGFloat = 560
 
     /// Panes offered for the current hardware — same gate as the
     /// context-menu entry in MenuBarManager: One-Click Access only exists

--- a/Sources/Pelmet/Telemetry/CrashReportMonitor.swift
+++ b/Sources/Pelmet/Telemetry/CrashReportMonitor.swift
@@ -1,0 +1,158 @@
+import AppKit
+import os
+import PelmetCore
+
+/// Local-only crash follow-up. Pelmet never uploads a crash report: this type
+/// only notices that the previous session ended uncleanly, offers to open a
+/// prefilled GitHub issue the user reviews and submits themselves, and reveals
+/// the system `.ips` report in Finder so they can attach it if they choose.
+///
+/// It also owns the clean-exit sentinel that feeds the heartbeat's single
+/// `prev_session_clean` boolean (the entire crash signal in telemetry: a
+/// boolean, never a trace).
+final class CrashReportMonitor {
+
+    static let shared = CrashReportMonitor()
+
+    private let log = Logger(subsystem: "com.ismatbabirli.Pelmet", category: "CrashReport")
+
+    /// Captured once at launch, before the sentinel is flipped, so both the
+    /// crash prompt and `TelemetryManager` read a stable value. Defaults to
+    /// true so a brand-new install is never treated as a crash.
+    private(set) var previousSessionEndedCleanly = true
+
+    private var signalSources: [DispatchSourceSignal] = []
+
+    private init() {}
+
+    // MARK: - Lifecycle
+
+    /// Reads the sentinel (how the last session ended), re-arms it for this
+    /// session, and, if the last session crashed, offers the report prompt.
+    /// The capture is synchronous so ordering against `TelemetryManager.start()`
+    /// does not matter.
+    func checkOnLaunch() {
+        previousSessionEndedCleanly = Preferences.lastSessionCleanExit
+        Preferences.lastSessionCleanExit = false
+        installCleanExitSignalHandlers()
+
+        guard !previousSessionEndedCleanly else { return }
+        log.debug("previous session ended uncleanly")
+        guard !Preferences.crashPromptDisabled else { return }
+
+        // Defer the alert so it never lands during the launch storm; onboarding
+        // popovers retry, so ordering with them is safe.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 5) { [weak self] in
+            self?.presentCrashPrompt()
+        }
+    }
+
+    /// Marks this session as having ended cleanly. Called from
+    /// `applicationWillTerminate` and from the SIGINT/SIGTERM handlers, so a
+    /// normal quit, a Ctrl-C under `swift run`, and a logout-time SIGTERM are
+    /// all distinguished from an actual crash.
+    func markCleanExit() {
+        Preferences.lastSessionCleanExit = true
+    }
+
+    /// A clean SIGINT/SIGTERM never counts as a crash. `SIG_IGN` defuses the
+    /// default terminate; the dispatch source then records a clean exit and
+    /// quits. Without this, every Ctrl-C under `swift run` (and every logout)
+    /// would look like a crash on the next launch.
+    private func installCleanExitSignalHandlers() {
+        for sig in [SIGINT, SIGTERM] {
+            signal(sig, SIG_IGN)
+            let source = DispatchSource.makeSignalSource(signal: sig, queue: .main)
+            source.setEventHandler { [weak self] in
+                self?.markCleanExit()
+                exit(0)
+            }
+            source.resume()
+            signalSources.append(source)
+        }
+    }
+
+    // MARK: - Reporting
+
+    /// About pane "Report a Problem": open a prefilled issue with environment
+    /// info. No crash report is involved on this path.
+    func reportProblem() {
+        NSWorkspace.shared.open(issueURL())
+    }
+
+    private func presentCrashPrompt() {
+        NSApp.activate(ignoringOtherApps: true)
+        let alert = NSAlert()
+        alert.messageText = "Pelmet quit unexpectedly last time"
+        alert.informativeText = "Sorry about that. Crash details stay on your Mac; Pelmet "
+            + "never sends them anywhere. If you have a minute, Pelmet can open a GitHub "
+            + "issue prefilled with your Pelmet and macOS versions, and show you the crash "
+            + "report so you can look it over and attach it yourself."
+        alert.addButton(withTitle: "Report a Problem…")
+        alert.addButton(withTitle: "Not Now")
+        alert.showsSuppressionButton = true
+        alert.suppressionButton?.title = "Don't offer this after future crashes"
+
+        let response = alert.runModal()
+        if alert.suppressionButton?.state == .on {
+            Preferences.crashPromptDisabled = true
+        }
+        guard response == .alertFirstButtonReturn else { return }
+
+        if let report = newestCrashReport() {
+            NSWorkspace.shared.activateFileViewerSelecting([report])
+        }
+        NSWorkspace.shared.open(issueURL())
+    }
+
+    /// Newest `Pelmet-*.ips` in the top level of DiagnosticReports (aged-out
+    /// reports move to a `Retired/` subfolder, which we skip). Read failures
+    /// degrade to nil: the issue still opens, just without the Finder reveal.
+    private func newestCrashReport() -> URL? {
+        let dir = FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent("Library/Logs/DiagnosticReports", isDirectory: true)
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: dir,
+            includingPropertiesForKeys: [.contentModificationDateKey],
+            options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]
+        ) else { return nil }
+
+        return entries
+            .filter { $0.lastPathComponent.hasPrefix("Pelmet-") && $0.pathExtension == "ips" }
+            .max { modificationDate($0) < modificationDate($1) }
+    }
+
+    private func modificationDate(_ url: URL) -> Date {
+        (try? url.resourceValues(forKeys: [.contentModificationDateKey]))?
+            .contentModificationDate ?? .distantPast
+    }
+
+    /// A prefilled bug-report form URL. Query keys match the field `id`s in
+    /// `.github/ISSUE_TEMPLATE/bug_report.yml`; the "what happened" field stays
+    /// empty for the user to fill.
+    private func issueURL() -> URL {
+        var components = URLComponents(url: AppLinks.issues, resolvingAgainstBaseURL: false)
+        components?.queryItems = [
+            URLQueryItem(name: "template", value: "bug_report.yml"),
+            URLQueryItem(name: "labels", value: "bug"),
+            URLQueryItem(name: "version", value: AppVersionInfo.current.displayValue),
+            URLQueryItem(name: "environment", value: Self.environmentDescription),
+        ]
+        return components?.url ?? AppLinks.issues
+    }
+
+    /// "macOS 15.5, arm64, notched display" style summary for the prefill.
+    private static var environmentDescription: String {
+        let v = ProcessInfo.processInfo.operatingSystemVersion
+        let macOS = "macOS \(v.majorVersion).\(v.minorVersion).\(v.patchVersion)"
+        #if arch(arm64)
+        let arch = "arm64"
+        #elseif arch(x86_64)
+        let arch = "x86_64"
+        #else
+        let arch = "unknown"
+        #endif
+        let notch = LayoutStatus.shared.hasNotchedDisplay ? ", notched display" : ""
+        return "\(macOS), \(arch)\(notch)"
+    }
+}

--- a/Sources/Pelmet/Telemetry/CrashReportMonitor.swift
+++ b/Sources/Pelmet/Telemetry/CrashReportMonitor.swift
@@ -23,6 +23,14 @@ final class CrashReportMonitor {
 
     private var signalSources: [DispatchSourceSignal] = []
 
+    /// How recent a `.ips` must be to count as the report for the crash we are
+    /// following up on. An unclean exit is broader than "left a report": a Force
+    /// Quit, `SIGKILL`, or power loss ends the session uncleanly yet writes no
+    /// `.ips`, and without this bound the newest match could be a stale, unrelated
+    /// report from a crash weeks ago. Pelmet is relaunched soon after a crash, so
+    /// 24h comfortably covers a genuine report while excluding old cruft.
+    private let maxCrashReportAge: TimeInterval = 24 * 3600
+
     private init() {}
 
     // MARK: - Lifecycle
@@ -106,8 +114,10 @@ final class CrashReportMonitor {
     }
 
     /// Newest `Pelmet-*.ips` in the top level of DiagnosticReports (aged-out
-    /// reports move to a `Retired/` subfolder, which we skip). Read failures
-    /// degrade to nil: the issue still opens, just without the Finder reveal.
+    /// reports move to a `Retired/` subfolder, which we skip), provided it is
+    /// recent enough to belong to the crash we are following up on. Read failures
+    /// and a too-old newest report both degrade to nil: the issue still opens,
+    /// just without the Finder reveal.
     private func newestCrashReport() -> URL? {
         let dir = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Library/Logs/DiagnosticReports", isDirectory: true)
@@ -117,9 +127,17 @@ final class CrashReportMonitor {
             options: [.skipsHiddenFiles, .skipsSubdirectoryDescendants]
         ) else { return nil }
 
-        return entries
-            .filter { $0.lastPathComponent.hasPrefix("Pelmet-") && $0.pathExtension == "ips" }
-            .max { modificationDate($0) < modificationDate($1) }
+        guard let newest = entries
+            .filter({ $0.lastPathComponent.hasPrefix("Pelmet-") && $0.pathExtension == "ips" })
+            .max(by: { modificationDate($0) < modificationDate($1) })
+        else { return nil }
+
+        // An unclean exit without a fresh report (Force Quit, SIGKILL) must not
+        // surface an old, unrelated one.
+        guard Date().timeIntervalSince(modificationDate(newest)) <= maxCrashReportAge else {
+            return nil
+        }
+        return newest
     }
 
     private func modificationDate(_ url: URL) -> Date {
@@ -129,12 +147,13 @@ final class CrashReportMonitor {
 
     /// A prefilled bug-report form URL. Query keys match the field `id`s in
     /// `.github/ISSUE_TEMPLATE/bug_report.yml`; the "what happened" field stays
-    /// empty for the user to fill.
+    /// empty for the user to fill. No `labels` item: the template already applies
+    /// `bug`, and a `labels` query param requires repo triage access, so passing
+    /// it would make the prefill fail for users who lack it.
     private func issueURL() -> URL {
         var components = URLComponents(url: AppLinks.issues, resolvingAgainstBaseURL: false)
         components?.queryItems = [
             URLQueryItem(name: "template", value: "bug_report.yml"),
-            URLQueryItem(name: "labels", value: "bug"),
             URLQueryItem(name: "version", value: AppVersionInfo.current.displayValue),
             URLQueryItem(name: "environment", value: Self.environmentDescription),
         ]

--- a/Sources/Pelmet/Telemetry/TelemetryManager.swift
+++ b/Sources/Pelmet/Telemetry/TelemetryManager.swift
@@ -18,11 +18,11 @@ final class TelemetryManager {
 
     /// PostHog project API key. This is a PUBLIC, write-only ingestion token
     /// (it can only send events, never read data back), so it is safe to embed
-    /// in open-source source. Swap the placeholder for the real key before
-    /// release; until then `isConfigured` is false and nothing is sent even in
-    /// a release build. The project must have "Discard client IP data" enabled.
-    private static let apiKey = "phc_REPLACE_WITH_POSTHOG_PROJECT_KEY"
-    private static let endpoint = URL(string: "https://eu.i.posthog.com/i/v0/e/")!
+    /// in open-source source. The "Pelmet" project on PostHog Cloud US has
+    /// "Discard client IP data" enabled. The `phc_REPLACE` sentinel below keeps
+    /// `isConfigured` false (and stops all sends) if the key is ever cleared.
+    private static let apiKey = "phc_tpzRsgpnvLvi8WZrY8N6XJw3kaNNNsXQJ6qAnjS9XBqS"
+    private static let endpoint = URL(string: "https://us.i.posthog.com/i/v0/e/")!
 
     private static var isConfigured: Bool { !apiKey.hasPrefix("phc_REPLACE") }
 

--- a/Sources/Pelmet/Telemetry/TelemetryManager.swift
+++ b/Sources/Pelmet/Telemetry/TelemetryManager.swift
@@ -194,7 +194,8 @@ final class TelemetryManager {
             isDevelopmentBuild: AppVersionInfo.current.isDevelopmentBuild,
             isDebugBuild: Self.isDebugBuild,
             doNotTrack: env["DO_NOT_TRACK"],
-            disableOverride: env["PELMET_DISABLE_TELEMETRY"]
+            disableOverride: env["PELMET_DISABLE_TELEMETRY"],
+            forceOverride: env["PELMET_FORCE_TELEMETRY"]
         )
     }
 

--- a/Sources/Pelmet/Telemetry/TelemetryManager.swift
+++ b/Sources/Pelmet/Telemetry/TelemetryManager.swift
@@ -1,0 +1,221 @@
+import AppKit
+import os
+import PelmetCore
+
+/// Sends Pelmet's one anonymous event: a daily "heartbeat". Modeled on
+/// `UpdaterController` (a thin singleton started from
+/// `applicationDidFinishLaunching`) and, like it, inert unless it is a real
+/// release build the user has been told about.
+///
+/// Everything that decides *whether* to send lives in `PelmetCore`
+/// (`TelemetryGate`, `HeartbeatSchedule`) and is unit-tested; this type only
+/// gathers inputs, builds the payload, and does the network I/O. It has no
+/// reference to the Shelf or `NSRunningApplication`, so a user's menu bar
+/// contents cannot reach the wire.
+final class TelemetryManager {
+
+    static let shared = TelemetryManager()
+
+    /// PostHog project API key. This is a PUBLIC, write-only ingestion token
+    /// (it can only send events, never read data back), so it is safe to embed
+    /// in open-source source. Swap the placeholder for the real key before
+    /// release; until then `isConfigured` is false and nothing is sent even in
+    /// a release build. The project must have "Discard client IP data" enabled.
+    private static let apiKey = "phc_REPLACE_WITH_POSTHOG_PROJECT_KEY"
+    private static let endpoint = URL(string: "https://eu.i.posthog.com/i/v0/e/")!
+
+    private static var isConfigured: Bool { !apiKey.hasPrefix("phc_REPLACE") }
+
+    #if DEBUG
+    private static let isDebugBuild = true
+    #else
+    private static let isDebugBuild = false
+    #endif
+
+    private let log = Logger(subsystem: "com.ismatbabirli.Pelmet", category: "Telemetry")
+
+    private var timer: Timer?
+    private var wakeObserver: NSObjectProtocol?
+    /// True only if the first-run notice was shown during THIS process, which
+    /// arms the cooling-off hold on the very first send.
+    private var noticeShownThisSession = false
+
+    private lazy var session: URLSession = {
+        let config = URLSessionConfiguration.ephemeral // no cookies, no cache
+        config.timeoutIntervalForRequest = 15
+        config.waitsForConnectivity = false // fail fast; the next tick retries
+        return URLSession(configuration: config)
+    }()
+
+    private init() {}
+
+    // MARK: - Lifecycle
+
+    /// Schedules checks only; never blocks launch and never sends synchronously.
+    func start() {
+        scheduleTimer()
+        wakeObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didWakeNotification, object: nil, queue: .main
+        ) { [weak self] _ in
+            self?.checkNow()
+        }
+        // A missed repeating-timer fire during sleep is covered by the wake
+        // observer; the launch delay keeps us off the network during login.
+        DispatchQueue.main.asyncAfter(deadline: .now() + HeartbeatSchedule.launchDelay) { [weak self] in
+            self?.checkNow()
+        }
+    }
+
+    private func scheduleTimer() {
+        let timer = Timer(timeInterval: HeartbeatSchedule.recheckInterval, repeats: true) { [weak self] _ in
+            self?.checkNow()
+        }
+        timer.tolerance = 300 // generous: the send decision is idempotent per day
+        RunLoop.main.add(timer, forMode: .common)
+        self.timer = timer
+    }
+
+    // MARK: - Consent / settings
+
+    /// Whether the first-run notice should be offered (used by the onboarding
+    /// chain). False in dev/debug builds, under DO_NOT_TRACK, or once shown.
+    var needsFirstRunNotice: Bool { TelemetryGate.shouldOfferNotice(gateInputs) }
+
+    /// Called when the first-run notice has actually been shown. Burns the flag
+    /// and starts the cooling-off window; does not send now.
+    func recordNoticeShown() {
+        Preferences.didShowTelemetryNotice = true
+        Preferences.telemetryNoticeShownAt = Date()
+        noticeShownThisSession = true
+    }
+
+    var isEnabled: Bool { Preferences.telemetryEnabled }
+
+    /// The Settings toggle target. Persists the preference and, on opt-out,
+    /// forgets the install ID so re-enabling starts a fresh, unlinkable identity.
+    func setEnabled(_ enabled: Bool) {
+        Preferences.telemetryEnabled = enabled
+        if enabled {
+            checkNow()
+        } else {
+            Preferences.telemetryInstallID = nil
+        }
+    }
+
+    /// "Reset Install ID" in Settings: a new random identifier, unlinkable from
+    /// past pings.
+    func resetInstallID() {
+        Preferences.telemetryInstallID = UUID().uuidString
+    }
+
+    /// The exact JSON that would be sent right now, for the Settings "what is
+    /// sent" disclosure. Uses the persisted install ID, or a zeroed placeholder
+    /// when none exists yet (so the preview never mints an ID as a side effect).
+    func currentPreviewJSON() -> String {
+        let id = Preferences.telemetryInstallID ?? "00000000-0000-0000-0000-000000000000"
+        return makePayload(distinctID: id).previewJSON(apiKey: Self.apiKey)
+    }
+
+    // MARK: - Sending
+
+    func checkNow() {
+        let verbose = ProcessInfo.processInfo.environment["PELMET_DEBUG_TELEMETRY"] == "verbose"
+        let now = Date()
+        let active = TelemetryGate.isActive(gateInputs)
+        let coolingElapsed = HeartbeatSchedule.coolingOffElapsed(
+            noticeShownThisSession: noticeShownThisSession,
+            noticeShownAt: Preferences.telemetryNoticeShownAt,
+            now: now
+        )
+        let due = HeartbeatSchedule.shouldSend(
+            lastSentDay: Preferences.telemetryLastHeartbeatDay, now: now
+        )
+
+        if verbose {
+            let id = Preferences.telemetryInstallID ?? "<generated at first send>"
+            print("""
+            Pelmet telemetry (dry run): active=\(active) configured=\(Self.isConfigured) \
+            coolingOffElapsed=\(coolingElapsed) dueToday=\(due)
+            \(makePayload(distinctID: id).previewJSON(apiKey: Self.apiKey))
+            """)
+            fflush(stdout)
+        }
+
+        guard Self.isConfigured, active, coolingElapsed, due else { return }
+        send(makePayload(distinctID: installIDForSend()))
+    }
+
+    private func send(_ payload: TelemetryPayload) {
+        guard let body = try? payload.postHogBody(apiKey: Self.apiKey) else { return }
+        var request = URLRequest(url: Self.endpoint)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = body
+
+        let day = HeartbeatSchedule.dayKey(for: payload.timestamp)
+        session.dataTask(with: request) { [weak self] _, response, error in
+            guard error == nil,
+                  let http = response as? HTTPURLResponse,
+                  (200 ..< 300).contains(http.statusCode) else {
+                // Fail totally silently: a blocked endpoint (Little Snitch,
+                // Pi-hole) is a no-op, and the next tick is the only retry.
+                self?.log.debug("heartbeat send did not complete; will retry next tick")
+                return
+            }
+            Preferences.telemetryLastHeartbeatDay = day
+            self?.log.debug("heartbeat sent")
+        }.resume()
+    }
+
+    // MARK: - Inputs
+
+    private var gateInputs: TelemetryGate.Inputs {
+        let env = ProcessInfo.processInfo.environment
+        return TelemetryGate.Inputs(
+            enabledPreference: Preferences.telemetryEnabled,
+            noticeShown: Preferences.didShowTelemetryNotice,
+            isDevelopmentBuild: AppVersionInfo.current.isDevelopmentBuild,
+            isDebugBuild: Self.isDebugBuild,
+            doNotTrack: env["DO_NOT_TRACK"],
+            disableOverride: env["PELMET_DISABLE_TELEMETRY"]
+        )
+    }
+
+    private func installIDForSend() -> String {
+        if let existing = Preferences.telemetryInstallID { return existing }
+        let new = UUID().uuidString
+        Preferences.telemetryInstallID = new
+        return new
+    }
+
+    private func makePayload(distinctID: String) -> TelemetryPayload {
+        TelemetryPayload(
+            distinctID: distinctID,
+            timestamp: Date(),
+            appVersion: AppVersionInfo.current.shortVersion ?? AppVersion.developmentBuild,
+            macOS: Self.macOSVersionString,
+            arch: Self.archString,
+            notch: LayoutStatus.shared.hasNotchedDisplay,
+            shelfEnabled: Preferences.shelfEnabled,
+            oneClickEnabled: Preferences.activationEngineEnabled,
+            autoRehide: Preferences.autoRehide,
+            managesItems: Preferences.hasEverManagedItems,
+            prevSessionClean: CrashReportMonitor.shared.previousSessionEndedCleanly
+        )
+    }
+
+    private static var macOSVersionString: String {
+        let v = ProcessInfo.processInfo.operatingSystemVersion
+        return "\(v.majorVersion).\(v.minorVersion)"
+    }
+
+    private static var archString: String {
+        #if arch(arm64)
+        return "arm64"
+        #elseif arch(x86_64)
+        return "x86_64"
+        #else
+        return "unknown"
+        #endif
+    }
+}

--- a/Sources/Pelmet/Telemetry/TelemetryManager.swift
+++ b/Sources/Pelmet/Telemetry/TelemetryManager.swift
@@ -39,6 +39,12 @@ final class TelemetryManager {
     /// True only if the first-run notice was shown during THIS process, which
     /// arms the cooling-off hold on the very first send.
     private var noticeShownThisSession = false
+    /// The UTC day of a send that is currently in flight, reserved synchronously
+    /// on the main thread before the request starts. The persisted last-sent day
+    /// only updates when the request completes, so without this two overlapping
+    /// `checkNow()` calls (e.g. the launch check and a wake) could both see the
+    /// day as due and double-send. Only ever touched on the main thread.
+    private var inFlightHeartbeatDay: String?
 
     private lazy var session: URLSession = {
         let config = URLSessionConfiguration.ephemeral // no cookies, no cache
@@ -141,7 +147,8 @@ final class TelemetryManager {
             fflush(stdout)
         }
 
-        guard Self.isConfigured, active, coolingElapsed, due else { return }
+        guard Self.isConfigured, active, coolingElapsed, due,
+              inFlightHeartbeatDay != HeartbeatSchedule.dayKey(for: now) else { return }
         send(makePayload(distinctID: installIDForSend()))
     }
 
@@ -152,18 +159,28 @@ final class TelemetryManager {
         request.setValue("application/json", forHTTPHeaderField: "Content-Type")
         request.httpBody = body
 
+        // Reserve the day synchronously (on main) before the request starts, so a
+        // second checkNow() during the round trip sees it as taken. On completion,
+        // a success promotes it to the persisted last-sent day; either way the
+        // reservation is released so the next day can send.
         let day = HeartbeatSchedule.dayKey(for: payload.timestamp)
+        inFlightHeartbeatDay = day
         session.dataTask(with: request) { [weak self] _, response, error in
-            guard error == nil,
-                  let http = response as? HTTPURLResponse,
-                  (200 ..< 300).contains(http.statusCode) else {
-                // Fail totally silently: a blocked endpoint (Little Snitch,
-                // Pi-hole) is a no-op, and the next tick is the only retry.
-                self?.log.debug("heartbeat send did not complete; will retry next tick")
-                return
+            let succeeded = error == nil
+                && (response as? HTTPURLResponse).map { (200 ..< 300).contains($0.statusCode) } ?? false
+            DispatchQueue.main.async {
+                if succeeded {
+                    Preferences.telemetryLastHeartbeatDay = day
+                    self?.log.debug("heartbeat sent")
+                } else {
+                    // Fail totally silently: a blocked endpoint (Little Snitch,
+                    // Pi-hole) is a no-op, and the next tick is the only retry.
+                    self?.log.debug("heartbeat send did not complete; will retry next tick")
+                }
+                if self?.inFlightHeartbeatDay == day {
+                    self?.inFlightHeartbeatDay = nil
+                }
             }
-            Preferences.telemetryLastHeartbeatDay = day
-            self?.log.debug("heartbeat sent")
         }.resume()
     }
 

--- a/Sources/PelmetCore/Telemetry/HeartbeatSchedule.swift
+++ b/Sources/PelmetCore/Telemetry/HeartbeatSchedule.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+/// Pure scheduling decisions for the daily heartbeat. Kept UTC-based and free
+/// of wall-clock reads so it is deterministic and unit-testable; the app layer
+/// supplies `now` and the persisted last-sent day.
+public enum HeartbeatSchedule {
+
+    /// Wait this long after launch before the first send check, so telemetry
+    /// never races login, network bring-up, or the first-run notice.
+    public static let launchDelay: TimeInterval = 30
+
+    /// How often the running app re-checks whether a new UTC day has started.
+    /// Hourly is plenty: the decision is idempotent (one send per day).
+    public static let recheckInterval: TimeInterval = 3600
+
+    /// The UTC calendar day as "yyyy-MM-dd". Aligns with PostHog's daily active
+    /// buckets and is timezone-independent, so two Macs in different zones agree
+    /// on the day boundary.
+    public static func dayKey(for date: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return formatter.string(from: date)
+    }
+
+    /// True when no heartbeat has been sent for the current UTC day.
+    public static func shouldSend(lastSentDay: String?, now: Date) -> Bool {
+        guard let lastSentDay else { return true }
+        return lastSentDay != dayKey(for: now)
+    }
+
+    /// After the notice is first shown, hold the very first send until the user
+    /// has had a real chance to opt out: either a later app launch, or 24 hours,
+    /// whichever comes first. A menu-bar app can run for weeks, so "next launch"
+    /// alone could delay data indefinitely; the 24h fallback keeps it timely.
+    ///
+    /// - Parameter noticeShownThisSession: true only when the notice was shown
+    ///   during the current process. If it was shown in a previous session, a
+    ///   launch has already happened, so the window has passed.
+    public static func coolingOffElapsed(
+        noticeShownThisSession: Bool,
+        noticeShownAt: Date?,
+        now: Date
+    ) -> Bool {
+        guard noticeShownThisSession else { return true }
+        guard let noticeShownAt else { return true }
+        return now.timeIntervalSince(noticeShownAt) >= 24 * 3600
+    }
+}

--- a/Sources/PelmetCore/Telemetry/TelemetryGate.swift
+++ b/Sources/PelmetCore/Telemetry/TelemetryGate.swift
@@ -1,0 +1,72 @@
+import Foundation
+
+/// Pure decision logic for whether telemetry may run. Every input is passed in
+/// so the whole gate is unit-testable with no UserDefaults, environment, or
+/// bundle reads. The app layer (`TelemetryManager`) gathers the inputs and
+/// obeys the answer.
+public enum TelemetryGate {
+
+    public struct Inputs: Equatable {
+        /// The user's `telemetryEnabled` preference (defaults to true, opt-out).
+        public let enabledPreference: Bool
+        /// Whether the first-run notice has been shown. Nothing may send until
+        /// the user has been told, regardless of the opt-out default.
+        public let noticeShown: Bool
+        /// `swift run` (no Info.plist) has no marketing version.
+        public let isDevelopmentBuild: Bool
+        /// A `#if DEBUG` compile: the XcodeGen Debug `.app` has a real version
+        /// so `isDevelopmentBuild` is false there, but it must still stay inert.
+        public let isDebugBuild: Bool
+        /// The `DO_NOT_TRACK` environment variable, if set.
+        public let doNotTrack: String?
+        /// The `PELMET_DISABLE_TELEMETRY` QA override, if set.
+        public let disableOverride: String?
+
+        public init(
+            enabledPreference: Bool,
+            noticeShown: Bool,
+            isDevelopmentBuild: Bool,
+            isDebugBuild: Bool,
+            doNotTrack: String?,
+            disableOverride: String?
+        ) {
+            self.enabledPreference = enabledPreference
+            self.noticeShown = noticeShown
+            self.isDevelopmentBuild = isDevelopmentBuild
+            self.isDebugBuild = isDebugBuild
+            self.doNotTrack = doNotTrack
+            self.disableOverride = disableOverride
+        }
+    }
+
+    /// May a heartbeat be sent right now?
+    public static func isActive(_ i: Inputs) -> Bool {
+        i.enabledPreference
+            && i.noticeShown
+            && !i.isDevelopmentBuild
+            && !i.isDebugBuild
+            && !envFlagSet(i.doNotTrack)
+            && !envFlagSet(i.disableOverride)
+    }
+
+    /// Should the first-run notice be offered? True only when everything except
+    /// `noticeShown` would allow sending. We never show a "we collect stats"
+    /// notice to someone who has already opted out, nor in a build (dev/debug)
+    /// or environment (`DO_NOT_TRACK`) where nothing would ever be sent.
+    public static func shouldOfferNotice(_ i: Inputs) -> Bool {
+        !i.noticeShown
+            && i.enabledPreference
+            && !i.isDevelopmentBuild
+            && !i.isDebugBuild
+            && !envFlagSet(i.doNotTrack)
+            && !envFlagSet(i.disableOverride)
+    }
+
+    /// The `console.dev` / `DO_NOT_TRACK` convention: a variable counts as set
+    /// when it is present, non-empty, and not "0". Whitespace is trimmed.
+    public static func envFlagSet(_ value: String?) -> Bool {
+        guard let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !trimmed.isEmpty else { return false }
+        return trimmed != "0"
+    }
+}

--- a/Sources/PelmetCore/Telemetry/TelemetryGate.swift
+++ b/Sources/PelmetCore/Telemetry/TelemetryGate.swift
@@ -21,6 +21,11 @@ public enum TelemetryGate {
         public let doNotTrack: String?
         /// The `PELMET_DISABLE_TELEMETRY` QA override, if set.
         public let disableOverride: String?
+        /// The `PELMET_FORCE_TELEMETRY` developer override, if set. Unlocks the
+        /// dev-build, debug-build, and notice gates so a local `swift run` can
+        /// send a real heartbeat for testing. It never beats an explicit opt-out
+        /// (`DO_NOT_TRACK`, `PELMET_DISABLE_TELEMETRY`, or `enabledPreference`).
+        public let forceOverride: String?
 
         public init(
             enabledPreference: Bool,
@@ -28,7 +33,8 @@ public enum TelemetryGate {
             isDevelopmentBuild: Bool,
             isDebugBuild: Bool,
             doNotTrack: String?,
-            disableOverride: String?
+            disableOverride: String?,
+            forceOverride: String? = nil
         ) {
             self.enabledPreference = enabledPreference
             self.noticeShown = noticeShown
@@ -36,17 +42,20 @@ public enum TelemetryGate {
             self.isDebugBuild = isDebugBuild
             self.doNotTrack = doNotTrack
             self.disableOverride = disableOverride
+            self.forceOverride = forceOverride
         }
     }
 
     /// May a heartbeat be sent right now?
     public static func isActive(_ i: Inputs) -> Bool {
-        i.enabledPreference
-            && i.noticeShown
+        // Explicit opt-outs always win, even over the force override.
+        if envFlagSet(i.doNotTrack) || envFlagSet(i.disableOverride) { return false }
+        guard i.enabledPreference else { return false }
+        // Developer/QA hatch: send from a dev or debug build without the notice.
+        if envFlagSet(i.forceOverride) { return true }
+        return i.noticeShown
             && !i.isDevelopmentBuild
             && !i.isDebugBuild
-            && !envFlagSet(i.doNotTrack)
-            && !envFlagSet(i.disableOverride)
     }
 
     /// Should the first-run notice be offered? True only when everything except

--- a/Sources/PelmetCore/Telemetry/TelemetryPayload.swift
+++ b/Sources/PelmetCore/Telemetry/TelemetryPayload.swift
@@ -137,7 +137,7 @@ public struct TelemetryPayload: Equatable {
         ]
     }
 
-    /// The request body for `POST https://eu.i.posthog.com/i/v0/e/`.
+    /// The request body for `POST https://us.i.posthog.com/i/v0/e/`.
     /// `.sortedKeys` makes the bytes deterministic (testable, cache-friendly).
     public func postHogBody(apiKey: String) throws -> Data {
         try JSONSerialization.data(

--- a/Sources/PelmetCore/Telemetry/TelemetryPayload.swift
+++ b/Sources/PelmetCore/Telemetry/TelemetryPayload.swift
@@ -1,0 +1,161 @@
+import Foundation
+
+/// A single JSON value in the telemetry payload. Deliberately closed to two
+/// cases (string, bool) so the payload can only ever hold coarse, non-personal
+/// facts. There is no `.int`, no `.dictionary`, no free-form `Any`: a field that
+/// does not fit these two shapes cannot be added without a code change here, and
+/// that change trips the schema test in `Tests/PelmetCoreTests`.
+public enum TelemetryValue: Equatable {
+    case string(String)
+    case bool(Bool)
+
+    /// The Foundation value handed to `JSONSerialization`. A Swift `Bool`
+    /// bridges to a boolean `NSNumber`, so it serializes as `true`/`false`
+    /// (never `0`/`1`).
+    var jsonValue: Any {
+        switch self {
+        case let .string(value): return value
+        case let .bool(value): return value
+        }
+    }
+}
+
+/// The one and only telemetry event Pelmet sends: an anonymous daily
+/// "heartbeat". This type is the single source of truth for what goes on the
+/// wire AND for the "what is sent" preview in Settings, so the two can never
+/// drift.
+///
+/// It is a frozen struct of named fields (no dictionaries, no `Any`), lives in
+/// `PelmetCore` with no UI or AppKit imports, and has no reference to the Shelf
+/// or `NSRunningApplication`: it is structurally impossible for a user's menu
+/// bar contents (the names of the other apps they run) to reach here. Adding or
+/// renaming a field is a deliberate act that fails `TelemetryPayloadTests`,
+/// which forces the `docs/TELEMETRY.md` + `CHANGELOG.md` update ritual.
+public struct TelemetryPayload: Equatable {
+
+    /// PostHog event name. One event type is enough: version adoption and
+    /// update events are derivable from the same event (a stable `distinctID`
+    /// whose `app_version` changes day over day).
+    public static let eventName = "heartbeat"
+
+    // MARK: Identity (top-level PostHog fields)
+
+    /// Random per-install UUID. Derived from nothing, resettable by the user.
+    public let distinctID: String
+    /// Event time; encoded as an ISO 8601 UTC string.
+    public let timestamp: Date
+
+    // MARK: Data fields (PostHog `properties`)
+
+    /// Marketing version only (`CFBundleShortVersionString`), e.g. "0.3.0".
+    public let appVersion: String
+    /// macOS major.minor only, e.g. "15.5". Never the patch or build.
+    public let macOS: String
+    /// "arm64" or "x86_64". Never the exact model identifier.
+    public let arch: String
+    /// Whether this Mac has a notched display (the one hardware fact the
+    /// product actually branches on).
+    public let notch: Bool
+    public let shelfEnabled: Bool
+    public let oneClickEnabled: Bool
+    public let autoRehide: Bool
+    /// Whether the user has ever actually hidden icons (tells a real user
+    /// apart from a bounced install).
+    public let managesItems: Bool
+    /// Whether the previous session ended cleanly. This is the entire crash
+    /// signal: a boolean, never a trace.
+    public let prevSessionClean: Bool
+
+    public init(
+        distinctID: String,
+        timestamp: Date,
+        appVersion: String,
+        macOS: String,
+        arch: String,
+        notch: Bool,
+        shelfEnabled: Bool,
+        oneClickEnabled: Bool,
+        autoRehide: Bool,
+        managesItems: Bool,
+        prevSessionClean: Bool
+    ) {
+        self.distinctID = distinctID
+        self.timestamp = timestamp
+        self.appVersion = appVersion
+        self.macOS = macOS
+        self.arch = arch
+        self.notch = notch
+        self.shelfEnabled = shelfEnabled
+        self.oneClickEnabled = oneClickEnabled
+        self.autoRehide = autoRehide
+        self.managesItems = managesItems
+        self.prevSessionClean = prevSessionClean
+    }
+
+    // MARK: - Serialization
+
+    /// The exact `properties` object sent to PostHog. The two `$`-prefixed keys
+    /// are PostHog privacy directives: `$process_person_profile: false` keeps
+    /// events anonymous (no person profile is ever created) and
+    /// `$geoip_disable: true` skips server-side geo lookup on top of the
+    /// project's "discard client IP" setting.
+    public var properties: [String: TelemetryValue] {
+        [
+            "$process_person_profile": .bool(false),
+            "$geoip_disable": .bool(true),
+            "app_version": .string(appVersion),
+            "macos": .string(macOS),
+            "arch": .string(arch),
+            "notch": .bool(notch),
+            "shelf_enabled": .bool(shelfEnabled),
+            "one_click_enabled": .bool(oneClickEnabled),
+            "auto_rehide": .bool(autoRehide),
+            "manages_items": .bool(managesItems),
+            "prev_session_clean": .bool(prevSessionClean),
+        ]
+    }
+
+    /// ISO 8601 UTC, e.g. "2026-07-13T00:04:11Z". Deterministic for a given
+    /// `timestamp` (fixed formatter, UTC), so the body is byte-stable and
+    /// unit-testable.
+    static func iso8601(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.timeZone = TimeZone(identifier: "UTC")
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.string(from: date)
+    }
+
+    private func eventObject(apiKey: String) -> [String: Any] {
+        var props: [String: Any] = [:]
+        for (key, value) in properties { props[key] = value.jsonValue }
+        return [
+            "api_key": apiKey,
+            "event": Self.eventName,
+            "distinct_id": distinctID,
+            "timestamp": Self.iso8601(timestamp),
+            "properties": props,
+        ]
+    }
+
+    /// The request body for `POST https://eu.i.posthog.com/i/v0/e/`.
+    /// `.sortedKeys` makes the bytes deterministic (testable, cache-friendly).
+    public func postHogBody(apiKey: String) throws -> Data {
+        try JSONSerialization.data(
+            withJSONObject: eventObject(apiKey: apiKey),
+            options: [.sortedKeys]
+        )
+    }
+
+    /// Human-readable JSON for the Settings "what exactly is sent" disclosure.
+    /// Built from the same object as the wire body, so the preview cannot lie
+    /// about what ships.
+    public func previewJSON(apiKey: String) -> String {
+        guard let data = try? JSONSerialization.data(
+            withJSONObject: eventObject(apiKey: apiKey),
+            options: [.prettyPrinted, .sortedKeys]
+        ), let string = String(data: data, encoding: .utf8) else {
+            return "{}"
+        }
+        return string
+    }
+}

--- a/Tests/PelmetCoreTests/HeartbeatScheduleTests.swift
+++ b/Tests/PelmetCoreTests/HeartbeatScheduleTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+@testable import PelmetCore
+
+struct HeartbeatScheduleTests {
+
+    // 2025-07-13T12:00:00Z
+    private let noon = Date(timeIntervalSince1970: 1_752_408_000)
+
+    @Test func testDayKeyIsUTC() {
+        #expect(HeartbeatSchedule.dayKey(for: Date(timeIntervalSince1970: 0)) == "1970-01-01")
+        #expect(HeartbeatSchedule.dayKey(for: noon) == "2025-07-13")
+    }
+
+    @Test func testSendsWhenNeverSent() {
+        #expect(HeartbeatSchedule.shouldSend(lastSentDay: nil, now: noon))
+    }
+
+    @Test func testBlocksSameDay() {
+        let today = HeartbeatSchedule.dayKey(for: noon)
+        #expect(!HeartbeatSchedule.shouldSend(lastSentDay: today, now: noon))
+    }
+
+    @Test func testSendsNextDay() {
+        #expect(HeartbeatSchedule.shouldSend(lastSentDay: "2025-07-12", now: noon))
+    }
+
+    /// The day boundary is UTC midnight, not local: 23:59Z and 00:01Z are
+    /// different days regardless of the machine's timezone.
+    @Test func testUTCBoundary() {
+        let justBefore = Date(timeIntervalSince1970: 1_752_364_740) // 2025-07-12T23:59:00Z
+        let justAfter = Date(timeIntervalSince1970: 1_752_364_860)  // 2025-07-13T00:01:00Z
+        #expect(HeartbeatSchedule.dayKey(for: justBefore) == "2025-07-12")
+        #expect(HeartbeatSchedule.dayKey(for: justAfter) == "2025-07-13")
+        // Sent just before midnight, a moment later it is a new day => send.
+        #expect(HeartbeatSchedule.shouldSend(lastSentDay: "2025-07-12", now: justAfter))
+    }
+
+    @Test func testCoolingOffPassesWhenNotShownThisSession() {
+        // Shown in a previous session (a launch has since happened).
+        #expect(HeartbeatSchedule.coolingOffElapsed(
+            noticeShownThisSession: false, noticeShownAt: nil, now: noon))
+        #expect(HeartbeatSchedule.coolingOffElapsed(
+            noticeShownThisSession: false, noticeShownAt: noon, now: noon))
+    }
+
+    @Test func testCoolingOffHoldsWithinDayOfShowing() {
+        let oneHourLater = noon.addingTimeInterval(3600)
+        #expect(!HeartbeatSchedule.coolingOffElapsed(
+            noticeShownThisSession: true, noticeShownAt: noon, now: oneHourLater))
+    }
+
+    @Test func testCoolingOffElapsesAfter24h() {
+        let dayLater = noon.addingTimeInterval(24 * 3600)
+        #expect(HeartbeatSchedule.coolingOffElapsed(
+            noticeShownThisSession: true, noticeShownAt: noon, now: dayLater))
+    }
+}

--- a/Tests/PelmetCoreTests/TelemetryGateTests.swift
+++ b/Tests/PelmetCoreTests/TelemetryGateTests.swift
@@ -1,0 +1,79 @@
+import Testing
+@testable import PelmetCore
+
+struct TelemetryGateTests {
+
+    /// All-clear inputs: enabled, notice shown, real release build, no env
+    /// overrides. Individual tests flip one field to prove it blocks alone.
+    private func clear(
+        enabledPreference: Bool = true,
+        noticeShown: Bool = true,
+        isDevelopmentBuild: Bool = false,
+        isDebugBuild: Bool = false,
+        doNotTrack: String? = nil,
+        disableOverride: String? = nil
+    ) -> TelemetryGate.Inputs {
+        TelemetryGate.Inputs(
+            enabledPreference: enabledPreference,
+            noticeShown: noticeShown,
+            isDevelopmentBuild: isDevelopmentBuild,
+            isDebugBuild: isDebugBuild,
+            doNotTrack: doNotTrack,
+            disableOverride: disableOverride
+        )
+    }
+
+    @Test func testActiveWhenAllClear() {
+        #expect(TelemetryGate.isActive(clear()))
+    }
+
+    @Test func testEachFactorBlocksAlone() {
+        #expect(!TelemetryGate.isActive(clear(enabledPreference: false)))
+        #expect(!TelemetryGate.isActive(clear(noticeShown: false)))
+        #expect(!TelemetryGate.isActive(clear(isDevelopmentBuild: true)))
+        #expect(!TelemetryGate.isActive(clear(isDebugBuild: true)))
+        #expect(!TelemetryGate.isActive(clear(doNotTrack: "1")))
+        #expect(!TelemetryGate.isActive(clear(disableOverride: "1")))
+    }
+
+    @Test func testDoNotTrackWins() {
+        // Enabled and notice shown, but DO_NOT_TRACK overrides everything.
+        #expect(!TelemetryGate.isActive(clear(doNotTrack: "true")))
+        #expect(!TelemetryGate.isActive(clear(doNotTrack: "yes")))
+    }
+
+    @Test func testEnvFlagZeroOrEmptyDoesNotBlock() {
+        #expect(TelemetryGate.isActive(clear(doNotTrack: "0")))
+        #expect(TelemetryGate.isActive(clear(doNotTrack: "")))
+        #expect(TelemetryGate.isActive(clear(doNotTrack: "   ")))
+        #expect(TelemetryGate.isActive(clear(disableOverride: "0")))
+    }
+
+    @Test func testEnvFlagSetHelper() {
+        #expect(TelemetryGate.envFlagSet("1"))
+        #expect(TelemetryGate.envFlagSet("true"))
+        #expect(!TelemetryGate.envFlagSet(nil))
+        #expect(!TelemetryGate.envFlagSet(""))
+        #expect(!TelemetryGate.envFlagSet("0"))
+        #expect(!TelemetryGate.envFlagSet(" 0 "))
+    }
+
+    @Test func testShouldOfferNoticeOnlyBeforeNoticeShown() {
+        #expect(TelemetryGate.shouldOfferNotice(clear(noticeShown: false)))
+        // Already shown: never re-offer.
+        #expect(!TelemetryGate.shouldOfferNotice(clear(noticeShown: true)))
+    }
+
+    @Test func testShouldNotOfferNoticeToOptedOutOrSilencedBuilds() {
+        // A user who set the pref off (via defaults write) before first launch
+        // must not be nagged with a notice about data we will never send.
+        #expect(!TelemetryGate.shouldOfferNotice(clear(enabledPreference: false, noticeShown: false)))
+        #expect(!TelemetryGate.shouldOfferNotice(clear(noticeShown: false, isDevelopmentBuild: true)))
+        #expect(!TelemetryGate.shouldOfferNotice(clear(noticeShown: false, isDebugBuild: true)))
+        #expect(!TelemetryGate.shouldOfferNotice(clear(noticeShown: false, doNotTrack: "1")))
+    }
+
+    @Test func testNoticeShownButDisabledStaysInactive() {
+        #expect(!TelemetryGate.isActive(clear(enabledPreference: false, noticeShown: true)))
+    }
+}

--- a/Tests/PelmetCoreTests/TelemetryGateTests.swift
+++ b/Tests/PelmetCoreTests/TelemetryGateTests.swift
@@ -11,7 +11,8 @@ struct TelemetryGateTests {
         isDevelopmentBuild: Bool = false,
         isDebugBuild: Bool = false,
         doNotTrack: String? = nil,
-        disableOverride: String? = nil
+        disableOverride: String? = nil,
+        forceOverride: String? = nil
     ) -> TelemetryGate.Inputs {
         TelemetryGate.Inputs(
             enabledPreference: enabledPreference,
@@ -19,7 +20,8 @@ struct TelemetryGateTests {
             isDevelopmentBuild: isDevelopmentBuild,
             isDebugBuild: isDebugBuild,
             doNotTrack: doNotTrack,
-            disableOverride: disableOverride
+            disableOverride: disableOverride,
+            forceOverride: forceOverride
         )
     }
 
@@ -75,5 +77,28 @@ struct TelemetryGateTests {
 
     @Test func testNoticeShownButDisabledStaysInactive() {
         #expect(!TelemetryGate.isActive(clear(enabledPreference: false, noticeShown: true)))
+    }
+
+    @Test func testForceOverrideUnlocksDevAndDebugAndNotice() {
+        // A local `swift run` (dev + debug build, no notice shown) sends when
+        // PELMET_FORCE_TELEMETRY is set.
+        #expect(TelemetryGate.isActive(clear(
+            noticeShown: false,
+            isDevelopmentBuild: true,
+            isDebugBuild: true,
+            forceOverride: "1"
+        )))
+    }
+
+    @Test func testForceOverrideNeverBeatsExplicitOptOut() {
+        // Force yields to DO_NOT_TRACK, the disable override, and an off preference.
+        #expect(!TelemetryGate.isActive(clear(isDebugBuild: true, doNotTrack: "1", forceOverride: "1")))
+        #expect(!TelemetryGate.isActive(clear(isDebugBuild: true, disableOverride: "1", forceOverride: "1")))
+        #expect(!TelemetryGate.isActive(clear(enabledPreference: false, isDebugBuild: true, forceOverride: "1")))
+    }
+
+    @Test func testForceOverrideUnsetOrZeroDoesNotUnlock() {
+        #expect(!TelemetryGate.isActive(clear(isDebugBuild: true, forceOverride: "0")))
+        #expect(!TelemetryGate.isActive(clear(isDebugBuild: true, forceOverride: nil)))
     }
 }

--- a/Tests/PelmetCoreTests/TelemetryPayloadTests.swift
+++ b/Tests/PelmetCoreTests/TelemetryPayloadTests.swift
@@ -1,0 +1,110 @@
+import Foundation
+import Testing
+@testable import PelmetCore
+
+struct TelemetryPayloadTests {
+
+    private func samplePayload(
+        prevSessionClean: Bool = true
+    ) -> TelemetryPayload {
+        TelemetryPayload(
+            distinctID: "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d",
+            timestamp: Date(timeIntervalSince1970: 1_752_364_800), // 2025-07-13T00:00:00Z
+            appVersion: "0.3.0",
+            macOS: "15.5",
+            arch: "arm64",
+            notch: true,
+            shelfEnabled: true,
+            oneClickEnabled: false,
+            autoRehide: true,
+            managesItems: true,
+            prevSessionClean: prevSessionClean
+        )
+    }
+
+    /// The heart of the "no field creep, nothing leaks" guarantee: the wire
+    /// payload's key set is exactly this and nothing more. If someone adds a
+    /// field to `TelemetryPayload` this test fails, forcing the TELEMETRY.md +
+    /// CHANGELOG update. If the field were ever something about the user's menu
+    /// bar, this is where it would be caught.
+    @Test func testExactPropertyKeySet() throws {
+        let body = try samplePayload().postHogBody(apiKey: "phc_test")
+        let json = try JSONSerialization.jsonObject(with: body) as! [String: Any]
+        let properties = json["properties"] as! [String: Any]
+
+        let expected: Set<String> = [
+            "$process_person_profile", "$geoip_disable",
+            "app_version", "macos", "arch", "notch",
+            "shelf_enabled", "one_click_enabled", "auto_rehide",
+            "manages_items", "prev_session_clean",
+        ]
+        #expect(Set(properties.keys) == expected)
+
+        // Top level: exactly the four PostHog envelope fields.
+        #expect(Set(json.keys) == ["api_key", "event", "distinct_id", "timestamp", "properties"])
+    }
+
+    @Test func testAnonymityAndGeoFlags() throws {
+        let body = try samplePayload().postHogBody(apiKey: "phc_test")
+        let json = try JSONSerialization.jsonObject(with: body) as! [String: Any]
+        let properties = json["properties"] as! [String: Any]
+
+        #expect(properties["$process_person_profile"] as? Bool == false)
+        #expect(properties["$geoip_disable"] as? Bool == true)
+    }
+
+    @Test func testEnvelopeFields() throws {
+        let body = try samplePayload().postHogBody(apiKey: "phc_secret")
+        let json = try JSONSerialization.jsonObject(with: body) as! [String: Any]
+
+        #expect(json["api_key"] as? String == "phc_secret")
+        #expect(json["event"] as? String == "heartbeat")
+        #expect(json["distinct_id"] as? String == "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d")
+        #expect(json["timestamp"] as? String == "2025-07-13T00:00:00Z")
+    }
+
+    @Test func testDataFieldsPassThrough() throws {
+        let body = try samplePayload(prevSessionClean: false).postHogBody(apiKey: "k")
+        let json = try JSONSerialization.jsonObject(with: body) as! [String: Any]
+        let properties = json["properties"] as! [String: Any]
+
+        #expect(properties["app_version"] as? String == "0.3.0")
+        #expect(properties["macos"] as? String == "15.5")
+        #expect(properties["arch"] as? String == "arm64")
+        #expect(properties["notch"] as? Bool == true)
+        #expect(properties["shelf_enabled"] as? Bool == true)
+        #expect(properties["one_click_enabled"] as? Bool == false)
+        #expect(properties["auto_rehide"] as? Bool == true)
+        #expect(properties["manages_items"] as? Bool == true)
+        #expect(properties["prev_session_clean"] as? Bool == false)
+    }
+
+    /// Booleans must serialize as JSON `true`/`false`, never `0`/`1`.
+    @Test func testBooleansAreJSONBooleans() throws {
+        let body = try samplePayload().postHogBody(apiKey: "k")
+        let text = String(data: body, encoding: .utf8)!
+        #expect(text.contains("\"notch\":true"))
+        #expect(text.contains("\"$process_person_profile\":false"))
+        #expect(!text.contains("\"notch\":1"))
+    }
+
+    /// Deterministic bytes: same payload encodes identically every time.
+    @Test func testDeterministicEncoding() throws {
+        let a = try samplePayload().postHogBody(apiKey: "k")
+        let b = try samplePayload().postHogBody(apiKey: "k")
+        #expect(a == b)
+    }
+
+    @Test func testPreviewJSONIsReadableAndHonest() {
+        let preview = samplePayload().previewJSON(apiKey: "phc_test")
+        // Pretty-printed (has newlines) and shows the real field names.
+        #expect(preview.contains("\n"))
+        #expect(preview.contains("prev_session_clean"))
+        #expect(preview.contains("heartbeat"))
+    }
+
+    @Test func testISO8601IsUTC() {
+        let date = Date(timeIntervalSince1970: 0)
+        #expect(TelemetryPayload.iso8601(date) == "1970-01-01T00:00:00Z")
+    }
+}

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -1,0 +1,151 @@
+# Telemetry
+
+**TL;DR**
+
+- One anonymous event per day. That is the entire event stream.
+- Opt-out: an in-app notice appears before anything is ever sent.
+- Data: app version, macOS version (major.minor), `arm64` or `x86_64`, notch
+  yes/no, a handful of feature on/off booleans, whether the previous session
+  ended cleanly, and a random resettable install ID.
+- Destination: PostHog Cloud EU (Frankfurt). IP addresses are discarded.
+- Off switches: the Settings toggle, one `defaults` command, or `DO_NOT_TRACK=1`.
+
+## Why we collect anything
+
+Pelmet ships outside the App Store, so there is no dashboard telling us how many
+people run it, which macOS versions to keep supporting, or which features earn
+their maintenance. One tiny event per day answers all of that: an install count,
+version adoption, the macOS and chip spread, which features are switched on, and
+a crash rate. That is why there is nothing else here.
+
+## Exactly what is sent
+
+A single `heartbeat` event, at most once per UTC day, as a plain HTTPS `POST` to
+`https://eu.i.posthog.com/i/v0/e/`:
+
+```json
+{
+  "api_key": "<public write-only project key>",
+  "event": "heartbeat",
+  "distinct_id": "9b1deb4d-3b7d-4bad-9bdd-2b0d7b3dcb6d",
+  "timestamp": "2026-07-13T00:04:11Z",
+  "properties": {
+    "$process_person_profile": false,
+    "$geoip_disable": true,
+    "app_version": "0.3.0",
+    "macos": "15.5",
+    "arch": "arm64",
+    "notch": true,
+    "shelf_enabled": true,
+    "one_click_enabled": false,
+    "auto_rehide": true,
+    "manages_items": true,
+    "prev_session_clean": true
+  }
+}
+```
+
+The exact same JSON is visible live in **Settings > General > Privacy > "What
+exactly is sent?"**, rendered from the same code that builds the wire payload,
+so the preview cannot drift from reality.
+
+| Field | Example | Why we need it |
+|---|---|---|
+| `distinct_id` | random UUID | Count one Mac once per day/month. Derived from nothing, resettable. |
+| `app_version` | `0.3.0` | Version adoption; deciding when an old version can be dropped. |
+| `macos` | `15.5` | Which macOS versions to keep supporting. Major.minor only. |
+| `arch` | `arm64` | Apple silicon vs Intel split. |
+| `notch` | `true` | Whether notch-specific features matter to real users. |
+| `shelf_enabled` | `true` | Is the Shelf used? |
+| `one_click_enabled` | `false` | Is the opt-in Accessibility feature used? |
+| `auto_rehide` | `true` | Is auto re-hide left on? |
+| `manages_items` | `true` | Has this install ever actually hidden icons? |
+| `prev_session_clean` | `true` | Crash rate: did the previous session end cleanly? |
+| `$process_person_profile` | `false` | PostHog directive: never build a person profile (stay anonymous). |
+| `$geoip_disable` | `true` | PostHog directive: skip server-side geo lookup. |
+
+## What we NEVER collect
+
+- **Your IP address** is discarded on arrival and geo lookup is disabled; we
+  never see or store it.
+- **No names, emails, usernames, or device names.**
+- **No file paths, filenames, or window titles.**
+- **Nothing about your menu bar contents**: not the names, not the count, not the
+  icons of the apps you run. Pelmet's Shelf reads other apps' names locally to
+  draw its rows; that data never enters telemetry. The payload is a fixed struct
+  and a unit test fails the build if a field is added without updating this
+  document.
+- **No unique hardware identifiers**: no serial number, no exact model
+  identifier, no MAC address.
+- **No location, locale, or timezone.**
+- **No behavioral stream**: no clicks, no timings, no session lengths, no hotkey
+  usage.
+
+## When it is sent
+
+Once per UTC day, checked at launch and hourly while running. The very first send
+only happens after the in-app notice has been shown, and never sooner than the
+next launch or 24 hours after you saw it, whichever comes first, so you always
+have a real window to turn it off first.
+
+## The install ID
+
+A random UUID that Pelmet invents on the first send, derived from nothing about
+you or your Mac. It exists only so one install counts once per day and month. You
+can generate a fresh one any time with **Settings > General > Privacy > "Reset
+Install ID"**; resetting unlinks all past pings from the new one. Turning
+telemetry off forgets the ID entirely.
+
+## Where the data goes
+
+PostHog Cloud EU, hosted in Frankfurt. The request is a plain HTTPS `POST`; there
+is no SDK. The API key embedded in the source is a public, write-only ingestion
+token: it can only send events, never read anything back. Events are flagged so
+PostHog creates no person profiles, and the project is configured to discard
+client IPs.
+
+## Retention
+
+Raw events are deleted after at most 12 months. We work from aggregates.
+
+## Public numbers
+
+The dashboard built from this data is shared publicly (link to be added with the
+0.3.0 release), so you can see exactly what we see.
+
+## How to turn it off
+
+1. **Settings > General > Privacy > "Share anonymous usage statistics".**
+2. `defaults write com.ismatbabirli.Pelmet telemetryEnabled -bool NO`
+   (works before first launch too).
+3. Set `DO_NOT_TRACK=1` in the app's environment. Note: apps launched from Finder
+   do not inherit your shell profile, so use `launchctl setenv DO_NOT_TRACK 1` or
+   the `defaults` command above.
+
+Also: `swift run` and debug builds never send anything, and blocking
+`eu.i.posthog.com` (Little Snitch, Pi-hole, a firewall) blocks it entirely and
+silently.
+
+## Crash reports stay on your Mac
+
+Pelmet never uploads crash data. After a crash, the next launch offers to open a
+GitHub issue prefilled with your Pelmet and macOS versions, and reveals the crash
+report (`.ips`) in Finder so you can look it over and attach it yourself, or just
+close the tab. The daily ping carries a single boolean, `prev_session_clean`, and
+nothing from the trace.
+
+## The sending code
+
+- [`Sources/PelmetCore/Telemetry/TelemetryPayload.swift`](../Sources/PelmetCore/Telemetry/TelemetryPayload.swift):
+  the frozen payload struct and its JSON encoding.
+- [`Sources/Pelmet/Telemetry/TelemetryManager.swift`](../Sources/Pelmet/Telemetry/TelemetryManager.swift):
+  the gates and the one `URLSession` call.
+- [`Tests/PelmetCoreTests/TelemetryPayloadTests.swift`](../Tests/PelmetCoreTests/TelemetryPayloadTests.swift):
+  the schema test that pins the exact field set.
+
+## Changes
+
+Any new or changed field requires a change to this file and a `CHANGELOG.md`
+entry in the same pull request. That rule is written into `CONTRIBUTING.md`, and
+the schema test above fails the build if the payload and this document drift
+apart.

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -108,11 +108,6 @@ client IPs.
 
 Raw events are deleted after at most 12 months. We work from aggregates.
 
-## Public numbers
-
-The dashboard built from this data is shared publicly (link to be added with the
-0.3.0 release), so you can see exactly what we see.
-
 ## How to turn it off
 
 1. **Settings > General > Privacy > "Share anonymous usage statistics".**

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -7,7 +7,7 @@
 - Data: app version, macOS version (major.minor), `arm64` or `x86_64`, notch
   yes/no, a handful of feature on/off booleans, whether the previous session
   ended cleanly, and a random resettable install ID.
-- Destination: PostHog Cloud EU (Frankfurt). IP addresses are discarded.
+- Destination: PostHog Cloud US. IP addresses are discarded.
 - Off switches: the Settings toggle, one `defaults` command, or `DO_NOT_TRACK=1`.
 
 ## Why we collect anything
@@ -21,7 +21,7 @@ a crash rate. That is why there is nothing else here.
 ## Exactly what is sent
 
 A single `heartbeat` event, at most once per UTC day, as a plain HTTPS `POST` to
-`https://eu.i.posthog.com/i/v0/e/`:
+`https://us.i.posthog.com/i/v0/e/`:
 
 ```json
 {
@@ -98,7 +98,7 @@ telemetry off forgets the ID entirely.
 
 ## Where the data goes
 
-PostHog Cloud EU, hosted in Frankfurt. The request is a plain HTTPS `POST`; there
+PostHog Cloud US. The request is a plain HTTPS `POST`; there
 is no SDK. The API key embedded in the source is a public, write-only ingestion
 token: it can only send events, never read anything back. Events are flagged so
 PostHog creates no person profiles, and the project is configured to discard
@@ -123,7 +123,7 @@ The dashboard built from this data is shared publicly (link to be added with the
    the `defaults` command above.
 
 Also: `swift run` and debug builds never send anything, and blocking
-`eu.i.posthog.com` (Little Snitch, Pi-hole, a firewall) blocks it entirely and
+`us.i.posthog.com` (Little Snitch, Pi-hole, a firewall) blocks it entirely and
 silently.
 
 ## Crash reports stay on your Mac

--- a/docs/TELEMETRY.md
+++ b/docs/TELEMETRY.md
@@ -122,7 +122,8 @@ The dashboard built from this data is shared publicly (link to be added with the
    do not inherit your shell profile, so use `launchctl setenv DO_NOT_TRACK 1` or
    the `defaults` command above.
 
-Also: `swift run` and debug builds never send anything, and blocking
+Also: `swift run` and debug builds never send anything (unless a developer
+deliberately sets `PELMET_FORCE_TELEMETRY` to test the send path), and blocking
 `us.i.posthog.com` (Little Snitch, Pi-hole, a firewall) blocks it entirely and
 silently.
 

--- a/docs/shelf-verification.md
+++ b/docs/shelf-verification.md
@@ -76,3 +76,21 @@ On a notched Mac:
     slide/fade. Reduce Transparency → the panel draws opaque.
 21. `PELMET_DEBUG_LAYOUT=verbose swift run` → no repeating republish loop from
     PID-only churn (the digest ignores owner changes).
+
+## Telemetry (anonymous daily ping)
+
+22. **Dry run, nothing sent.** `PELMET_DEBUG_TELEMETRY=verbose swift run` → prints
+    the gate decision and the exact JSON payload to stdout, and `active=false`
+    (a `swift run` dev build is inert). Confirms the payload shape without a send.
+23. **Kill switch.** `PELMET_DISABLE_TELEMETRY=1` or `DO_NOT_TRACK=1` → the verbose
+    trace shows `active=false`; the Settings toggle renders off and disabled under
+    `DO_NOT_TRACK`.
+24. **Inert Debug bundle.** In the XcodeGen Debug `.app`, telemetry stays off via
+    `#if DEBUG` even though the bundle has a real version. Only a Release build with
+    a real PostHog key (see `docs/TELEMETRY.md`) actually sends.
+25. **First-run notice.** On a fresh profile the "Anonymous usage statistics" notice
+    appears once, after the welcome tip, and does not stack on Sparkle's prompt.
+    "Turn Off" flips the Settings toggle; nothing sends during that session.
+26. **Crash follow-up (local only).** `kill -TRAP <pid>` a Release build, relaunch →
+    the "Pelmet quit unexpectedly" alert offers a prefilled GitHub issue and reveals
+    the newest `Pelmet-*.ips` in Finder. A normal quit or Ctrl-C does not trigger it.

--- a/docs/shelf-verification.md
+++ b/docs/shelf-verification.md
@@ -82,6 +82,11 @@ On a notched Mac:
 22. **Dry run, nothing sent.** `PELMET_DEBUG_TELEMETRY=verbose swift run` → prints
     the gate decision and the exact JSON payload to stdout, and `active=false`
     (a `swift run` dev build is inert). Confirms the payload shape without a send.
+    To actually send one from local for an end-to-end check, add
+    `PELMET_FORCE_TELEMETRY=1` (developer hatch: unlocks the dev/debug/notice gates
+    only, never beats `DO_NOT_TRACK`, `PELMET_DISABLE_TELEMETRY`, or an off
+    preference). The day is recorded on success, so re-sending the same day needs
+    `defaults delete com.ismatbabirli.Pelmet telemetryLastHeartbeatDay` first.
 23. **Kill switch.** `PELMET_DISABLE_TELEMETRY=1` or `DO_NOT_TRACK=1` → the verbose
     trace shows `active=false`; the Settings toggle renders off and disabled under
     `DO_NOT_TRACK`.


### PR DESCRIPTION
## What & why

Pelmet ships outside the App Store with no way to know how many people use it, which macOS versions to keep supporting, or which features earn maintenance, so this adds one anonymous daily "heartbeat" to PostHog EU (raw `URLSession`, no SDK, no new dependency) carrying app version, macOS major.minor, arch, notch, a few feature booleans, and a `prev_session_clean` flag. It is opt-out but sends nothing until a first-run notice is shown, with easy off switches (Settings toggle, `defaults write`, `DO_NOT_TRACK=1`), IP discarding, no person profiles, and a frozen payload struct plus schema test so nothing about the user's menu bar can leak in. Crash handling stays fully local: an unclean prior exit is detected and the next launch offers a prefilled GitHub issue the user reviews and submits themselves, and the previously documented "no analytics" invariant is amended across the docs with a new `docs/TELEMETRY.md` covering every field and off switch.

## How I tested it

`swift build` and the full `swift test` suite (132 tests, incl. new gate/schedule/payload suites) pass; `PELMET_DEBUG_TELEMETRY=verbose swift run` confirms the app is inert in dev builds and prints the exact payload without sending. Note before release: the PostHog project key is a placeholder (`isConfigured` keeps sending off until it is swapped), and the public dashboard link in `docs/TELEMETRY.md` is still a TODO.