### PR TITLE
Add What's New window after app updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,4 +59,9 @@ jobs:
             -scheme Pelmet \
             -configuration Debug \
             -destination 'platform=macOS' \
+            -derivedDataPath build \
             CODE_SIGNING_ALLOWED=NO
+      - name: Verify bundled changelog
+        run: |
+          APP="$PWD/build/Build/Products/Debug/Pelmet.app"
+          test -s "$APP/Contents/Resources/CHANGELOG.md"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,35 @@ jobs:
           echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
           echo "Building version $VERSION (dry_run=$DRY_RUN)"
 
+      - name: Validate versioned changelog entry
+        env:
+          VERSION: ${{ steps.v.outputs.version }}
+        run: |
+          SEMVER_RE='^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$'
+          if [[ ! "$VERSION" =~ $SEMVER_RE ]]; then
+            echo "Release version is not valid Semantic Versioning: $VERSION"
+            exit 1
+          fi
+          if [[ "$VERSION" == *-* ]]; then
+            PRERELEASE="${VERSION#*-}"
+            PRERELEASE="${PRERELEASE%%+*}"
+            IFS='.' read -r -a IDENTIFIERS <<< "$PRERELEASE"
+            for IDENTIFIER in "${IDENTIFIERS[@]}"; do
+              if [[ "$IDENTIFIER" =~ ^[0-9]+$ && ${#IDENTIFIER} -gt 1 && "$IDENTIFIER" == 0* ]]; then
+                echo "Numeric prerelease identifiers cannot have leading zeroes: $IDENTIFIER"
+                exit 1
+              fi
+            done
+          fi
+          if ! awk -v prefix="## [$VERSION]" '
+            $0 == prefix || index($0, prefix " - ") == 1 { found = 1 }
+            END { exit(found ? 0 : 1) }
+          ' CHANGELOG.md; then
+            echo "CHANGELOG.md has no exact version heading for $VERSION"
+            echo "Move Unreleased changes under ## [$VERSION] - YYYY-MM-DD before tagging."
+            exit 1
+          fi
+
       - name: Pin version into project.yml
         env:
           VERSION: ${{ steps.v.outputs.version }}
@@ -69,6 +98,11 @@ jobs:
             -derivedDataPath build \
             CODE_SIGNING_ALLOWED=NO
           echo "APP=$PWD/build/Build/Products/Release/Pelmet.app" >> "$GITHUB_ENV"
+
+      - name: Verify bundled changelog
+        run: |
+          test -s "$APP/Contents/Resources/CHANGELOG.md"
+          grep -F "## [${{ steps.v.outputs.version }}]" "$APP/Contents/Resources/CHANGELOG.md"
 
       # ---- Dry run stops here: publish the unsigned .app for inspection ----
       - name: Upload unsigned app (dry run)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-07-21
+
 ### Added
 
 - A native **What's New** window now appears once after each app update. It uses
@@ -115,7 +117,8 @@ First public release — the working MVP.
 - Requires **macOS 13 Ventura** or later.
 - The core hide/show experience needs **zero special permissions**.
 
-[Unreleased]: https://github.com/ismatBabirli/pelmet/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/ismatBabirli/pelmet/compare/v0.3.2...HEAD
+[0.3.2]: https://github.com/ismatBabirli/pelmet/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/ismatBabirli/pelmet/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/ismatBabirli/pelmet/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/ismatBabirli/pelmet/compare/v0.1.0...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A native **What's New** window now appears once after each app update. It uses
+  the changelog bundled with the app, includes every release skipped since the
+  last acknowledged version, and links to the full changelog on GitHub. New
+  installs start silently, while existing users see the feature's first release.
+
 ## [0.3.1] - 2026-07-21
 
 ### Fixed

--- a/Sources/Pelmet/AppDelegate.swift
+++ b/Sources/Pelmet/AppDelegate.swift
@@ -17,6 +17,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             return
         }
 
+        // Sample the app domain before menu setup seeds status-item positions.
+        // That is the only reliable way to distinguish a truly fresh install
+        // from an existing user receiving the first What's New-enabled release.
+        let hadExistingPreferences = Preferences.hasPersistentApplicationPreferences
+        WhatsNewWindowController.shared.prepareAutomaticPresentation(
+            hadExistingPreferences: hadExistingPreferences
+        )
+
         MenuBarManager.shared.setUp()
 
         // Start Sparkle (bundled .app only). Sparkle asks the user once on
@@ -43,6 +51,12 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let registration = HotkeyManager.shared.register()
 
         printStartupBanner(hotkeys: registration)
+
+        // Let applicationDidFinishLaunching return before taking focus. The
+        // controller waits if Sparkle happens to own a modal at this point.
+        DispatchQueue.main.async {
+            WhatsNewWindowController.shared.presentPreparedIfNeeded()
+        }
     }
 
     func applicationSupportsSecureRestorableState(_ app: NSApplication) -> Bool {

--- a/Sources/Pelmet/AppVersionInfo.swift
+++ b/Sources/Pelmet/AppVersionInfo.swift
@@ -30,7 +30,7 @@ enum AppVersionInfo {
 /// compare links already in `CHANGELOG.md`; GitHub is case-insensitive on it.
 enum AppLinks {
     static let repo = URL(string: "https://github.com/ismatBabirli/pelmet")!
-    static let releases = URL(string: "https://github.com/ismatBabirli/pelmet/releases")!
+    static let changelog = URL(string: "https://github.com/ismatBabirli/pelmet/blob/main/CHANGELOG.md")!
     static let issues = URL(string: "https://github.com/ismatBabirli/pelmet/issues/new")!
     /// Full field-by-field telemetry disclosure. Linked from the first-run
     /// notice and the Settings Privacy section.

--- a/Sources/Pelmet/MenuBarManager.swift
+++ b/Sources/Pelmet/MenuBarManager.swift
@@ -286,6 +286,13 @@ final class MenuBarManager: NSObject {
     /// Called on every confirmed snapshot and again when a tip closes (the
     /// tips chain: divider → toggle → count education).
     func reapplyOnboardingChecks() {
+        // Launch surfaces are serialized: release notes first, then a possible
+        // crash alert, then anchored onboarding. The dismissal paths re-run
+        // this method, so returning here never starves a one-time presenter.
+        guard !WhatsNewWindowController.shared.isPendingOrVisible,
+              NSApp.modalWindow == nil
+        else { return }
+
         // The welcome and the one-click offer are layout-independent, so they
         // still run before any classification confirms (a busy just-logged-in
         // bar may never settle). Swallowed-education needs a real count.

--- a/Sources/Pelmet/Preferences.swift
+++ b/Sources/Pelmet/Preferences.swift
@@ -29,6 +29,7 @@ enum Preferences {
         static let telemetryLastHeartbeatDay = "telemetryLastHeartbeatDay"
         static let lastSessionCleanExit = "lastSessionCleanExit"
         static let crashPromptDisabled = "crashPromptDisabled"
+        static let lastAcknowledgedWhatsNewVersion = "lastAcknowledgedWhatsNewVersion"
     }
 
     /// Last collapse state, restored at launch. Defaults to expanded so a
@@ -164,6 +165,24 @@ enum Preferences {
     static var crashPromptDisabled: Bool {
         get { UserDefaults.standard.bool(forKey: Keys.crashPromptDisabled) }
         set { UserDefaults.standard.set(newValue, forKey: Keys.crashPromptDisabled) }
+    }
+
+    // MARK: - What's New
+
+    /// Marketing version whose automatic release-notes window the user last
+    /// dismissed. A missing value is interpreted using whether this app domain
+    /// existed before launch setup mutated it (fresh install vs feature rollout).
+    static var lastAcknowledgedWhatsNewVersion: String? {
+        get { UserDefaults.standard.string(forKey: Keys.lastAcknowledgedWhatsNewVersion) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.lastAcknowledgedWhatsNewVersion) }
+    }
+
+    /// Must be sampled before menu setup writes status-item positions. A real
+    /// bundled install has a bundle identifier; `swift run` does not and is
+    /// intentionally treated as a fresh development launch.
+    static var hasPersistentApplicationPreferences: Bool {
+        guard let bundleIdentifier = Bundle.main.bundleIdentifier else { return false }
+        return UserDefaults.standard.persistentDomain(forName: bundleIdentifier)?.isEmpty == false
     }
 
     // MARK: - One-time onboarding flags

--- a/Sources/Pelmet/Settings/AboutPaneView.swift
+++ b/Sources/Pelmet/Settings/AboutPaneView.swift
@@ -45,8 +45,11 @@ struct AboutPaneView: View {
             }
 
             Section {
+                Button("What's New…") {
+                    WhatsNewWindowController.shared.showManually()
+                }
                 Link("View on GitHub", destination: AppLinks.repo)
-                Link("Release Notes", destination: AppLinks.releases)
+                Link("Full Changelog", destination: AppLinks.changelog)
                 // Opens a GitHub issue prefilled with the version and
                 // environment; the user writes and submits it themselves.
                 Button("Report a Problem…") {

--- a/Sources/Pelmet/Telemetry/CrashReportMonitor.swift
+++ b/Sources/Pelmet/Telemetry/CrashReportMonitor.swift
@@ -89,6 +89,23 @@ final class CrashReportMonitor {
     }
 
     private func presentCrashPrompt() {
+        // Release notes are already on screen (or waiting for Sparkle), so queue
+        // this more disruptive modal rather than stacking launch surfaces.
+        if WhatsNewWindowController.shared.isPendingOrVisible {
+            WhatsNewWindowController.shared.performAfterPresentation { [weak self] in
+                self?.presentCrashPrompt()
+            }
+            return
+        }
+        // Sparkle can own a first-launch modal. Wait for it as well; only one
+        // retry is scheduled by each invocation.
+        guard NSApp.modalWindow == nil else {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+                self?.presentCrashPrompt()
+            }
+            return
+        }
+
         NSApp.activate(ignoringOtherApps: true)
         let alert = NSAlert()
         alert.messageText = "Pelmet quit unexpectedly last time"
@@ -102,6 +119,11 @@ final class CrashReportMonitor {
         alert.suppressionButton?.title = "Don't offer this after future crashes"
 
         let response = alert.runModal()
+        // Any pending onboarding was gated by NSApp.modalWindow. Re-run it now
+        // that the alert has left the modal session.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+            MenuBarManager.shared.reapplyOnboardingChecks()
+        }
         if alert.suppressionButton?.state == .on {
             Preferences.crashPromptDisabled = true
         }

--- a/Sources/Pelmet/WhatsNew/WhatsNewView.swift
+++ b/Sources/Pelmet/WhatsNew/WhatsNewView.swift
@@ -1,0 +1,170 @@
+import AppKit
+import PelmetCore
+import SwiftUI
+
+struct WhatsNewView: View {
+    let versionLabel: String
+    let releases: [ChangelogRelease]
+    let onDone: () -> Void
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+                .padding(.horizontal, 28)
+                .padding(.vertical, 22)
+
+            Divider()
+
+            ScrollView {
+                VStack(alignment: .leading, spacing: 24) {
+                    if releases.isEmpty {
+                        fallbackContent
+                    } else {
+                        if !hasCurrentRelease {
+                            fallbackContent
+                        }
+                        ForEach(Array(releases.enumerated()), id: \.offset) { _, release in
+                            releaseView(release)
+                        }
+                    }
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(28)
+            }
+            .textSelection(.enabled)
+
+            Divider()
+
+            HStack {
+                Link("View Full Changelog", destination: AppLinks.changelog)
+                Spacer()
+                Button("Done", action: onDone)
+                    .keyboardShortcut(.defaultAction)
+            }
+            .padding(.horizontal, 20)
+            .padding(.vertical, 14)
+        }
+        .frame(minWidth: 460, minHeight: 360)
+    }
+
+    private var header: some View {
+        HStack(spacing: 18) {
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .frame(width: 72, height: 72)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 5) {
+                Text("What's New in Pelmet \(versionLabel)")
+                    .font(.title2.bold())
+                    .accessibilityAddTraits(.isHeader)
+                Text(releases.count > 1
+                    ? "Here’s everything that changed across the updates you skipped."
+                    : "Pelmet has been updated. Here are the highlights.")
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private var fallbackContent: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("Pelmet was updated to version \(versionLabel).")
+                .font(.headline)
+            Text("The bundled notes for this version aren't available. You can still read the full changelog on GitHub.")
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+    }
+
+    private var hasCurrentRelease: Bool {
+        releases.contains { $0.version.description == versionLabel }
+    }
+
+    private func releaseView(_ release: ChangelogRelease) -> some View {
+        VStack(alignment: .leading, spacing: 16) {
+            HStack(alignment: .firstTextBaseline) {
+                Text("Version \(release.version.description)")
+                    .font(.title3.bold())
+                    .accessibilityAddTraits(.isHeader)
+                if let date = release.date {
+                    Text(date)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+
+            ForEach(Array(release.sections.enumerated()), id: \.offset) { _, section in
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(section.title)
+                        .font(.headline)
+                        .accessibilityAddTraits(.isHeader)
+                    ForEach(Array(section.items.enumerated()), id: \.offset) { _, item in
+                        HStack(alignment: .firstTextBaseline, spacing: 8) {
+                            Text("•")
+                                .accessibilityHidden(true)
+                            Text(attributedMarkdown(item))
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                        .accessibilityElement(children: .combine)
+                    }
+                }
+            }
+
+            if release.sections.isEmpty {
+                Text("The bundled notes for this version aren't available. See the full changelog on GitHub.")
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        }
+    }
+
+    private func attributedMarkdown(_ markdown: String) -> AttributedString {
+        (try? AttributedString(
+            markdown: markdown,
+            options: .init(interpretedSyntax: .inlineOnlyPreservingWhitespace)
+        )) ?? AttributedString(markdown)
+    }
+}
+
+#Preview("Current release") {
+    WhatsNewView(
+        versionLabel: "0.4.0",
+        releases: [ChangelogRelease(
+            version: SemanticVersion("0.4.0")!,
+            date: "2026-08-01",
+            sections: [
+                ChangelogSection(
+                    title: "Added",
+                    items: ["A focused **What's New** window after updates."]
+                ),
+                ChangelogSection(title: "Fixed", items: ["Improved launch presentation ordering."]),
+            ]
+        )],
+        onDone: {}
+    )
+    .frame(width: 560, height: 600)
+}
+
+#Preview("Skipped releases") {
+    WhatsNewView(
+        versionLabel: "0.4.0",
+        releases: [
+            ChangelogRelease(
+                version: SemanticVersion("0.4.0")!,
+                sections: [ChangelogSection(title: "Added", items: ["Current changes."])]
+            ),
+            ChangelogRelease(
+                version: SemanticVersion("0.3.1")!,
+                sections: [ChangelogSection(title: "Fixed", items: ["Earlier fixes."])]
+            ),
+        ],
+        onDone: {}
+    )
+    .frame(width: 560, height: 600)
+}
+
+#Preview("Fallback") {
+    WhatsNewView(versionLabel: "0.4.0", releases: [], onDone: {})
+        .frame(width: 560, height: 600)
+}

--- a/Sources/Pelmet/WhatsNew/WhatsNewWindowController.swift
+++ b/Sources/Pelmet/WhatsNew/WhatsNewWindowController.swift
@@ -1,0 +1,213 @@
+import AppKit
+import PelmetCore
+import SwiftUI
+
+/// Owns Pelmet's single, reusable release-notes window and the launch gate that
+/// keeps it from stacking with onboarding or crash prompts.
+final class WhatsNewWindowController: NSWindowController, NSWindowDelegate {
+
+    static let shared = WhatsNewWindowController()
+
+    private struct Presentation {
+        let versionLabel: String
+        let releases: [ChangelogRelease]
+        let versionToAcknowledge: String?
+    }
+
+    private var pendingPresentation: Presentation?
+    private var acknowledgmentSession: WhatsNewAcknowledgmentSession?
+    private var afterPresentationActions: [() -> Void] = []
+    private var retryScheduled = false
+    private var isTrackedAsOpen = false
+    private var hasCenteredWindow = false
+
+    /// True while automatic notes are waiting for another modal to finish or
+    /// while this window is visible. Launch-time presenters use it as a gate.
+    var isPendingOrVisible: Bool {
+        pendingPresentation != nil || window?.isVisible == true
+    }
+
+    private convenience init() {
+        self.init(window: nil)
+    }
+
+    /// Called before menu setup writes any defaults. A new install silently
+    /// records a baseline; an existing install receives the current notes once.
+    func prepareAutomaticPresentation(hadExistingPreferences: Bool) {
+        let releases = Self.loadBundledReleases()
+        switch WhatsNewPolicy.decision(
+            currentVersion: AppVersionInfo.current.shortVersion,
+            lastAcknowledgedVersion: Preferences.lastAcknowledgedWhatsNewVersion,
+            hadExistingPreferences: hadExistingPreferences,
+            releases: releases
+        ) {
+        case .none:
+            break
+        case let .establishBaseline(version):
+            Preferences.lastAcknowledgedWhatsNewVersion = version.description
+        case let .present(content):
+            pendingPresentation = Presentation(
+                versionLabel: content.currentVersion.description,
+                releases: content.releases,
+                versionToAcknowledge: content.currentVersion.description
+            )
+        }
+    }
+
+    /// Presents prepared automatic notes once AppDelegate has finished wiring
+    /// the app. If Sparkle owns a modal at that moment, retry without stacking.
+    func presentPreparedIfNeeded() {
+        guard pendingPresentation != nil else { return }
+        guard NSApp.modalWindow == nil else {
+            schedulePresentationRetry()
+            return
+        }
+        presentPending()
+    }
+
+    /// Permanent replay path from Settings > About. If automatic notes are
+    /// pending, replaying them counts as the same presentation and acknowledges
+    /// them only when this window closes.
+    func showManually() {
+        if window?.isVisible == true {
+            bringWindowForward()
+            return
+        }
+
+        OnboardingController.shared.closeActiveTip()
+        if pendingPresentation != nil {
+            presentPending()
+            return
+        }
+
+        let version = AppVersionInfo.current
+        let releases = Self.loadBundledReleases()
+        let currentRelease = version.shortVersion
+            .flatMap(SemanticVersion.init)
+            .flatMap { current in releases.first { $0.version == current } }
+        show(Presentation(
+            versionLabel: version.shortVersion ?? version.displayValue,
+            releases: currentRelease.map { [$0] } ?? [],
+            versionToAcknowledge: nil
+        ))
+    }
+
+    /// Queues launch UI that must not cover this window. The action runs on the
+    /// next main-loop turn after dismissal so AppKit can finish closing first.
+    func performAfterPresentation(_ action: @escaping () -> Void) {
+        guard isPendingOrVisible else {
+            action()
+            return
+        }
+        afterPresentationActions.append(action)
+    }
+
+    private func presentPending() {
+        guard let pendingPresentation else { return }
+        guard NSApp.modalWindow == nil else {
+            schedulePresentationRetry()
+            return
+        }
+        show(pendingPresentation)
+    }
+
+    private func show(_ presentation: Presentation) {
+        configureWindowIfNeeded()
+        guard let window else { return }
+
+        window.title = "What's New in Pelmet \(presentation.versionLabel)"
+        window.contentViewController = NSHostingController(rootView: WhatsNewView(
+            versionLabel: presentation.versionLabel,
+            releases: presentation.releases,
+            onDone: { [weak self] in self?.window?.performClose(nil) }
+        ))
+
+        NSApp.activate(ignoringOtherApps: true)
+        if !hasCenteredWindow {
+            window.center()
+            hasCenteredWindow = true
+        }
+        showWindow(nil)
+        window.makeKeyAndOrderFront(nil)
+
+        guard window.isVisible else { return }
+        pendingPresentation = nil
+        if let rawVersion = presentation.versionToAcknowledge,
+           let version = SemanticVersion(rawVersion) {
+            acknowledgmentSession = WhatsNewAcknowledgmentSession(version: version)
+            acknowledgmentSession?.recordSuccessfulOpen()
+        }
+        if !isTrackedAsOpen {
+            isTrackedAsOpen = true
+            UIActivityTracker.shared.surfaceOpened()
+        }
+    }
+
+    private func configureWindowIfNeeded() {
+        guard window == nil else { return }
+        let window = WhatsNewWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 560, height: 600),
+            styleMask: [.titled, .closable, .resizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "What's New in Pelmet"
+        window.minSize = NSSize(width: 460, height: 360)
+        window.isReleasedWhenClosed = false
+        window.collectionBehavior = [.moveToActiveSpace]
+        window.delegate = self
+        self.window = window
+    }
+
+    private func bringWindowForward() {
+        NSApp.activate(ignoringOtherApps: true)
+        showWindow(nil)
+        window?.makeKeyAndOrderFront(nil)
+    }
+
+    private func schedulePresentationRetry() {
+        guard !retryScheduled else { return }
+        retryScheduled = true
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) { [weak self] in
+            guard let self else { return }
+            self.retryScheduled = false
+            self.presentPreparedIfNeeded()
+        }
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        if var session = acknowledgmentSession,
+           let version = session.recordDismissal() {
+            Preferences.lastAcknowledgedWhatsNewVersion = version.description
+        }
+        acknowledgmentSession = nil
+        if isTrackedAsOpen {
+            isTrackedAsOpen = false
+            UIActivityTracker.shared.surfaceClosed()
+        }
+
+        let actions = afterPresentationActions
+        afterPresentationActions.removeAll()
+        DispatchQueue.main.async {
+            actions.forEach { $0() }
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+                MenuBarManager.shared.reapplyOnboardingChecks()
+            }
+        }
+    }
+
+    private static func loadBundledReleases() -> [ChangelogRelease] {
+        guard let url = Bundle.main.url(forResource: "CHANGELOG", withExtension: "md"),
+              let markdown = try? String(contentsOf: url, encoding: .utf8)
+        else { return [] }
+        return ChangelogParser.parse(markdown)
+    }
+}
+
+/// Escape closes the focused release-notes window without requiring a hidden
+/// SwiftUI button solely to own the cancel keyboard shortcut.
+private final class WhatsNewWindow: NSWindow {
+    override func cancelOperation(_ sender: Any?) {
+        performClose(sender)
+    }
+}

--- a/Sources/PelmetCore/SemanticVersion.swift
+++ b/Sources/PelmetCore/SemanticVersion.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+/// A strict Semantic Version 2.0 value used to decide whether release notes
+/// belong to a newer app version. Build metadata is accepted but deliberately
+/// omitted from equality and ordering because SemVer says it has no precedence.
+public struct SemanticVersion: Comparable, Hashable, Sendable, CustomStringConvertible {
+
+    public let major: Int
+    public let minor: Int
+    public let patch: Int
+    public let prereleaseIdentifiers: [String]
+
+    public init?(_ rawValue: String) {
+        let value = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !value.isEmpty else { return nil }
+
+        let buildParts = value.split(separator: "+", omittingEmptySubsequences: false)
+        guard buildParts.count <= 2 else { return nil }
+        if buildParts.count == 2 {
+            guard Self.identifiersAreValid(String(buildParts[1]), forbidLeadingZeroes: false) else {
+                return nil
+            }
+        }
+
+        let precedenceParts = buildParts[0].split(
+            separator: "-", maxSplits: 1, omittingEmptySubsequences: false
+        )
+        let numberParts = precedenceParts[0].split(separator: ".", omittingEmptySubsequences: false)
+        guard numberParts.count == 3,
+              let major = Self.parseCoreNumber(numberParts[0]),
+              let minor = Self.parseCoreNumber(numberParts[1]),
+              let patch = Self.parseCoreNumber(numberParts[2])
+        else { return nil }
+
+        let prerelease: [String]
+        if precedenceParts.count == 2 {
+            let rawPrerelease = String(precedenceParts[1])
+            guard Self.identifiersAreValid(rawPrerelease, forbidLeadingZeroes: true) else {
+                return nil
+            }
+            prerelease = rawPrerelease.split(separator: ".").map(String.init)
+        } else {
+            prerelease = []
+        }
+
+        self.major = major
+        self.minor = minor
+        self.patch = patch
+        self.prereleaseIdentifiers = prerelease
+    }
+
+    public var description: String {
+        let core = "\(major).\(minor).\(patch)"
+        guard !prereleaseIdentifiers.isEmpty else { return core }
+        return core + "-" + prereleaseIdentifiers.joined(separator: ".")
+    }
+
+    public static func < (lhs: SemanticVersion, rhs: SemanticVersion) -> Bool {
+        if lhs.major != rhs.major { return lhs.major < rhs.major }
+        if lhs.minor != rhs.minor { return lhs.minor < rhs.minor }
+        if lhs.patch != rhs.patch { return lhs.patch < rhs.patch }
+
+        if lhs.prereleaseIdentifiers.isEmpty { return false }
+        if rhs.prereleaseIdentifiers.isEmpty { return true }
+
+        for (left, right) in zip(lhs.prereleaseIdentifiers, rhs.prereleaseIdentifiers) {
+            if left == right { continue }
+            let leftNumber = Int(left)
+            let rightNumber = Int(right)
+            switch (leftNumber, rightNumber) {
+            case let (.some(left), .some(right)): return left < right
+            case (.some, .none): return true
+            case (.none, .some): return false
+            case (.none, .none): return left < right
+            }
+        }
+        return lhs.prereleaseIdentifiers.count < rhs.prereleaseIdentifiers.count
+    }
+
+    private static func parseCoreNumber(_ value: Substring) -> Int? {
+        guard !value.isEmpty,
+              value.allSatisfy(\.isNumber),
+              value == "0" || value.first != "0"
+        else { return nil }
+        return Int(value)
+    }
+
+    private static func identifiersAreValid(
+        _ value: String,
+        forbidLeadingZeroes: Bool
+    ) -> Bool {
+        let identifiers = value.split(separator: ".", omittingEmptySubsequences: false)
+        guard !identifiers.isEmpty else { return false }
+        return identifiers.allSatisfy { identifier in
+            guard !identifier.isEmpty,
+                  identifier.allSatisfy({ $0.isASCII && ($0.isLetter || $0.isNumber || $0 == "-") })
+            else { return false }
+            if forbidLeadingZeroes,
+               identifier.allSatisfy(\.isNumber),
+               identifier.count > 1,
+               identifier.first == "0" {
+                return false
+            }
+            return true
+        }
+    }
+}

--- a/Sources/PelmetCore/WhatsNew.swift
+++ b/Sources/PelmetCore/WhatsNew.swift
@@ -1,0 +1,223 @@
+import Foundation
+
+public struct ChangelogSection: Equatable, Sendable {
+    public let title: String
+    public let items: [String]
+
+    public init(title: String, items: [String]) {
+        self.title = title
+        self.items = items
+    }
+}
+
+public struct ChangelogRelease: Equatable, Sendable {
+    public let version: SemanticVersion
+    public let date: String?
+    public let sections: [ChangelogSection]
+
+    public init(
+        version: SemanticVersion,
+        date: String? = nil,
+        sections: [ChangelogSection]
+    ) {
+        self.version = version
+        self.date = date
+        self.sections = sections
+    }
+}
+
+/// Parses the versioned sections of the repository's Keep a Changelog file.
+/// Block-level Markdown is reduced to releases, section headings, and bullets;
+/// inline Markdown inside a bullet is preserved for the SwiftUI renderer.
+public enum ChangelogParser {
+
+    public static func parse(_ markdown: String) -> [ChangelogRelease] {
+        var releases: [ChangelogRelease] = []
+        var releaseBuilder: ReleaseBuilder?
+        var sectionBuilder: SectionBuilder?
+
+        func finishSection() {
+            guard let section = sectionBuilder else { return }
+            sectionBuilder = nil
+            guard !section.items.isEmpty else { return }
+            releaseBuilder?.sections.append(
+                ChangelogSection(title: section.title, items: section.items)
+            )
+        }
+
+        func finishRelease() {
+            finishSection()
+            guard let release = releaseBuilder else { return }
+            releaseBuilder = nil
+            releases.append(ChangelogRelease(
+                version: release.version,
+                date: release.date,
+                sections: release.sections
+            ))
+        }
+
+        for rawLine in markdown.components(separatedBy: .newlines) {
+            let trimmed = rawLine.trimmingCharacters(in: .whitespaces)
+
+            if trimmed.hasPrefix("## ") && !trimmed.hasPrefix("### ") {
+                finishRelease()
+                releaseBuilder = parseReleaseHeading(trimmed)
+                continue
+            }
+
+            guard releaseBuilder != nil else { continue }
+
+            if trimmed.hasPrefix("### ") {
+                finishSection()
+                let title = String(trimmed.dropFirst(4)).trimmingCharacters(in: .whitespaces)
+                if !title.isEmpty {
+                    sectionBuilder = SectionBuilder(title: title, items: [])
+                }
+                continue
+            }
+
+            guard sectionBuilder != nil else { continue }
+            if trimmed.hasPrefix("- ") {
+                let item = String(trimmed.dropFirst(2)).trimmingCharacters(in: .whitespaces)
+                if !item.isEmpty { sectionBuilder?.items.append(item) }
+            } else if !trimmed.isEmpty,
+                      !isLinkDefinition(trimmed),
+                      sectionBuilder?.items.isEmpty == false {
+                let last = sectionBuilder!.items.removeLast()
+                sectionBuilder!.items.append(last + " " + trimmed)
+            }
+        }
+
+        finishRelease()
+        return releases
+    }
+
+    private static func parseReleaseHeading(_ heading: String) -> ReleaseBuilder? {
+        guard heading.hasPrefix("## ["),
+              let closingBracket = heading.firstIndex(of: "]")
+        else { return nil }
+
+        let versionStart = heading.index(heading.startIndex, offsetBy: 4)
+        guard versionStart < closingBracket,
+              let version = SemanticVersion(String(heading[versionStart..<closingBracket]))
+        else { return nil }
+
+        let remainderStart = heading.index(after: closingBracket)
+        let remainder = heading[remainderStart...].trimmingCharacters(in: .whitespaces)
+        let date: String?
+        if remainder.hasPrefix("-") {
+            let value = remainder.dropFirst().trimmingCharacters(in: .whitespaces)
+            date = value.isEmpty ? nil : value
+        } else {
+            date = nil
+        }
+        return ReleaseBuilder(version: version, date: date, sections: [])
+    }
+
+    private static func isLinkDefinition(_ line: String) -> Bool {
+        guard line.hasPrefix("["), let marker = line.firstIndex(of: "]") else { return false }
+        let next = line.index(after: marker)
+        return next < line.endIndex && line[next] == ":"
+    }
+
+    private final class ReleaseBuilder {
+        let version: SemanticVersion
+        let date: String?
+        var sections: [ChangelogSection]
+
+        init(version: SemanticVersion, date: String?, sections: [ChangelogSection]) {
+            self.version = version
+            self.date = date
+            self.sections = sections
+        }
+    }
+
+    private struct SectionBuilder {
+        let title: String
+        var items: [String]
+    }
+}
+
+public struct WhatsNewContent: Equatable, Sendable {
+    public let currentVersion: SemanticVersion
+    public let releases: [ChangelogRelease]
+
+    public init(currentVersion: SemanticVersion, releases: [ChangelogRelease]) {
+        self.currentVersion = currentVersion
+        self.releases = releases
+    }
+}
+
+public enum WhatsNewDecision: Equatable, Sendable {
+    case none
+    case establishBaseline(version: SemanticVersion)
+    case present(WhatsNewContent)
+}
+
+/// Tracks the two UI facts required before a version may be persisted as seen:
+/// the window actually became visible, and it was subsequently dismissed.
+public struct WhatsNewAcknowledgmentSession: Equatable, Sendable {
+    public let version: SemanticVersion
+    private var openedSuccessfully = false
+    private var acknowledged = false
+
+    public init(version: SemanticVersion) {
+        self.version = version
+    }
+
+    public mutating func recordSuccessfulOpen() {
+        openedSuccessfully = true
+    }
+
+    /// Returns the version exactly once, and only after a successful open.
+    public mutating func recordDismissal() -> SemanticVersion? {
+        guard openedSuccessfully, !acknowledged else { return nil }
+        acknowledged = true
+        return version
+    }
+}
+
+/// Pure launch policy. The app layer owns UserDefaults and acknowledgment;
+/// this type only decides what a launch should do from supplied facts.
+public enum WhatsNewPolicy {
+
+    public static func decision(
+        currentVersion rawCurrentVersion: String?,
+        lastAcknowledgedVersion rawLastAcknowledgedVersion: String?,
+        hadExistingPreferences: Bool,
+        releases: [ChangelogRelease]
+    ) -> WhatsNewDecision {
+        guard let rawCurrentVersion,
+              let currentVersion = SemanticVersion(rawCurrentVersion)
+        else { return .none }
+
+        guard let rawLastAcknowledgedVersion else {
+            if hadExistingPreferences {
+                let currentRelease = releases.first { $0.version == currentVersion }
+                return .present(WhatsNewContent(
+                    currentVersion: currentVersion,
+                    releases: currentRelease.map { [$0] } ?? []
+                ))
+            }
+            return .establishBaseline(version: currentVersion)
+        }
+
+        guard let lastAcknowledgedVersion = SemanticVersion(rawLastAcknowledgedVersion) else {
+            let currentRelease = releases.first { $0.version == currentVersion }
+            return .present(WhatsNewContent(
+                currentVersion: currentVersion,
+                releases: currentRelease.map { [$0] } ?? []
+            ))
+        }
+
+        guard currentVersion > lastAcknowledgedVersion else { return .none }
+
+        let unseenReleases = releases
+            .filter { $0.version > lastAcknowledgedVersion && $0.version <= currentVersion }
+            .sorted { $0.version > $1.version }
+        return .present(WhatsNewContent(
+            currentVersion: currentVersion,
+            releases: unseenReleases
+        ))
+    }
+}

--- a/Tests/PelmetCoreTests/SemanticVersionTests.swift
+++ b/Tests/PelmetCoreTests/SemanticVersionTests.swift
@@ -1,0 +1,32 @@
+import Testing
+@testable import PelmetCore
+
+struct SemanticVersionTests {
+
+    @Test func testParsesStablePrereleaseAndBuildMetadata() {
+        #expect(SemanticVersion("1.2.3")?.description == "1.2.3")
+        #expect(SemanticVersion("1.2.3-beta.2+build.19")?.description == "1.2.3-beta.2")
+    }
+
+    @Test func testRejectsInvalidVersions() {
+        for value in ["", "1", "1.2", "01.2.3", "1.02.3", "1.2.03", "1.2.3-", "1.2.3-01"] {
+            #expect(SemanticVersion(value) == nil)
+        }
+    }
+
+    @Test func testSemanticVersionPrecedence() throws {
+        let ordered = [
+            "1.0.0-alpha", "1.0.0-alpha.1", "1.0.0-alpha.beta", "1.0.0-beta",
+            "1.0.0-beta.2", "1.0.0-beta.11", "1.0.0-rc.1", "1.0.0",
+        ].compactMap(SemanticVersion.init)
+
+        #expect(ordered.count == 8)
+        for pair in zip(ordered, ordered.dropFirst()) {
+            #expect(pair.0 < pair.1)
+        }
+    }
+
+    @Test func testBuildMetadataDoesNotAffectEquality() throws {
+        #expect(SemanticVersion("1.2.3+one") == SemanticVersion("1.2.3+two"))
+    }
+}

--- a/Tests/PelmetCoreTests/WhatsNewTests.swift
+++ b/Tests/PelmetCoreTests/WhatsNewTests.swift
@@ -1,0 +1,148 @@
+import Testing
+@testable import PelmetCore
+
+struct WhatsNewTests {
+
+    private let markdown = """
+    # Changelog
+
+    ## [Unreleased]
+
+    ### Added
+
+    - Not ready yet.
+
+    ## [0.3.0] - 2026-07-19
+
+    ### Added
+
+    - **Shelf improvements** with `inline code` and a
+      continuation line.
+
+    ### Fixed
+
+    - Fixed a crash.
+
+    ## [0.2.0] - 2026-07-13
+
+    ### Changed
+
+    - Added [Sparkle](https://sparkle-project.org).
+
+    [Unreleased]: https://example.com/compare
+    [0.3.0]: https://example.com/0.3.0
+    """
+
+    @Test func testParsesVersionedSectionsAndMultilineBullets() throws {
+        let releases = ChangelogParser.parse(markdown)
+
+        #expect(releases.count == 2)
+        #expect(releases[0].version == SemanticVersion("0.3.0"))
+        #expect(releases[0].date == "2026-07-19")
+        #expect(releases[0].sections.map(\.title) == ["Added", "Fixed"])
+        #expect(releases[0].sections[0].items == [
+            "**Shelf improvements** with `inline code` and a continuation line."
+        ])
+        #expect(releases[1].sections[0].items[0].contains("[Sparkle](https://sparkle-project.org)"))
+    }
+
+    @Test func testIgnoresMalformedAndUnreleasedHeadings() {
+        let releases = ChangelogParser.parse("""
+        ## [Unreleased]
+        ### Added
+        - No.
+        ## [01.2.3] - 2026-01-01
+        ### Fixed
+        - Invalid SemVer.
+        """)
+
+        #expect(releases.isEmpty)
+    }
+
+    @Test func testFreshInstallEstablishesBaseline() {
+        let decision = WhatsNewPolicy.decision(
+            currentVersion: "0.3.0",
+            lastAcknowledgedVersion: nil,
+            hadExistingPreferences: false,
+            releases: ChangelogParser.parse(markdown)
+        )
+        #expect(decision == .establishBaseline(version: SemanticVersion("0.3.0")!))
+    }
+
+    @Test func testFirstRolloutShowsOnlyCurrentReleaseToExistingInstall() {
+        let decision = WhatsNewPolicy.decision(
+            currentVersion: "0.3.0",
+            lastAcknowledgedVersion: nil,
+            hadExistingPreferences: true,
+            releases: ChangelogParser.parse(markdown)
+        )
+        guard case let .present(content) = decision else {
+            Issue.record("Expected release notes")
+            return
+        }
+        #expect(content.releases.map(\.version) == [SemanticVersion("0.3.0")!])
+    }
+
+    @Test func testSkippedUpgradeShowsAllUnseenVersionsNewestFirst() {
+        let decision = WhatsNewPolicy.decision(
+            currentVersion: "0.3.0",
+            lastAcknowledgedVersion: "0.1.0",
+            hadExistingPreferences: true,
+            releases: ChangelogParser.parse(markdown)
+        )
+        guard case let .present(content) = decision else {
+            Issue.record("Expected release notes")
+            return
+        }
+        #expect(content.releases.map(\.version) == [
+            SemanticVersion("0.3.0")!, SemanticVersion("0.2.0")!,
+        ])
+    }
+
+    @Test func testSameVersionAndDowngradeDoNothing() {
+        let releases = ChangelogParser.parse(markdown)
+        #expect(WhatsNewPolicy.decision(
+            currentVersion: "0.3.0", lastAcknowledgedVersion: "0.3.0",
+            hadExistingPreferences: true, releases: releases
+        ) == .none)
+        #expect(WhatsNewPolicy.decision(
+            currentVersion: "0.2.0", lastAcknowledgedVersion: "0.3.0",
+            hadExistingPreferences: true, releases: releases
+        ) == .none)
+    }
+
+    @Test func testDevelopmentAndInvalidVersionsDoNothing() {
+        #expect(WhatsNewPolicy.decision(
+            currentVersion: nil, lastAcknowledgedVersion: nil,
+            hadExistingPreferences: true, releases: []
+        ) == .none)
+        #expect(WhatsNewPolicy.decision(
+            currentVersion: "Development build", lastAcknowledgedVersion: nil,
+            hadExistingPreferences: true, releases: []
+        ) == .none)
+    }
+
+    @Test func testMissingReleaseStillPresentsFallbackContent() {
+        let decision = WhatsNewPolicy.decision(
+            currentVersion: "0.4.0",
+            lastAcknowledgedVersion: "0.3.0",
+            hadExistingPreferences: true,
+            releases: ChangelogParser.parse(markdown)
+        )
+        guard case let .present(content) = decision else {
+            Issue.record("Expected fallback content")
+            return
+        }
+        #expect(content.currentVersion == SemanticVersion("0.4.0"))
+        #expect(content.releases.isEmpty)
+    }
+
+    @Test func testAcknowledgmentRequiresSuccessfulOpenThenDismissal() {
+        var session = WhatsNewAcknowledgmentSession(version: SemanticVersion("0.4.0")!)
+
+        #expect(session.recordDismissal() == nil)
+        session.recordSuccessfulOpen()
+        #expect(session.recordDismissal() == SemanticVersion("0.4.0"))
+        #expect(session.recordDismissal() == nil)
+    }
+}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -139,7 +139,9 @@ first time — but you still must flip on Pages.)
 ## Cutting a release
 
 ```bash
-# 1. Update the changelog (move Unreleased → the new version).
+# 1. Update the changelog (move Unreleased → an exact SemVer heading).
+#    This entry is bundled for the offline What's New window, so it must exist
+#    before the tag is pushed. The release workflow rejects a missing entry.
 $EDITOR CHANGELOG.md
 
 # 2. Tag and push. The workflow does the rest.
@@ -149,7 +151,10 @@ git push origin v0.1.0
 
 Watch the run under the repo's **Actions** tab. When it's green you'll have a
 GitHub Release with the `.dmg`/`.zip`, and `brew upgrade --cask pelmet` will pick
-up the new version.
+up the new version. The workflow also verifies that `CHANGELOG.md` is present in
+`Pelmet.app/Contents/Resources`; users who update will see that version's entry
+locally even when they are offline. If they skipped releases, Pelmet shows every
+entry newer than the last one they dismissed.
 
 ## Testing the build without secrets
 

--- a/project.yml
+++ b/project.yml
@@ -35,6 +35,9 @@ targets:
     sources:
       - Sources/Pelmet
       - Resources/Assets.xcassets
+      # Offline source of truth for the post-update What's New window.
+      - path: CHANGELOG.md
+        buildPhase: resources
     info:
       path: Sources/Pelmet/Info.plist
       properties:


### PR DESCRIPTION
## Summary

- show a focused native “What’s New” window once after each marketing-version upgrade
- parse the bundled `CHANGELOG.md` offline and aggregate every skipped release
- distinguish fresh installs from existing users receiving the feature for the first time
- add manual replay and a full changelog link in Settings > About
- serialize release notes with onboarding, telemetry, Sparkle, and crash prompts
- validate versioned changelog entries and bundled notes during CI/release builds

## Why

Pelmet updates currently install without an after-update explanation. This gives users a concise, accessible summary of what changed while keeping the repository changelog as the single offline source of truth.

## User impact

Fresh installs establish a silent baseline. Existing installs see the current release once when this feature first ships, and future upgrades show every unseen release newest-first. Development builds, same-version launches, and downgrades do not auto-present.

## Validation

- `swift test` — 152 tests passed
- `swift build`
- `xcodegen generate`
- unsigned Debug `xcodebuild`
- verified the built app contains a nonempty `Contents/Resources/CHANGELOG.md`
- verified the bundled changelog matches the repository file byte-for-byte
- parsed both GitHub Actions workflow files as YAML
- `git diff --check`
