### PR TITLE
Fix What's New modal footer clipping

### DIFF
--- a/Sources/Pelmet/WhatsNew/WhatsNewWindowController.swift
+++ b/Sources/Pelmet/WhatsNew/WhatsNewWindowController.swift
@@ -152,7 +152,10 @@ final class WhatsNewWindowController: NSWindowController, NSWindowDelegate {
             defer: false
         )
         window.title = "What's New in Pelmet"
-        window.minSize = NSSize(width: 460, height: 360)
+        // Match WhatsNewView's minimum content size. NSWindow.minSize includes
+        // the title bar, which allowed the hosting view's footer to be clipped
+        // by the title-bar height when the window was resized to its minimum.
+        window.contentMinSize = NSSize(width: 460, height: 360)
         window.isReleasedWhenClosed = false
         window.collectionBehavior = [.moveToActiveSpace]
         window.delegate = self


### PR DESCRIPTION
## Summary

- enforce the What's New window minimum on its content area
- preserve the footer's intended padding and button alignment at the minimum window size

## Root cause

`NSWindow.minSize` includes the title bar, while `WhatsNewView` requires the full 360-point minimum for its content. At the smallest permitted window size, the title bar consumed part of that height and clipped the bottom of the SwiftUI hosting view.

## Impact

The changelog link and Done button now remain fully visible and correctly spaced from the bottom edge when the modal is resized to its minimum size.

## Verification

- `swift test` — 165 tests passed
