### PR TITLE
Make app updates reliable and user-approved

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,25 @@ jobs:
           test -s "$APP/Contents/Resources/CHANGELOG.md"
           grep -F "## [${{ steps.v.outputs.version }}]" "$APP/Contents/Resources/CHANGELOG.md"
 
+      - name: Verify app update configuration
+        env:
+          VERSION: ${{ steps.v.outputs.version }}
+          BUILD: ${{ github.run_number }}
+        run: |
+          INFO_PLIST="$APP/Contents/Info.plist"
+          plutil -lint "$INFO_PLIST"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "$INFO_PLIST")" = "$VERSION"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :CFBundleVersion' "$INFO_PLIST")" = "$BUILD"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :SUFeedURL' "$INFO_PLIST")" = \
+            "https://ismatbabirli.github.io/pelmet/appcast.xml"
+          test -n "$(/usr/libexec/PlistBuddy -c 'Print :SUPublicEDKey' "$INFO_PLIST")"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :SUScheduledCheckInterval' "$INFO_PLIST")" = "86400"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :SUAllowsAutomaticUpdates' "$INFO_PLIST")" = "false"
+          if /usr/libexec/PlistBuddy -c 'Print :SUEnableAutomaticChecks' "$INFO_PLIST" >/dev/null 2>&1; then
+            echo "SUEnableAutomaticChecks must stay unset so Sparkle asks for consent."
+            exit 1
+          fi
+
       # ---- Dry run stops here: publish the unsigned .app for inspection ----
       - name: Upload unsigned app (dry run)
         if: env.DRY_RUN == 'true'
@@ -278,6 +297,16 @@ jobs:
           EOF
           fi
 
+          # Refuse to publish onto a malformed feed or reuse/regress Sparkle's
+          # monotonically increasing build number.
+          xmllint --noout appcast.xml
+          PREVIOUS_MAX_BUILD="$(grep -oE '<sparkle:version>[0-9]+</sparkle:version>' appcast.xml \
+            | sed -E 's#</?sparkle:version>##g' | sort -n | tail -1 || true)"
+          if [ -n "$PREVIOUS_MAX_BUILD" ] && [ "$BUILD" -le "$PREVIOUS_MAX_BUILD" ]; then
+            echo "Build $BUILD must exceed the current appcast build $PREVIOUS_MAX_BUILD."
+            exit 1
+          fi
+
           # Build the new <item>. $SIG_AND_LEN already holds
           # sparkle:edSignature="…" length="…".
           cat > "$RUNNER_TEMP/item.xml" <<EOF
@@ -298,11 +327,48 @@ jobs:
             { print }
           ' appcast.xml > appcast.new && mv appcast.new appcast.xml
 
+          # Validate the exact item Sparkle will consume, including the signed
+          # enclosure metadata, before publishing the feed.
+          xmllint --noout appcast.xml
+          ITEM_COUNT="$(xmllint --xpath \
+            "count(//*[local-name()='item'][*[local-name()='version' and text()='$BUILD'] and *[local-name()='shortVersionString' and text()='$VERSION']])" \
+            appcast.xml)"
+          ENCLOSURE_COUNT="$(xmllint --xpath \
+            "count(//*[local-name()='item'][*[local-name()='version' and text()='$BUILD'] and *[local-name()='shortVersionString' and text()='$VERSION']]/enclosure[@url='$ENCLOSURE_URL' and string-length(@*[local-name()='edSignature']) > 0 and number(@length) > 0])" \
+            appcast.xml)"
+          if [ "$ITEM_COUNT" != "1" ] || [ "$ENCLOSURE_COUNT" != "1" ]; then
+            echo "Generated appcast item is missing, duplicated, unsigned, or has no content length."
+            exit 1
+          fi
+          curl -fsSIL --retry 5 --retry-all-errors "$ENCLOSURE_URL" >/dev/null
+
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add appcast.xml
           git commit -m "appcast: Pelmet $VERSION" || echo "nothing to commit"
           git push origin gh-pages
+
+          # GitHub Pages deployment is asynchronous. Do not call the release
+          # complete until the public feed serves this exact version/build.
+          PUBLIC_FEED="https://ismatbabirli.github.io/pelmet/appcast.xml"
+          PUBLISHED=false
+          for ATTEMPT in {1..20}; do
+            if curl -fsSL --retry 2 --retry-all-errors \
+                 "${PUBLIC_FEED}?build=${BUILD}&attempt=${ATTEMPT}" \
+                 -o "$RUNNER_TEMP/public-appcast.xml" \
+              && xmllint --noout "$RUNNER_TEMP/public-appcast.xml" \
+              && [ "$(xmllint --xpath \
+                   "count(//*[local-name()='item'][*[local-name()='version' and text()='$BUILD'] and *[local-name()='shortVersionString' and text()='$VERSION']])" \
+                   "$RUNNER_TEMP/public-appcast.xml")" = "1" ]; then
+              PUBLISHED=true
+              break
+            fi
+            sleep 15
+          done
+          if [ "$PUBLISHED" != "true" ]; then
+            echo "Public appcast did not expose Pelmet $VERSION (build $BUILD) within five minutes."
+            exit 1
+          fi
 
       # ---- Keep the Homebrew tap's cask in sync with this release ----
       - name: Bump Homebrew cask

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3] - 2026-07-22
+
 ### Added
 
 - Available updates now stay visible as a monochrome **↑** beside Pelmet's
@@ -139,7 +141,8 @@ First public release — the working MVP.
 - Requires **macOS 13 Ventura** or later.
 - The core hide/show experience needs **zero special permissions**.
 
-[Unreleased]: https://github.com/ismatBabirli/pelmet/compare/v0.3.2...HEAD
+[Unreleased]: https://github.com/ismatBabirli/pelmet/compare/v0.3.3...HEAD
+[0.3.3]: https://github.com/ismatBabirli/pelmet/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/ismatBabirli/pelmet/compare/v0.3.1...v0.3.2
 [0.3.1]: https://github.com/ismatBabirli/pelmet/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/ismatBabirli/pelmet/compare/v0.2.0...v0.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Available updates now stay visible as a monochrome **↑** beside Pelmet's
