### PR TITLE
Fix telemetry notice delivery for collapsed upgrades

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-07-21
+
+### Fixed
+
+- The anonymous usage notice now appears for existing users who upgrade while
+  Pelmet is collapsed, so telemetry can start after the required disclosure
+  instead of remaining inactive indefinitely. The notice also has a fallback
+  when menu bar layout measurement does not produce a confirmed snapshot.
+
 ## [0.3.0] - 2026-07-19
 
 ### Added
@@ -99,7 +108,8 @@ First public release — the working MVP.
 - Requires **macOS 13 Ventura** or later.
 - The core hide/show experience needs **zero special permissions**.
 
-[Unreleased]: https://github.com/ismatBabirli/pelmet/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/ismatBabirli/pelmet/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/ismatBabirli/pelmet/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/ismatBabirli/pelmet/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/ismatBabirli/pelmet/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/ismatBabirli/pelmet/releases/tag/v0.1.0

--- a/Sources/Pelmet/MenuBarManager.swift
+++ b/Sources/Pelmet/MenuBarManager.swift
@@ -54,9 +54,9 @@ final class MenuBarManager: NSObject {
     private var toggleRescueAttempts = 0
     private var lastToggleRescue = Date.distantPast
 
-    /// One-shot fallback so first-run onboarding isn't hostage to a confirmed
+    /// One-shot fallback so pending onboarding isn't hostage to a confirmed
     /// layout that a busy bar may never produce.
-    private var firstRunWelcomeTimer: Timer?
+    private var onboardingFallbackTimer: Timer?
 
     /// The Shelf's seam to the opt-in activation machinery. Always present;
     /// degrades honestly when the Accessibility grant is absent.
@@ -137,17 +137,20 @@ final class MenuBarManager: NSObject {
         }
 
         NotchLayoutMonitor.shared.requestMeasurement(reason: .launch)
-        armFirstRunWelcomeFallback()
+        armOnboardingFallback()
     }
 
     /// If the layout never settles into a confirmed classification, `apply()`