+  menu-bar toggle (combined as **+N ↑** when icons are hidden by the notch).
+  Settings also shows the available version, retry state, and last successful
+  check time.
+
+### Changed
+
+- Automatic update checks remain opt-in and run daily, while installing an
+  update always requires approval in Sparkle's standard Install and Relaunch
+  dialog. The release workflow now validates the app's update configuration,
+  appcast XML, increasing build number, signed enclosure, downloadable ZIP,
+  and publicly deployed feed item.
+
+### Fixed
+
+- A scheduled check that fails because the Mac is offline no longer disappears
+  for a full day. Pelmet remembers the failure across relaunches, retries after
+  connectivity returns or with bounded backoff, and stops after three recovery
+  attempts so repeated failures cannot form a tight loop.
+
 ## [0.3.2] - 2026-07-21
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -63,7 +63,11 @@ Pelmet places two items in your menu bar:
 Pelmet needs zero special permissions, has no accounts, and embeds no tracking
 SDKs. It makes two kinds of network calls, both under your control:
 
-- **Update checks** (Sparkle): asks you once before checking automatically.
+- **Update checks** (Sparkle): asks you once before enabling daily checks.
+  If a scheduled check meets a temporary network failure, Pelmet performs at
+  most three recovery checks and shows the retry state in Settings. An **↑** in
+  the menu bar means an update is ready to review; Pelmet never installs it
+  without your approval.
 - **Anonymous usage ping**: one tiny event per day (app version, macOS version,
   chip type, which Pelmet features are on) so we know how many people use Pelmet
   and what to prioritize. No personal data, no menu bar contents, never anything
@@ -162,7 +166,7 @@ open Pelmet.xcodeproj   # then build & run with ⌘R
 - [ ] Profiles and per-item rules (e.g. "presentation mode")
 - [ ] Custom hotkey recorder (replace the hardcoded ⌥⌘B)
 - [x] **Notarized releases + Homebrew cask** — a signed, notarized `.dmg` on every tagged release; `brew install --cask ismatBabirli/pelmet/pelmet`
-- [x] **Sparkle auto-updates** — in-app update checks (Sparkle 2), EdDSA-signed, with an appcast on GitHub Pages; "Check for Updates…" in the menu and a Software Update toggle in Settings
+- [x] **Reliable Sparkle updates** — opt-in daily checks, bounded retry after temporary network failures, an **↑** menu-bar reminder, EdDSA-signed downloads, and explicit approval before Install and Relaunch
 
 The full vision and phased plan live in [PROJECT.md](PROJECT.md); release history
 is in [CHANGELOG.md](CHANGELOG.md).

--- a/Sources/Pelmet/AppDelegate.swift
+++ b/Sources/Pelmet/AppDelegate.swift
@@ -28,9 +28,11 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         MenuBarManager.shared.setUp()
 
         // Start Sparkle (bundled .app only). Sparkle asks the user once on
-        // first launch whether to check automatically; nothing hits the network
-        // until they opt in. Inert under `swift run` (no bundle, no Sparkle).
-        _ = UpdaterController.shared
+        // during early use whether to check automatically; nothing hits the network
+        // until they opt in. The menu bar observes its gentle-reminder state.
+        // Inert under `swift run` (no bundle, no Sparkle).
+        let updater = UpdaterController.shared
+        MenuBarManager.shared.observeUpdater(updater)
 
         // Local-only crash follow-up: captures the clean-exit sentinel first,
         // then (if the last session crashed) offers a prefilled GitHub issue.

--- a/Sources/Pelmet/MenuBarManager.swift
+++ b/Sources/Pelmet/MenuBarManager.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Combine
 import PelmetCore
 
 /// Manages two NSStatusItems:
@@ -45,6 +46,8 @@ final class MenuBarManager: NSObject {
 
     private var toggleItem: NSStatusItem!
     private var separatorItem: NSStatusItem!
+    private var updaterObservation: AnyCancellable?
+    private var updateAvailableVersion: String?
 
     /// Latest confirmed layout facts from NotchLayoutMonitor.
     private var swallowedCount = 0
@@ -138,6 +141,21 @@ final class MenuBarManager: NSObject {
 
         NotchLayoutMonitor.shared.requestMeasurement(reason: .launch)
         armOnboardingFallback()
+    }
+
+    /// Sparkle's scheduled update UI is deliberately replaced by a persistent
+    /// menu-bar cue. Binding after both services initialize also replays the
+    /// current value, so an update found during launch cannot be missed.
+    func observeUpdater(_ updater: UpdaterController) {
+        updateAvailableVersion = updater.availableVersion
+        updaterObservation = updater.$status
+            .map(\.availableVersion)
+            .removeDuplicates()
+            .receive(on: RunLoop.main)
+            .sink { [weak self] version in
+                self?.updateAvailableVersion = version
+                self?.updateToggleIcon()
+            }
     }
 
     /// If the layout never settles into a confirmed classification, `apply()`
@@ -429,10 +447,9 @@ final class MenuBarManager: NSObject {
             .compactMap { $0 }
     }
 
-    /// State is conveyed by the chevron glyph and a plain-text count ONLY —
-    /// never a colored dot. Small colored dots in the menu bar are macOS
-    /// privacy vocabulary (green = camera, orange = mic, purple = screen
-    /// capture) and a badge in that grammar reads as a recording alarm.
+    /// State is conveyed by the chevron glyph and plain monochrome text — never
+    /// a colored dot. Small colored dots in the menu bar are macOS privacy
+    /// vocabulary (green = camera, orange = mic, purple = screen capture).
     private func updateToggleIcon() {
         guard let button = toggleItem.button else { return }
 
@@ -443,17 +460,22 @@ final class MenuBarManager: NSObject {
         )
 
         let showCount = !isCollapsed && swallowedCount > 0 && Preferences.showSwallowedCount
-        if showCount {
+        let updatePresentation = MenuBarUpdatePresentation(
+            swallowedCount: swallowedCount,
+            showsSwallowedCount: showCount,
+            availableVersion: updateAvailableVersion
+        )
+        if !updatePresentation.badgeText.isEmpty {
             button.attributedTitle = NSAttributedString(
-                string: "+\(swallowedCount)",
+                string: updatePresentation.badgeText,
                 attributes: [.font: NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .medium)]
             )
         } else {
             button.attributedTitle = NSAttributedString(string: "")
         }
 
-        let tooltip: String
-        let accessibilityValue: String
+        var tooltip: String
+        var accessibilityValue: String
         if isCollapsed {
             tooltip = "Pelmet: show hidden icons (⌥⌘B)"
             accessibilityValue = "Icons hidden"
@@ -473,6 +495,12 @@ final class MenuBarManager: NSObject {
         } else {
             tooltip = "Pelmet: hide icons (⌥⌘B)"
             accessibilityValue = "Icons shown"
+        }
+        if let updateNotice = updatePresentation.tooltipNotice {
+            tooltip = "\(updateNotice) \(tooltip)"
+        }
+        if let updateNotice = updatePresentation.accessibilityNotice {
+            accessibilityValue = "\(updateNotice) \(accessibilityValue)"
         }
         button.toolTip = tooltip
         button.setAccessibilityValue(accessibilityValue)
@@ -578,8 +606,14 @@ final class MenuBarManager: NSObject {
 
         // Sparkle: only in the bundled .app (compiled out under `swift run`).
         if UpdaterController.shared.isAvailable {
+            let updatePresentation = MenuBarUpdatePresentation(
+                swallowedCount: swallowedCount,
+                showsSwallowedCount: !isCollapsed && swallowedCount > 0
+                    && Preferences.showSwallowedCount,
+                availableVersion: updateAvailableVersion
+            )
             let updatesEntry = NSMenuItem(
-                title: "Check for Updates…",
+                title: updatePresentation.actionTitle,
                 action: #selector(checkForUpdates),
                 keyEquivalent: ""
             )

--- a/Sources/Pelmet/Preferences.swift
+++ b/Sources/Pelmet/Preferences.swift
@@ -1,4 +1,5 @@
 import Foundation
+import PelmetCore
 
 /// Simple UserDefaults-backed preferences.
 /// Kept as static accessors so both AppKit (MenuBarManager)
@@ -30,6 +31,8 @@ enum Preferences {
         static let lastSessionCleanExit = "lastSessionCleanExit"
         static let crashPromptDisabled = "crashPromptDisabled"
         static let lastAcknowledgedWhatsNewVersion = "lastAcknowledgedWhatsNewVersion"
+        static let updateRetrySnapshot = "updateRetrySnapshot"
+        static let lastSuccessfulUpdateCheck = "lastSuccessfulUpdateCheck"
     }
 
     /// Last collapse state, restored at launch. Defaults to expanded so a
@@ -76,6 +79,37 @@ enum Preferences {
     static var settingsPane: String {
         get { UserDefaults.standard.string(forKey: Keys.settingsPane) ?? "" }
         set { UserDefaults.standard.set(newValue, forKey: Keys.settingsPane) }
+    }
+
+    // MARK: - Software update recovery
+
+    /// Pelmet's bounded retry episode after Sparkle loses a scheduled check to
+    /// transient networking. Sparkle owns its normal schedule and preferences;
+    /// this stores only the recovery state Sparkle does not provide.
+    static var updateRetrySnapshot: UpdateRetrySnapshot? {
+        get {
+            guard let data = UserDefaults.standard.data(forKey: Keys.updateRetrySnapshot) else {
+                return nil
+            }
+            return try? JSONDecoder().decode(UpdateRetrySnapshot.self, from: data)
+        }
+        set {
+            guard let newValue,
+                  let data = try? JSONEncoder().encode(newValue)
+            else {
+                UserDefaults.standard.removeObject(forKey: Keys.updateRetrySnapshot)
+                return
+            }
+            UserDefaults.standard.set(data, forKey: Keys.updateRetrySnapshot)
+        }
+    }
+
+    /// Unlike Sparkle's `SULastCheckTime`, this advances only after the feed was
+    /// reached successfully, so Settings never labels an offline failure as a
+    /// successful check.
+    static var lastSuccessfulUpdateCheck: Date? {
+        get { UserDefaults.standard.object(forKey: Keys.lastSuccessfulUpdateCheck) as? Date }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.lastSuccessfulUpdateCheck) }
     }
 
     /// Whether the system Accessibility prompt was ever triggered — needed to

--- a/Sources/Pelmet/Settings/GeneralPaneView.swift
+++ b/Sources/Pelmet/Settings/GeneralPaneView.swift
@@ -7,6 +7,7 @@ import SwiftUI
 /// hatch when the user can't find the chevron (see AppDelegate reopen).
 struct GeneralPaneView: View {
 
+    @ObservedObject private var updater = UpdaterController.shared
     @AppStorage(Preferences.Keys.autoRehide) private var autoRehide = true
     @AppStorage(Preferences.Keys.rehideDelay) private var rehideDelay = 10.0
     @State private var launchAtLogin = (SMAppService.mainApp.status == .enabled)
@@ -60,17 +61,21 @@ struct GeneralPaneView: View {
             // Sparkle owns the "check automatically" preference (its own
             // defaults, no Preferences key). Hidden under `swift run`, where
             // Sparkle is absent and the updater can't run without a bundle.
-            if UpdaterController.shared.isAvailable {
+            if updater.isAvailable {
                 Section("Software Update") {
                     Toggle("Automatically check for updates", isOn: Binding(
                         get: { autoCheckUpdates },
                         set: { enabled in
                             autoCheckUpdates = enabled
-                            UpdaterController.shared.automaticallyChecksForUpdates = enabled
+                            updater.automaticallyChecksForUpdates = enabled
                         }
                     ))
-                    Button("Check for Updates…") {
-                        UpdaterController.shared.checkForUpdates(nil)
+                    Text(updater.status.settingsText)
+                        .font(.caption)
+                        .foregroundStyle(updater.status == .failed ? Color.red : Color.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    Button(updater.availableVersion == nil ? "Check for Updates…" : "Review Update…") {
+                        updater.checkForUpdates(nil)
                     }
                 }
             }

--- a/Sources/Pelmet/Updates/UpdaterController.swift
+++ b/Sources/Pelmet/Updates/UpdaterController.swift
@@ -1,51 +1,341 @@
 import AppKit
+import Combine
+import Foundation
+import PelmetCore
 
-/// Thin facade over Sparkle's `SPUStandardUpdaterController`.
-///
-/// The type exists in every build so call sites (menu, Settings) never need
-/// their own `#if`. Sparkle is embedded only in the XcodeGen `.app` build
-/// (see `project.yml`), so under `swift run` / SPM `canImport(Sparkle)` is
-/// false and this collapses to an inert stub whose `isAvailable` is `false`.
-/// The updater only works from a signed bundle anyway, so there's nothing to
-/// run without one — the same way launch-at-login degrades under `swift run`.
-#if canImport(Sparkle)
-import Sparkle
+enum UpdaterStatus: Equatable {
+    case unavailable
+    case idle(lastSuccessfulCheck: Date?)
+    case checking
+    case waitingForNetwork
+    case retryScheduled(Date)
+    case failed
+    case updateAvailable(version: String)
 
-final class UpdaterController {
-    static let shared = UpdaterController()
-
-    /// True in the bundled app: the "Check for Updates…" menu item and the
-    /// Software Update settings section show themselves off this.
-    var isAvailable: Bool { true }
-
-    // Starts the updater on init; retained for the process lifetime via the
-    // shared singleton so scheduled checks keep running.
-    private let controller: SPUStandardUpdaterController
-
-    private init() {
-        controller = SPUStandardUpdaterController(
-            startingUpdater: true,
-            updaterDelegate: nil,
-            userDriverDelegate: nil
-        )
+    var availableVersion: String? {
+        guard case let .updateAvailable(version) = self else { return nil }
+        return version
     }
 
-    /// Presents Sparkle's update UI (menu item / Settings button action).
+    var settingsText: String {
+        switch self {
+        case .unavailable:
+            return "Software Update is available in the bundled app."
+        case let .idle(lastSuccessfulCheck):
+            guard let lastSuccessfulCheck else {
+                return "Updates are checked daily after you opt in."
+            }
+            let formatter = RelativeDateTimeFormatter()
+            formatter.dateTimeStyle = .named
+            let relative = formatter.localizedString(for: lastSuccessfulCheck, relativeTo: Date())
+            return "Last checked \(relative)."
+        case .checking:
+            return "Checking for updates…"
+        case .waitingForNetwork:
+            return "Offline — retrying when connected."
+        case let .retryScheduled(date):
+            let formatter = RelativeDateTimeFormatter()
+            formatter.dateTimeStyle = .named
+            let relative = formatter.localizedString(for: date, relativeTo: Date())
+            return "Update check failed — retrying \(relative)."
+        case .failed:
+            return "Update check failed — try again."
+        case let .updateAvailable(version):
+            return "Update \(version) is available."
+        }
+    }
+}
+
+/// Thin facade over Sparkle plus Pelmet's bounded network-failure recovery and
+/// menu-bar-friendly update reminder state.
+///
+/// The type exists in every build so call sites never need their own `#if`.
+/// Sparkle is embedded only in the XcodeGen `.app`; `swift run` and tests use
+/// the inert implementation at the bottom of this file.
+#if canImport(Sparkle)
+import Network
+import Sparkle
+
+final class UpdaterController: NSObject, ObservableObject {
+    static let shared = UpdaterController()
+
+    @Published private(set) var status: UpdaterStatus
+
+    var isAvailable: Bool { true }
+    var availableVersion: String? { status.availableVersion }
+
+    private var controller: SPUStandardUpdaterController!
+    private var retryCoordinator: UpdateRetryCoordinator
+    private var retryTimer: Timer?
+    private var pathMonitor: NWPathMonitor?
+    private var connectivityAvailable: Bool?
+    private var automaticChecksObservation: NSKeyValueObservation?
+
+    private override init() {
+        retryCoordinator = UpdateRetryCoordinator(snapshot: Preferences.updateRetrySnapshot)
+        status = .idle(lastSuccessfulCheck: Preferences.lastSuccessfulUpdateCheck)
+        super.init()
+
+        // Both delegates are weakly held by Sparkle, so this singleton owns the
+        // updater controller and acts as the retained delegate for its lifetime.
+        controller = SPUStandardUpdaterController(
+            startingUpdater: true,
+            updaterDelegate: self,
+            userDriverDelegate: self
+        )
+
+        automaticChecksObservation = controller.updater.observe(
+            \SPUUpdater.automaticallyChecksForUpdates,
+            options: [.new]
+        ) { [weak self] _, change in
+            DispatchQueue.main.async {
+                guard let enabled = change.newValue else { return }
+                self?.automaticCheckPreferenceChanged(enabled)
+            }
+        }
+        automaticCheckPreferenceChanged(controller.updater.automaticallyChecksForUpdates)
+    }
+
     @objc func checkForUpdates(_ sender: Any?) {
+        if availableVersion == nil {
+            status = .checking
+        }
         controller.checkForUpdates(sender)
     }
 
-    /// Bridges Sparkle's own "check automatically" preference to the Settings
-    /// toggle. Sparkle persists it under its own defaults — no `Preferences` key.
     var automaticallyChecksForUpdates: Bool {
         get { controller.updater.automaticallyChecksForUpdates }
-        set { controller.updater.automaticallyChecksForUpdates = newValue }
+        set {
+            controller.updater.automaticallyChecksForUpdates = newValue
+            automaticCheckPreferenceChanged(newValue)
+        }
+    }
+
+    private func automaticCheckPreferenceChanged(_ enabled: Bool) {
+        if enabled {
+            startConnectivityMonitoring()
+        } else {
+            retryCoordinator.clear()
+            syncRetryState(effect: .none)
+            stopConnectivityMonitoring()
+            status = .idle(lastSuccessfulCheck: Preferences.lastSuccessfulUpdateCheck)
+        }
+    }
+
+    // MARK: - Connectivity and retry scheduling
+
+    private func startConnectivityMonitoring() {
+        guard pathMonitor == nil else { return }
+        connectivityAvailable = nil
+
+        let monitor = NWPathMonitor()
+        pathMonitor = monitor
+        monitor.pathUpdateHandler = { [weak self] path in
+            DispatchQueue.main.async {
+                self?.connectivityDidChange(path.status == .satisfied)
+            }
+        }
+        monitor.start(queue: DispatchQueue(label: "com.ismatbabirli.Pelmet.update-connectivity"))
+    }
+
+    private func stopConnectivityMonitoring() {
+        pathMonitor?.cancel()
+        pathMonitor = nil
+        connectivityAvailable = nil
+    }
+
+    private func connectivityDidChange(_ available: Bool) {
+        let wasKnown = connectivityAvailable != nil
+        connectivityAvailable = available
+
+        let effect: UpdateRetryEffect
+        if wasKnown {
+            effect = retryCoordinator.connectivityChanged(available: available, now: Date())
+        } else {
+            effect = retryCoordinator.resume(
+                now: Date(),
+                connectivityAvailable: available,
+                automaticallyChecks: automaticallyChecksForUpdates
+            )
+        }
+        syncRetryState(effect: effect)
+    }
+
+    private func syncRetryState(effect: UpdateRetryEffect) {
+        Preferences.updateRetrySnapshot = retryCoordinator.snapshot
+        retryTimer?.invalidate()
+        retryTimer = nil
+
+        switch retryCoordinator.phase {
+        case .inactive:
+            break
+        case .waitingForConnectivity:
+            status = .waitingForNetwork
+        case let .scheduled(date):
+            status = .retryScheduled(date)
+            let delay = max(0.05, date.timeIntervalSinceNow)
+            retryTimer = Timer.scheduledTimer(withTimeInterval: delay, repeats: false) { [weak self] _ in
+                self?.retryTimerDidFire()
+            }
+        case .checking:
+            status = .checking
+        }
+
+        switch effect {
+        case .none:
+            break
+        case .performRetry:
+            status = .checking
+            controller.updater.checkForUpdatesInBackground()
+        case .exhausted:
+            status = .failed
+        }
+    }
+
+    private func retryTimerDidFire() {
+        let effect = retryCoordinator.retryTimerFired(
+            now: Date(),
+            updaterCanCheck: controller.updater.canCheckForUpdates
+        )
+        syncRetryState(effect: effect)
+    }
+
+    private func recordSuccessfulCheck() {
+        let now = Date()
+        Preferences.lastSuccessfulUpdateCheck = now
+        retryCoordinator.clear()
+        syncRetryState(effect: .none)
+        status = .idle(lastSuccessfulCheck: now)
+    }
+
+    private func handleBackgroundFailure(_ error: Error) {
+        guard isTransientNetworkError(error) else {
+            retryCoordinator.clear()
+            syncRetryState(effect: .none)
+            status = .failed
+            return
+        }
+
+        let effect = retryCoordinator.recordNetworkFailure(
+            now: Date(),
+            connectivityAvailable: connectivityAvailable ?? false
+        )
+        syncRetryState(effect: effect)
+    }
+
+    private func isTransientNetworkError(_ error: Error, depth: Int = 0) -> Bool {
+        guard depth < 10 else { return false }
+        let nsError = error as NSError
+        let transientCodes: Set<Int> = [
+            URLError.Code.notConnectedToInternet.rawValue,
+            URLError.Code.networkConnectionLost.rawValue,
+            URLError.Code.timedOut.rawValue,
+            URLError.Code.cannotFindHost.rawValue,
+            URLError.Code.cannotConnectToHost.rawValue,
+            URLError.Code.dnsLookupFailed.rawValue,
+        ]
+        if nsError.domain == NSURLErrorDomain, transientCodes.contains(nsError.code) {
+            return true
+        }
+        if let underlying = nsError.userInfo[NSUnderlyingErrorKey] as? Error,
+           isTransientNetworkError(underlying, depth: depth + 1) {
+            return true
+        }
+        if let errors = nsError.userInfo["NSMultipleUnderlyingErrors"] as? [Error] {
+            return errors.contains { isTransientNetworkError($0, depth: depth + 1) }
+        }
+        return false
+    }
+}
+
+// MARK: - Sparkle delegates
+
+extension UpdaterController: SPUUpdaterDelegate {
+    func updater(_ updater: SPUUpdater, didFindValidUpdate item: SUAppcastItem) {
+        let now = Date()
+        Preferences.lastSuccessfulUpdateCheck = now
+        retryCoordinator.clear()
+        syncRetryState(effect: .none)
+        status = .updateAvailable(version: item.displayVersionString)
+    }
+
+    func updaterDidNotFindUpdate(_ updater: SPUUpdater, error: any Error) {
+        // Sparkle reports an ordinary "already current" result through its
+        // error-shaped no-update path. It still proves the feed was reached.
+        let nsError = error as NSError
+        if nsError.domain == SUSparkleErrorDomain,
+           nsError.code == SUError.noUpdateError.rawValue {
+            recordSuccessfulCheck()
+        }
+    }
+
+    func updater(
+        _ updater: SPUUpdater,
+        didFinishUpdateCycleFor updateCheck: SPUUpdateCheck,
+        error: (any Error)?
+    ) {
+        if let error {
+            let nsError = error as NSError
+            if nsError.domain == SUSparkleErrorDomain,
+               nsError.code == SUError.noUpdateError.rawValue {
+                recordSuccessfulCheck()
+            } else if updateCheck == .updatesInBackground {
+                handleBackgroundFailure(error)
+            } else if retryCoordinator.phase == .inactive {
+                status = .failed
+            } else {
+                // A manual check may happen while recovery is pending. Its
+                // failure must not erase or advance that background episode.
+                syncRetryState(effect: .none)
+            }
+            // User-initiated errors are presented by Sparkle and never create
+            // or advance a background retry episode.
+            return
+        }
+
+        if availableVersion == nil {
+            recordSuccessfulCheck()
+        }
+    }
+}
+
+extension UpdaterController: SPUStandardUserDriverDelegate {
+    var supportsGentleScheduledUpdateReminders: Bool { true }
+
+    func standardUserDriverShouldHandleShowingScheduledUpdate(
+        _ update: SUAppcastItem,
+        andInImmediateFocus immediateFocus: Bool
+    ) -> Bool {
+        // The persistent menu-bar cue owns scheduled discovery. A user click on
+        // that cue calls checkForUpdates and brings Sparkle's standard UI front.
+        false
+    }
+
+    func standardUserDriverWillHandleShowingUpdate(
+        _ handleShowingUpdate: Bool,
+        forUpdate update: SUAppcastItem,
+        state: SPUUserUpdateState
+    ) {
+        guard !handleShowingUpdate, !state.userInitiated else { return }
+        status = .updateAvailable(version: update.displayVersionString)
+    }
+
+    func standardUserDriverDidReceiveUserAttention(forUpdate update: SUAppcastItem) {
+        status = .idle(lastSuccessfulCheck: Preferences.lastSuccessfulUpdateCheck)
+    }
+
+    func standardUserDriverWillFinishUpdateSession() {
+        status = .idle(lastSuccessfulCheck: Preferences.lastSuccessfulUpdateCheck)
     }
 }
 #else
-final class UpdaterController {  // Sparkle absent (swift run / SPM / tests).
+final class UpdaterController: ObservableObject {
     static let shared = UpdaterController()
+
+    @Published private(set) var status: UpdaterStatus = .unavailable
     var isAvailable: Bool { false }
+    var availableVersion: String? { nil }
+
     private init() {}
     @objc func checkForUpdates(_ sender: Any?) {}
     var automaticallyChecksForUpdates: Bool {

--- a/Sources/PelmetCore/MenuBarUpdatePresentation.swift
+++ b/Sources/PelmetCore/MenuBarUpdatePresentation.swift
@@ -1,0 +1,30 @@
+/// Update-specific text that is combined with Pelmet's existing menu-bar
+/// chevron, notch count, tooltip, and accessibility value.
+public struct MenuBarUpdatePresentation: Equatable, Sendable {
+    public let badgeText: String
+    public let actionTitle: String
+    public let tooltipNotice: String?
+    public let accessibilityNotice: String?
+
+    public init(
+        swallowedCount: Int,
+        showsSwallowedCount: Bool,
+        availableVersion: String?
+    ) {
+        let countText = showsSwallowedCount && swallowedCount > 0
+            ? "+\(swallowedCount)"
+            : nil
+        let updateText = availableVersion == nil ? nil : "↑"
+        badgeText = [countText, updateText].compactMap { $0 }.joined(separator: " ")
+
+        if let availableVersion {
+            actionTitle = "Update Pelmet to \(availableVersion)…"
+            tooltipNotice = "Pelmet \(availableVersion) is available. Right-click to update."
+            accessibilityNotice = "Update \(availableVersion) available. Right-click to update."
+        } else {
+            actionTitle = "Check for Updates…"
+            tooltipNotice = nil
+            accessibilityNotice = nil
+        }
+    }
+}

--- a/Sources/PelmetCore/UpdateRetryCoordinator.swift
+++ b/Sources/PelmetCore/UpdateRetryCoordinator.swift
@@ -1,0 +1,195 @@
+import Foundation
+
+/// Persisted portion of an update-check recovery episode.
+///
+/// Sparkle records a failed scheduled check as the latest check time, so a
+/// transient offline moment otherwise postpones the next attempt for a day.
+/// This snapshot survives a Pelmet relaunch and lets the app resume a small,
+/// bounded recovery sequence without replacing Sparkle's normal scheduler.
+public struct UpdateRetrySnapshot: Codable, Equatable, Sendable {
+    public enum Mode: String, Codable, Sendable {
+        case waitingForConnectivity
+        case scheduled
+        case checking
+    }
+
+    /// Number of recovery checks already started, not including Sparkle's
+    /// original scheduled check.
+    public var attemptCount: Int
+    public var mode: Mode
+    public var nextRetryDate: Date?
+
+    public init(attemptCount: Int, mode: Mode, nextRetryDate: Date? = nil) {
+        self.attemptCount = max(0, attemptCount)
+        self.mode = mode
+        self.nextRetryDate = nextRetryDate
+    }
+}
+
+public enum UpdateRetryPhase: Equatable, Sendable {
+    case inactive
+    case waitingForConnectivity
+    case scheduled(Date)
+    case checking
+}
+
+public enum UpdateRetryEffect: Equatable, Sendable {
+    case none
+    case performRetry
+    case exhausted
+}
+
+/// Pure state machine for recovery after a scheduled update check fails due to
+/// transient networking. The app supplies clock, connectivity, persistence,
+/// timers, and the actual update-check closure.
+public struct UpdateRetryCoordinator: Equatable, Sendable {
+    public static let reconnectDebounce: TimeInterval = 30
+    public static let busyRetryDelay: TimeInterval = 60
+    public static let backoffDelays: [TimeInterval] = [5 * 60, 15 * 60, 60 * 60]
+
+    public private(set) var snapshot: UpdateRetrySnapshot?
+
+    public init(snapshot: UpdateRetrySnapshot? = nil) {
+        guard let snapshot,
+              snapshot.attemptCount >= 0,
+              snapshot.attemptCount <= Self.backoffDelays.count
+        else {
+            self.snapshot = nil
+            return
+        }
+        self.snapshot = snapshot
+    }
+
+    public var phase: UpdateRetryPhase {
+        guard let snapshot else { return .inactive }
+        switch snapshot.mode {
+        case .waitingForConnectivity:
+            return .waitingForConnectivity
+        case .scheduled:
+            guard let nextRetryDate = snapshot.nextRetryDate else {
+                return .waitingForConnectivity
+            }
+            return .scheduled(nextRetryDate)
+        case .checking:
+            return .checking
+        }
+    }
+
+    /// Restores a pending episode after launch. A check interrupted by process
+    /// termination is retried after the same reconnect debounce as an overdue
+    /// timer, rather than firing during launch setup.
+    @discardableResult
+    public mutating func resume(
+        now: Date,
+        connectivityAvailable: Bool,
+        automaticallyChecks: Bool
+    ) -> UpdateRetryEffect {
+        guard automaticallyChecks else {
+            snapshot = nil
+            return .none
+        }
+        guard var snapshot else { return .none }
+
+        guard connectivityAvailable else {
+            snapshot.mode = .waitingForConnectivity
+            snapshot.nextRetryDate = nil
+            self.snapshot = snapshot
+            return .none
+        }
+
+        switch snapshot.mode {
+        case .waitingForConnectivity, .checking:
+            snapshot.mode = .scheduled
+            snapshot.nextRetryDate = now.addingTimeInterval(Self.reconnectDebounce)
+        case .scheduled:
+            if snapshot.nextRetryDate == nil || snapshot.nextRetryDate! <= now {
+                snapshot.nextRetryDate = now.addingTimeInterval(Self.reconnectDebounce)
+            }
+        }
+        self.snapshot = snapshot
+        return .none
+    }
+
+    /// Starts or advances a recovery episode after a background check fails.
+    @discardableResult
+    public mutating func recordNetworkFailure(
+        now: Date,
+        connectivityAvailable: Bool
+    ) -> UpdateRetryEffect {
+        var snapshot = snapshot ?? UpdateRetrySnapshot(
+            attemptCount: 0,
+            mode: .waitingForConnectivity
+        )
+
+        guard snapshot.attemptCount < Self.backoffDelays.count else {
+            self.snapshot = nil
+            return .exhausted
+        }
+
+        if connectivityAvailable {
+            let delay = Self.backoffDelays[snapshot.attemptCount]
+            snapshot.mode = .scheduled
+            snapshot.nextRetryDate = now.addingTimeInterval(delay)
+        } else {
+            snapshot.mode = .waitingForConnectivity
+            snapshot.nextRetryDate = nil
+        }
+        self.snapshot = snapshot
+        return .none
+    }
+
+    /// Debounces a real reconnect and pauses an unstarted timer when the path
+    /// drops again. A check already in flight owns its own completion event.
+    @discardableResult
+    public mutating func connectivityChanged(
+        available: Bool,
+        now: Date
+    ) -> UpdateRetryEffect {
+        guard var snapshot else { return .none }
+        if available {
+            guard snapshot.mode == .waitingForConnectivity else { return .none }
+            snapshot.mode = .scheduled
+            snapshot.nextRetryDate = now.addingTimeInterval(Self.reconnectDebounce)
+        } else {
+            guard snapshot.mode == .scheduled else { return .none }
+            snapshot.mode = .waitingForConnectivity
+            snapshot.nextRetryDate = nil
+        }
+        self.snapshot = snapshot
+        return .none
+    }
+
+    /// Claims a due retry exactly once. If Sparkle is busy, preserve the
+    /// attempt and move the timer by a minute instead of overlapping sessions.
+    @discardableResult
+    public mutating func retryTimerFired(
+        now: Date,
+        updaterCanCheck: Bool
+    ) -> UpdateRetryEffect {
+        guard var snapshot,
+              snapshot.mode == .scheduled,
+              let nextRetryDate = snapshot.nextRetryDate,
+              nextRetryDate <= now
+        else { return .none }
+
+        guard updaterCanCheck else {
+            snapshot.nextRetryDate = now.addingTimeInterval(Self.busyRetryDelay)
+            self.snapshot = snapshot
+            return .none
+        }
+
+        guard snapshot.attemptCount < Self.backoffDelays.count else {
+            self.snapshot = nil
+            return .exhausted
+        }
+        snapshot.attemptCount += 1
+        snapshot.mode = .checking
+        snapshot.nextRetryDate = nil
+        self.snapshot = snapshot
+        return .performRetry
+    }
+
+    public mutating func clear() {
+        snapshot = nil
+    }
+}

--- a/Tests/PelmetCoreTests/MenuBarUpdatePresentationTests.swift
+++ b/Tests/PelmetCoreTests/MenuBarUpdatePresentationTests.swift
@@ -1,0 +1,50 @@
+import Testing
+@testable import PelmetCore
+
+struct MenuBarUpdatePresentationTests {
+    @Test func updateOnlyPresentation() {
+        let presentation = MenuBarUpdatePresentation(
+            swallowedCount: 0,
+            showsSwallowedCount: false,
+            availableVersion: "0.4.0"
+        )
+
+        #expect(presentation.badgeText == "↑")
+        #expect(presentation.actionTitle == "Update Pelmet to 0.4.0…")
+        #expect(presentation.tooltipNotice == "Pelmet 0.4.0 is available. Right-click to update.")
+        #expect(presentation.accessibilityNotice == "Update 0.4.0 available. Right-click to update.")
+    }
+
+    @Test func notchCountOnlyPresentation() {
+        let presentation = MenuBarUpdatePresentation(
+            swallowedCount: 3,
+            showsSwallowedCount: true,
+            availableVersion: nil
+        )
+
+        #expect(presentation.badgeText == "+3")
+        #expect(presentation.actionTitle == "Check for Updates…")
+        #expect(presentation.tooltipNotice == nil)
+        #expect(presentation.accessibilityNotice == nil)
+    }
+
+    @Test func combinedPresentation() {
+        let presentation = MenuBarUpdatePresentation(
+            swallowedCount: 2,
+            showsSwallowedCount: true,
+            availableVersion: "1.0.0"
+        )
+
+        #expect(presentation.badgeText == "+2 ↑")
+    }
+
+    @Test func hiddenNotchCountStillShowsUpdate() {
+        let presentation = MenuBarUpdatePresentation(
+            swallowedCount: 4,
+            showsSwallowedCount: false,
+            availableVersion: "1.0.0"
+        )
+
+        #expect(presentation.badgeText == "↑")
+    }
+}

--- a/Tests/PelmetCoreTests/UpdateRetryCoordinatorTests.swift
+++ b/Tests/PelmetCoreTests/UpdateRetryCoordinatorTests.swift
@@ -1,0 +1,111 @@
+import Foundation
+import Testing
+@testable import PelmetCore
+
+struct UpdateRetryCoordinatorTests {
+    private let now = Date(timeIntervalSince1970: 1_800_000_000)
+
+    @Test func offlineFailureWaitsForConnectivity() {
+        var coordinator = UpdateRetryCoordinator()
+        coordinator.recordNetworkFailure(now: now, connectivityAvailable: false)
+
+        #expect(coordinator.phase == .waitingForConnectivity)
+        #expect(coordinator.snapshot?.attemptCount == 0)
+    }
+
+    @Test func reconnectDebouncesForThirtySeconds() {
+        var coordinator = UpdateRetryCoordinator()
+        coordinator.recordNetworkFailure(now: now, connectivityAvailable: false)
+        coordinator.connectivityChanged(available: true, now: now)
+
+        #expect(coordinator.phase == .scheduled(now.addingTimeInterval(30)))
+    }
+
+    @Test func availablePathUsesBackoffSequence() {
+        var coordinator = UpdateRetryCoordinator()
+        coordinator.recordNetworkFailure(now: now, connectivityAvailable: true)
+        #expect(coordinator.phase == .scheduled(now.addingTimeInterval(5 * 60)))
+
+        let firstDue = now.addingTimeInterval(5 * 60)
+        #expect(coordinator.retryTimerFired(now: firstDue, updaterCanCheck: true) == .performRetry)
+        coordinator.recordNetworkFailure(now: firstDue, connectivityAvailable: true)
+        #expect(coordinator.phase == .scheduled(firstDue.addingTimeInterval(15 * 60)))
+
+        let secondDue = firstDue.addingTimeInterval(15 * 60)
+        #expect(coordinator.retryTimerFired(now: secondDue, updaterCanCheck: true) == .performRetry)
+        coordinator.recordNetworkFailure(now: secondDue, connectivityAvailable: true)
+        #expect(coordinator.phase == .scheduled(secondDue.addingTimeInterval(60 * 60)))
+    }
+
+    @Test func threeRecoveryChecksExhaustTheEpisode() {
+        var coordinator = UpdateRetryCoordinator()
+        var date = now
+
+        for delay in UpdateRetryCoordinator.backoffDelays {
+            coordinator.recordNetworkFailure(now: date, connectivityAvailable: true)
+            date = date.addingTimeInterval(delay)
+            #expect(coordinator.retryTimerFired(now: date, updaterCanCheck: true) == .performRetry)
+        }
+
+        #expect(coordinator.recordNetworkFailure(now: date, connectivityAvailable: true) == .exhausted)
+        #expect(coordinator.phase == .inactive)
+    }
+
+    @Test func busyUpdaterDoesNotConsumeAttemptOrOverlap() {
+        var coordinator = UpdateRetryCoordinator()
+        coordinator.recordNetworkFailure(now: now, connectivityAvailable: true)
+        let due = now.addingTimeInterval(5 * 60)
+
+        #expect(coordinator.retryTimerFired(now: due, updaterCanCheck: false) == .none)
+        #expect(coordinator.snapshot?.attemptCount == 0)
+        #expect(coordinator.phase == .scheduled(due.addingTimeInterval(60)))
+        #expect(coordinator.retryTimerFired(now: due, updaterCanCheck: true) == .none)
+    }
+
+    @Test func persistedRetryResumesAfterRelaunch() {
+        let snapshot = UpdateRetrySnapshot(
+            attemptCount: 1,
+            mode: .checking
+        )
+        var coordinator = UpdateRetryCoordinator(snapshot: snapshot)
+        coordinator.resume(now: now, connectivityAvailable: true, automaticallyChecks: true)
+
+        #expect(coordinator.phase == .scheduled(now.addingTimeInterval(30)))
+        #expect(coordinator.snapshot?.attemptCount == 1)
+    }
+
+    @Test func invalidPersistedAttemptCountIsDiscarded() {
+        let encoded = """
+        {"attemptCount":-1,"mode":"scheduled","nextRetryDate":0}
+        """.data(using: .utf8)!
+        let snapshot = try! JSONDecoder().decode(UpdateRetrySnapshot.self, from: encoded)
+
+        let coordinator = UpdateRetryCoordinator(snapshot: snapshot)
+
+        #expect(coordinator.phase == .inactive)
+    }
+
+    @Test func optOutAndSuccessClearPendingRetry() {
+        var optedOut = UpdateRetryCoordinator(
+            snapshot: UpdateRetrySnapshot(attemptCount: 1, mode: .waitingForConnectivity)
+        )
+        optedOut.resume(now: now, connectivityAvailable: true, automaticallyChecks: false)
+        #expect(optedOut.phase == .inactive)
+
+        var succeeded = UpdateRetryCoordinator(
+            snapshot: UpdateRetrySnapshot(attemptCount: 1, mode: .waitingForConnectivity)
+        )
+        succeeded.clear()
+        #expect(succeeded.phase == .inactive)
+    }
+
+    @Test func pathFlapRestartsReconnectDebounce() {
+        var coordinator = UpdateRetryCoordinator()
+        coordinator.recordNetworkFailure(now: now, connectivityAvailable: false)
+        coordinator.connectivityChanged(available: true, now: now)
+        coordinator.connectivityChanged(available: false, now: now.addingTimeInterval(10))
+        coordinator.connectivityChanged(available: true, now: now.addingTimeInterval(20))
+
+        #expect(coordinator.phase == .scheduled(now.addingTimeInterval(50)))
+    }
+}

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -8,9 +8,12 @@ Releases are automated. Pushing a `vX.Y.Z` tag triggers
 3. **notarizes** the app and the DMG with Apple and staples the tickets,
 4. packages `Pelmet-<version>.dmg` + `Pelmet-<version>.zip`,
 5. creates the GitHub Release with generated notes + checksums,
-6. EdDSA-signs the `.zip` and appends an item to the Sparkle **appcast** on the
-   `gh-pages` branch (served by GitHub Pages), and
-7. bumps the cask in the `ismatBabirli/homebrew-pelmet` tap.
+6. verifies the bundled Sparkle consent, daily-check, and user-approved install
+   configuration,
+7. EdDSA-signs the `.zip`, validates the appcast and enclosure, appends the item
+   to the `gh-pages` branch, and waits until GitHub Pages serves that exact
+   version/build, and
+8. bumps the cask in the `ismatBabirli/homebrew-pelmet` tap.
 
 The **git tag is the source of truth** for the released version — the workflow
 patches `project.yml`'s `CFBundleShortVersionString` from it, so you don't edit
@@ -156,6 +159,12 @@ up the new version. The workflow also verifies that `CHANGELOG.md` is present in
 locally even when they are offline. If they skipped releases, Pelmet shows every
 entry newer than the last one they dismissed.
 
+The Sparkle publish step fails if the existing or generated appcast is not valid
+XML, the new build does not exceed every published build, the enclosure lacks an
+EdDSA signature or byte length, the release ZIP cannot be reached, or GitHub
+Pages does not expose the new item within five minutes. A failed publish check
+is a failed release; do not announce it as available until the workflow is green.
+
 ## Testing the build without secrets
 
 Use the manual **dry run** — it builds the app and uploads it as a workflow
@@ -169,3 +178,18 @@ Actions → **Release** → **Run workflow** → set a version, leave **dry_run*
 spctl -a -vvv -t install /Applications/Pelmet.app   # → accepted, source=Notarized Developer ID
 xcrun stapler validate /Applications/Pelmet.app
 ```
+
+Before announcing the release, keep an older signed build installed and run the
+update path end to end:
+
+1. With automatic checks enabled, take the Mac offline when a scheduled check
+   runs, reconnect it, and confirm Settings reports the offline state and a new
+   check begins within one minute.
+2. Confirm the menu bar shows **↑** (or **+N ↑**) and Settings names the new
+   version without opening Sparkle's window in the background.
+3. Choose **Update Pelmet to _version_…**, approve **Install and Relaunch**, and
+   verify the launched app's version and build.
+4. Disable automatic checks and verify background requests and pending retries
+   stop, while **Check for Updates…** still performs a manual check.
+5. Repeat offline failures and confirm only three recovery checks occur before
+   Pelmet falls back to Sparkle's next daily check.

--- a/project.yml
+++ b/project.yml
@@ -57,7 +57,13 @@ targets:
         # and the login Keychain. See docs/RELEASING.md → "Sparkle auto-updates".
         SUPublicEDKey: "PNXQ+qmeChvGLPr2kXxFLXC6U9mwjbQTlJo5RHA3eSU="
         # SUEnableAutomaticChecks is intentionally unset: Sparkle asks the user
-        # once on first launch whether to check automatically (trust-first).
+        # once during early use whether to check automatically (trust-first).
+        # Opted-in scheduled checks run once per day. Network-only recovery is
+        # bounded separately by UpdaterController and never changes this cadence.
+        SUScheduledCheckInterval: 86400
+        # Never inherit Sparkle's legacy SUAutomaticallyUpdate preference. Pelmet
+        # always presents Sparkle's standard approval UI before installation.
+        SUAllowsAutomaticUpdates: false
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.ismatbabirli.Pelmet


### PR DESCRIPTION
## Summary

- add persisted, bounded recovery for scheduled Sparkle checks that fail because of transient network connectivity
- integrate Sparkle gentle reminders with Pelmet’s menu-bar cue and Settings status
- keep automatic checks opt-in and require approval before installation
- harden release-time appcast, enclosure, build-number, ZIP, and public-feed validation

## Root cause

Sparkle records a failed scheduled check as the latest check time. When Pelmet’s daily check ran while the Mac was offline, the failed attempt delayed the next scheduled check by another 24 hours without presenting any visible status or retry path.

## User impact

After opting into daily checks, temporary network failures now recover after connectivity returns or through bounded backoff. Available updates remain visible as `↑` or `+N ↑`, and selecting the update action brings Sparkle’s standard Install and Relaunch dialog into focus. Installation always requires user approval.

## Validation

- `swift test` — 165 tests passed
- `swiftformat Sources Tests --lint`
- XcodeGen Release build with Sparkle 2.9.4 and `CODE_SIGNING_ALLOWED=NO`
- built Info.plist checked for the daily interval, disabled automatic installation, unset consent key, and embedded Sparkle framework
- release workflow YAML and modified shell blocks syntax-checked
- appcast XML/XPath validation exercised against the public feed format

## Release verification

The signed older-build-to-newer-build installation flow must be completed when the next signed release is published. The checklist is included in `docs/RELEASING.md`.