-    /// never fires and onboarding would never run. After a short delay, drive
-    /// the checks directly — `maybeShowLaunchTips`/`maybeOfferOneClick` are
-    /// layout-independent and the `didShowToggleTip`/`didOfferOneClick` gates
-    /// keep this idempotent with the confirmed path.
-    private func armFirstRunWelcomeFallback() {
-        guard !Preferences.didShowToggleTip else { return }
-        firstRunWelcomeTimer = Timer.scheduledTimer(
+    /// never fires and pending onboarding would never run. This includes an
+    /// existing user who completed the welcome before a later release added the
+    /// telemetry notice. The presenters' persisted gates keep the fallback
+    /// idempotent with the confirmed path.
+    private func armOnboardingFallback() {
+        guard OnboardingCheckPlan.shouldArmFallback(
+            welcomeTipShown: Preferences.didShowToggleTip,
+            telemetryNoticeNeeded: TelemetryManager.shared.needsFirstRunNotice
+        ) else { return }
+        onboardingFallbackTimer = Timer.scheduledTimer(
             withTimeInterval: 4, repeats: false
         ) { [weak self] _ in
             self?.reapplyOnboardingChecks()
@@ -283,7 +286,6 @@ final class MenuBarManager: NSObject {
     /// Called on every confirmed snapshot and again when a tip closes (the
     /// tips chain: divider → toggle → count education).
     func reapplyOnboardingChecks() {
-        guard !isCollapsed else { return }
         // The welcome and the one-click offer are layout-independent, so they
         // still run before any classification confirms (a busy just-logged-in
         // bar may never settle). Swallowed-education needs a real count.
@@ -291,13 +293,21 @@ final class MenuBarManager: NSObject {
         // Toggle-anchored tips wait for a visible toggle — a popover anchored
         // to a notch-swallowed or just-recreated button shows detached.
         let toggleOK = classification?.toggleVisible ?? true
-        OnboardingController.shared.maybeShowLaunchTips(
-            separator: separatorItem,
-            toggle: toggleItem,
-            separatorVisible: classification?.separatorHealth == .visible,
+        let plan = OnboardingCheckPlan(
+            isCollapsed: isCollapsed,
+            hasClassification: classification != nil,
             toggleVisible: toggleOK
         )
-        if let classification, toggleOK {
+
+        if plan.attemptLaunchTips {
+            OnboardingController.shared.maybeShowLaunchTips(
+                separator: separatorItem,
+                toggle: toggleItem,
+                separatorVisible: classification?.separatorHealth == .visible,
+                toggleVisible: toggleOK
+            )
+        }
+        if plan.attemptLayoutEducation, let classification {
             OnboardingController.shared.maybeShowSwallowedEducation(
                 count: classification.swallowedCount,
                 toggle: toggleItem
@@ -307,12 +317,13 @@ final class MenuBarManager: NSObject {
                 toggle: toggleItem
             )
         }
-        if toggleOK {
-            // After the welcome, before the one-click pitch: the privacy notice
-            // is the next thing a new user sees. Each call is gated on
-            // activePopover == nil and its own one-shot flag, so only one shows
-            // per pass; the chain re-fires when a popover closes.
+        // After the welcome, before the one-click pitch: the privacy notice is
+        // the next thing a new user sees. For an existing user it also runs
+        // while collapsed, because the notice anchors to the visible toggle.
+        if plan.attemptTelemetryNotice {
             OnboardingController.shared.maybeShowTelemetryNotice(toggle: toggleItem)
+        }
+        if plan.attemptOneClickOffer {
             OnboardingController.shared.maybeOfferOneClick(toggle: toggleItem)
         }
     }

--- a/Sources/PelmetCore/OnboardingCheckPlan.swift
+++ b/Sources/PelmetCore/OnboardingCheckPlan.swift
@@ -1,0 +1,34 @@
+/// Describes which one-time onboarding checks the AppKit layer should attempt
+/// for its current menu bar state. The individual presenters still own their
+/// persisted one-shot gates; this plan only keeps UI state from starving a
+/// presenter that is safe to run.
+public struct OnboardingCheckPlan: Equatable {
+
+    public let attemptLaunchTips: Bool
+    public let attemptLayoutEducation: Bool
+    public let attemptTelemetryNotice: Bool
+    public let attemptOneClickOffer: Bool
+
+    public init(isCollapsed: Bool, hasClassification: Bool, toggleVisible: Bool) {
+        attemptLaunchTips = !isCollapsed
+        attemptLayoutEducation = !isCollapsed && hasClassification && toggleVisible
+
+        // The privacy notice anchors to the always-visible toggle and must not
+        // depend on the managed icons being expanded. Existing users commonly
+        // upgrade while Pelmet is collapsed.
+        attemptTelemetryNotice = toggleVisible
+
+        // Keep the optional feature pitch in the expanded onboarding sequence.
+        attemptOneClickOffer = !isCollapsed && toggleVisible
+    }
+
+    /// A confirmed layout normally drives onboarding. The fallback is also
+    /// required when an existing user has completed the welcome but still needs
+    /// a newly introduced privacy notice.
+    public static func shouldArmFallback(
+        welcomeTipShown: Bool,
+        telemetryNoticeNeeded: Bool
+    ) -> Bool {
+        !welcomeTipShown || telemetryNoticeNeeded
+    }
+}

--- a/Tests/PelmetCoreTests/OnboardingCheckPlanTests.swift
+++ b/Tests/PelmetCoreTests/OnboardingCheckPlanTests.swift
@@ -1,0 +1,57 @@
+import Testing
+@testable import PelmetCore
+
+struct OnboardingCheckPlanTests {
+
+    @Test func testCollapsedUpgradeWithoutClassificationStillAttemptsTelemetryNotice() {
+        let plan = OnboardingCheckPlan(
+            isCollapsed: true,
+            hasClassification: false,
+            toggleVisible: true
+        )
+
+        #expect(plan.attemptTelemetryNotice)
+        #expect(!plan.attemptLaunchTips)
+        #expect(!plan.attemptLayoutEducation)
+        #expect(!plan.attemptOneClickOffer)
+    }
+
+    @Test func testInvisibleToggleDefersEveryToggleAnchoredCheck() {
+        let plan = OnboardingCheckPlan(
+            isCollapsed: true,
+            hasClassification: true,
+            toggleVisible: false
+        )
+
+        #expect(!plan.attemptTelemetryNotice)
+        #expect(!plan.attemptOneClickOffer)
+    }
+
+    @Test func testExpandedOnboardingSequenceIsPreserved() {
+        let plan = OnboardingCheckPlan(
+            isCollapsed: false,
+            hasClassification: true,
+            toggleVisible: true
+        )
+
+        #expect(plan.attemptLaunchTips)
+        #expect(plan.attemptLayoutEducation)
+        #expect(plan.attemptTelemetryNotice)
+        #expect(plan.attemptOneClickOffer)
+    }
+
+    @Test func testTelemetryUpgradeArmsFallbackAfterWelcomeCompleted() {
+        #expect(OnboardingCheckPlan.shouldArmFallback(
+            welcomeTipShown: true,
+            telemetryNoticeNeeded: true
+        ))
+        #expect(OnboardingCheckPlan.shouldArmFallback(
+            welcomeTipShown: false,
+            telemetryNoticeNeeded: false
+        ))
+        #expect(!OnboardingCheckPlan.shouldArmFallback(
+            welcomeTipShown: true,
+            telemetryNoticeNeeded: false
+        ))
+    }
+}


### PR DESCRIPTION
## What & why

Fix the anonymous usage notice for existing users who upgrade while Pelmet is
already collapsed. The root cause was an early return in the onboarding pass,
which prevented the privacy notice from ever being attempted and left telemetry
inactive indefinitely.

This change:

- moves onboarding routing into a small, unit-tested `OnboardingCheckPlan`
- allows only the privacy notice to run while Pelmet is collapsed
- arms the fallback pass when an upgraded user needs the notice even after
  completing the original welcome
- preserves the expanded onboarding sequence and hidden-toggle safety checks
- prepares the changelog for patch release `0.3.1`

The telemetry payload, project token, endpoint, consent gate, and cooling-off
behavior are unchanged. No release tag is created by this PR.

## How I tested it

- `swiftformat .`
- `git diff --check`
- `swift test --filter OnboardingCheckPlanTests` (4 tests passed)
- `swift test` (139 tests passed)
- `xcodegen generate`
- Debug app-bundle build with `CODE_SIGNING_ALLOWED=NO`
- Release app-bundle build with `CODE_SIGNING_ALLOWED=NO`

A live production telemetry send was intentionally not triggered during
verification.
