### PR TITLE
Add show-on-hover menu bar reveal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Show on hover** can now be enabled in General settings to reveal managed
+  icons whenever the pointer enters the menu bar. It uses the existing
+  permission-free divider and follows the configured auto-rehide behavior.
+
 ## [0.3.3] - 2026-07-22
 
 ### Added

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -57,7 +57,8 @@ Pelmet occupies a deliberate position in that landscape:
 *Goal: something people can install and love in under a minute.*
 
 - **Fluid animations** for expand/collapse (the "Vanilla moment" — icons glide, not blink)
-- **Show on hover / scroll:** reveal hidden items when the pointer touches the menu bar or the user scrolls on it
+- ✅ **Show on hover:** opt-in reveal when the pointer touches the menu bar
+- **Show on scroll:** reveal hidden items when the user scrolls on the menu bar
 - **Custom hotkey recorder** (replace hardcoded ⌥⌘B)
 - ✅ **Onboarding:** first-launch walkthrough teaching the ⌘-drag gesture (shipped in 0.1.0)
 - ✅ **App icon & identity:** pelmet/curtain metaphor, warm and crafted (shipped in 0.1.0)

--- a/README.md
+++ b/README.md
@@ -22,8 +22,8 @@ This one hides your menu bar clutter, so nothing disappears behind the MacBook n
 
 > [!NOTE]
 > **Status: shipping.** Hide/show works with zero special permissions, and the
-> notch-aware Shelf panel and opt-in one-click access have shipped. Show-on-hover
-> and profiles are next on the [roadmap](#roadmap).
+> notch-aware Shelf panel, opt-in one-click access, and opt-in show-on-hover
+> have shipped. Profiles are next on the [roadmap](#roadmap).
 
 ## Why
 
@@ -86,11 +86,12 @@ that you review and submit yourself.
 | Action | How |
 |---|---|
 | Show/hide managed icons | Click the ‹ / › toggle, or press **⌥⌘B** |
+| Reveal managed icons on hover | Enable **Show hidden items on hover** in Settings, then move the pointer into the menu bar |
 | Keep an icon always visible | ⌘-drag it to the **right** of the ╱ divider |
 | See why icons are missing | Hover or right-click the toggle when it shows **+N** |
 | Lost the divider? | Right-click the toggle → Reset Divider Position |
 | Fit more icons beside the notch | Settings → Make Room… (incl. tighter icon spacing) |
-| Settings (auto-rehide, launch at login) | Right-click the toggle → Settings… |
+| Settings (hover, auto-rehide, launch at login) | Right-click the toggle → Settings… |
 | Quit | Right-click the toggle → Quit Pelmet |
 
 ## Install
@@ -162,7 +163,7 @@ open Pelmet.xcodeproj   # then build & run with ⌘R
 
 - [x] **The Shelf** — a blurred, rounded panel below the notch listing the icons macOS hid, opened by clicking the count (or ⌥⌘N). Rows show each item's app icon and name — **never a screen capture**, so no Screen Recording permission and no purple recording dot.
 - [x] **One-click access** — an *opt-in* Accessibility toggle that opens hidden items with a single click (and identifies them on macOS 26 Tahoe). Off by default; everything else works without it.
-- [ ] Show on hover — reveal when the pointer touches the menu bar
+- [x] Show on hover: reveal when the pointer touches the menu bar (opt-in)
 - [ ] Profiles and per-item rules (e.g. "presentation mode")
 - [ ] Custom hotkey recorder (replace the hardcoded ⌥⌘B)
 - [x] **Notarized releases + Homebrew cask** — a signed, notarized `.dmg` on every tagged release; `brew install --cask ismatBabirli/pelmet/pelmet`

--- a/Sources/Pelmet/AppDelegate.swift
+++ b/Sources/Pelmet/AppDelegate.swift
@@ -68,6 +68,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     /// Record a clean shutdown so the next launch doesn't mistake this quit for
     /// a crash. SIGINT/SIGTERM are handled separately in CrashReportMonitor.
     func applicationWillTerminate(_ notification: Notification) {
+        MenuBarManager.shared.tearDown()
         CrashReportMonitor.shared.markCleanExit()
     }
 
@@ -114,6 +115,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         ]
         if Preferences.autoRehide {
             lines.append("  • Revealed icons re-hide after \(Int(Preferences.rehideDelay)) s (right-click the chevron → Settings).")
+        }
+        if Preferences.showOnHover {
+            lines.append("  • Show on hover is on: move the pointer into the menu bar to reveal icons.")
         }
         lines.append(contentsOf: [
             "  • A number next to the chevron (like +3) means that many icons don't fit",

--- a/Sources/Pelmet/MenuBarHoverMonitor.swift
+++ b/Sources/Pelmet/MenuBarHoverMonitor.swift
@@ -1,0 +1,174 @@
+import AppKit
+import os
+import PelmetCore
+
+/// Observes permission-free pointer movement and emits edge transitions for
+/// the full menu bar band on the display currently hosting Pelmet's toggle.
+final class MenuBarHoverMonitor: NSObject {
+
+    typealias Region = (toggleFrame: CGRect, screenFrame: CGRect)
+
+    private let logger = Logger(
+        subsystem: "com.ismatbabirli.Pelmet",
+        category: "MenuBarHoverMonitor"
+    )
+
+    private var tracker = MenuBarHoverTracker()
+    private var regionProvider: (() -> Region?)?
+    private var onTransition: ((MenuBarHoverTransition) -> Void)?
+
+    private var globalEventMonitor: Any?
+    private var localEventMonitor: Any?
+    private var observers: [(center: NotificationCenter, token: NSObjectProtocol)] = []
+    private weak var toggleButton: NSStatusBarButton?
+    private var toggleTrackingArea: NSTrackingArea?
+    private var running = false
+
+    var isPointerInMenuBar: Bool {
+        running && tracker.isPointerInside
+    }
+
+    func attach(to button: NSStatusBarButton) {
+        if toggleButton === button { return }
+        removeToggleTrackingArea()
+        toggleButton = button
+        if running {
+            installToggleTrackingArea()
+            evaluatePointer()
+        }
+    }
+
+    func start(
+        regionProvider: @escaping () -> Region?,
+        onTransition: @escaping (MenuBarHoverTransition) -> Void
+    ) {
+        self.regionProvider = regionProvider
+        self.onTransition = onTransition
+
+        guard !running else {
+            evaluatePointer()
+            return
+        }
+        running = true
+
+        let mask: NSEvent.EventTypeMask = [
+            .mouseMoved,
+            .leftMouseUp,
+            .rightMouseUp,
+            .otherMouseUp,
+        ]
+        globalEventMonitor = NSEvent.addGlobalMonitorForEvents(matching: mask) { [weak self] _ in
+            self?.evaluatePointer()
+        }
+        if globalEventMonitor == nil {
+            logger.error("Unable to install the global hover event monitor")
+        }
+
+        localEventMonitor = NSEvent.addLocalMonitorForEvents(matching: mask) { [weak self] event in
+            self?.evaluatePointer()
+            return event
+        }
+
+        installToggleTrackingArea()
+        installDisplayObservers()
+        evaluatePointer()
+    }
+
+    func stop() {
+        guard running else { return }
+        running = false
+
+        if let globalEventMonitor {
+            NSEvent.removeMonitor(globalEventMonitor)
+        }
+        if let localEventMonitor {
+            NSEvent.removeMonitor(localEventMonitor)
+        }
+        globalEventMonitor = nil
+        localEventMonitor = nil
+
+        removeToggleTrackingArea()
+        observers.forEach { $0.center.removeObserver($0.token) }
+        observers = []
+        tracker.reset()
+        regionProvider = nil
+        onTransition = nil
+    }
+
+    @objc private func mouseEntered(_ event: NSEvent) {
+        evaluatePointer()
+    }
+
+    @objc private func mouseExited(_ event: NSEvent) {
+        evaluatePointer()
+    }
+
+    private func evaluatePointer() {
+        guard running else { return }
+        guard Thread.isMainThread else {
+            DispatchQueue.main.async { [weak self] in
+                self?.evaluatePointer()
+            }
+            return
+        }
+
+        let region = regionProvider?()
+        let transition = tracker.update(
+            enabled: true,
+            buttonsDown: NSEvent.pressedMouseButtons != 0,
+            point: NSEvent.mouseLocation,
+            toggleFrame: region?.toggleFrame,
+            screenFrame: region?.screenFrame
+        )
+        if let transition {
+            onTransition?(transition)
+        }
+    }
+
+    private func installToggleTrackingArea() {
+        guard toggleTrackingArea == nil, let toggleButton else { return }
+        let area = NSTrackingArea(
+            rect: .zero,
+            options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+            owner: self,
+            userInfo: nil
+        )
+        toggleButton.addTrackingArea(area)
+        toggleTrackingArea = area
+    }
+
+    private func removeToggleTrackingArea() {
+        if let toggleTrackingArea, let toggleButton {
+            toggleButton.removeTrackingArea(toggleTrackingArea)
+        }
+        toggleTrackingArea = nil
+    }
+
+    private func installDisplayObservers() {
+        guard observers.isEmpty else { return }
+        let workspaceCenter = NSWorkspace.shared.notificationCenter
+        observers = [
+            (.default, NotificationCenter.default.addObserver(
+                forName: NSApplication.didChangeScreenParametersNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                self?.evaluatePointer()
+            }),
+            (workspaceCenter, workspaceCenter.addObserver(
+                forName: NSWorkspace.activeSpaceDidChangeNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                self?.evaluatePointer()
+            }),
+            (workspaceCenter, workspaceCenter.addObserver(
+                forName: NSWorkspace.didWakeNotification,
+                object: nil,
+                queue: .main
+            ) { [weak self] _ in
+                self?.evaluatePointer()
+            }),
+        ]
+    }
+}

--- a/Sources/Pelmet/MenuBarManager.swift
+++ b/Sources/Pelmet/MenuBarManager.swift
@@ -43,6 +43,9 @@ final class MenuBarManager: NSObject {
 
     private(set) var isCollapsed = false
     private var rehideTimer: Timer?
+    private let hoverMonitor = MenuBarHoverMonitor()
+    private var lastShowOnHoverPreference = Preferences.showOnHover
+    private var lastAutoRehidePreference = Preferences.autoRehide
 
     private var toggleItem: NSStatusItem!
     private var separatorItem: NSStatusItem!
@@ -106,20 +109,20 @@ final class MenuBarManager: NSObject {
         // Never auto-collapse under an open tip popover or Pelmet window;
         // restart the full delay once everything is closed.
         UIActivityTracker.shared.onFirstOpened = { [weak self] in
-            self?.rehideTimer?.invalidate()
+            self?.cancelRehide()
         }
         UIActivityTracker.shared.onAllClosed = { [weak self] in
             guard let self, !self.isCollapsed else { return }
             self.scheduleRehideIfNeeded()
         }
 
-        // The Settings toggle for the chevron count writes straight to
-        // UserDefaults (@AppStorage); reflect changes immediately.
+        // Settings writes straight to UserDefaults through @AppStorage.
+        // Reflect display and behavior changes immediately.
         NotificationCenter.default.addObserver(
             forName: UserDefaults.didChangeNotification,
             object: nil, queue: .main
         ) { [weak self] _ in
-            self?.updateToggleIcon()
+            self?.preferencesDidChange()
         }
 
         // Restore the last collapse state. First launch starts EXPANDED and
@@ -130,6 +133,9 @@ final class MenuBarManager: NSObject {
         } else {
             expand(scheduleRehide: false)
         }
+        lastShowOnHoverPreference = Preferences.showOnHover
+        lastAutoRehidePreference = Preferences.autoRehide
+        configureHoverMonitoring()
 
         StatusItemActivationEngine.shared.start()
         // The engine's directory changes on its own schedule (grant lands,
@@ -141,6 +147,12 @@ final class MenuBarManager: NSObject {
 
         NotchLayoutMonitor.shared.requestMeasurement(reason: .launch)
         armOnboardingFallback()
+    }
+
+    func tearDown() {
+        cancelRehide()
+        onboardingFallbackTimer?.invalidate()
+        hoverMonitor.stop()
     }
 
     /// Sparkle's scheduled update UI is deliberately replaced by a persistent
@@ -212,6 +224,7 @@ final class MenuBarManager: NSObject {
         button.sendAction(on: [.leftMouseUp, .rightMouseUp])
         button.imagePosition = .imageLeading
         button.setAccessibilityLabel("Pelmet")
+        hoverMonitor.attach(to: button)
     }
 
     private func configureSeparatorButton(_ item: NSStatusItem) {
@@ -229,8 +242,18 @@ final class MenuBarManager: NSObject {
     }
 
     func expand(scheduleRehide: Bool = true) {
+        setExpanded(persistState: true, scheduleRehide: scheduleRehide)
+    }
+
+    private func expandForHover() {
+        setExpanded(persistState: false, scheduleRehide: false)
+    }
+
+    private func setExpanded(persistState: Bool, scheduleRehide: Bool) {
         isCollapsed = false
-        Preferences.isCollapsed = false
+        if persistState {
+            Preferences.isCollapsed = false
+        }
         separatorItem.length = expandedSeparatorLength
         separatorItem.button?.image = separatorImage()
         updateToggleIcon()
@@ -243,7 +266,7 @@ final class MenuBarManager: NSObject {
         ShelfPanelController.shared.hide(animated: false)
         isCollapsed = true
         Preferences.isCollapsed = true
-        rehideTimer?.invalidate()
+        cancelRehide()
         separatorItem.length = collapsedSeparatorLength
         // Hide the divider glyph while it's a giant invisible spacer.
         separatorItem.button?.image = nil
@@ -253,6 +276,67 @@ final class MenuBarManager: NSObject {
         separatorSwallowed = false
         updateToggleIcon()
         NotchLayoutMonitor.shared.requestMeasurement(reason: .collapseSettled)
+    }
+
+    // MARK: - Show on hover
+
+    private func configureHoverMonitoring() {
+        guard Preferences.showOnHover else {
+            hoverMonitor.stop()
+            return
+        }
+        hoverMonitor.start(
+            regionProvider: { [weak self] in
+                self?.currentHoverRegion
+            },
+            onTransition: { [weak self] transition in
+                self?.handleHoverTransition(transition)
+            }
+        )
+    }
+
+    private var currentHoverRegion: MenuBarHoverMonitor.Region? {
+        guard let window = toggleItem?.button?.window,
+              window.isVisible,
+              let screen = window.screen
+        else { return nil }
+        return (toggleFrame: window.frame, screenFrame: screen.frame)
+    }
+
+    private func handleHoverTransition(_ transition: MenuBarHoverTransition) {
+        let decision = MenuBarHoverPolicy.decide(
+            transition: transition,
+            isCollapsed: isCollapsed,
+            autoRehide: Preferences.autoRehide
+        )
+        if decision.cancelRehide {
+            cancelRehide()
+        }
+        if decision.reveal {
+            expandForHover()
+        }
+        if decision.scheduleRehide {
+            scheduleRehideIfNeeded()
+        }
+    }
+
+    private func preferencesDidChange() {
+        updateToggleIcon()
+
+        let showOnHover = Preferences.showOnHover
+        if showOnHover != lastShowOnHoverPreference {
+            lastShowOnHoverPreference = showOnHover
+            configureHoverMonitoring()
+        }
+
+        let autoRehide = Preferences.autoRehide
+        guard autoRehide != lastAutoRehidePreference else { return }
+        lastAutoRehidePreference = autoRehide
+        if autoRehide {
+            scheduleRehideIfNeeded()
+        } else {
+            cancelRehide()
+        }
     }
 
     // MARK: - Layout monitoring
@@ -674,15 +758,29 @@ final class MenuBarManager: NSObject {
 
     // MARK: - Auto-rehide
 
-    private func scheduleRehideIfNeeded() {
+    private func cancelRehide() {
         rehideTimer?.invalidate()
-        guard Preferences.autoRehide,
+        rehideTimer = nil
+    }
+
+    private func scheduleRehideIfNeeded() {
+        cancelRehide()
+        guard !isCollapsed,
+              Preferences.autoRehide,
+              !hoverMonitor.isPointerInMenuBar,
               UIActivityTracker.shared.openSurfaces == 0 else { return }
         rehideTimer = Timer.scheduledTimer(
             withTimeInterval: Preferences.rehideDelay,
             repeats: false
         ) { [weak self] _ in
-            self?.collapse()
+            guard let self else { return }
+            self.rehideTimer = nil
+            guard !self.isCollapsed,
+                  Preferences.autoRehide,
+                  !self.hoverMonitor.isPointerInMenuBar,
+                  UIActivityTracker.shared.openSurfaces == 0
+            else { return }
+            self.collapse()
         }
     }
 

--- a/Sources/Pelmet/Preferences.swift
+++ b/Sources/Pelmet/Preferences.swift
@@ -9,6 +9,7 @@ enum Preferences {
     enum Keys {
         static let autoRehide = "autoRehide"
         static let rehideDelay = "rehideDelay"
+        static let showOnHover = "showOnHover"
         static let isCollapsed = "isCollapsed"
         static let showSwallowedCount = "showSwallowedCount"
         static let didShowDividerTip = "didShowDividerTip"
@@ -44,6 +45,12 @@ enum Preferences {
 
     static var autoRehide: Bool {
         UserDefaults.standard.object(forKey: Keys.autoRehide) as? Bool ?? true
+    }
+
+    /// Opt-in accelerator that reveals managed items when the pointer enters
+    /// the menu bar. The click and hotkey controls remain available either way.
+    static var showOnHover: Bool {
+        UserDefaults.standard.bool(forKey: Keys.showOnHover)
     }
 
     /// Seconds before revealed items hide again.

--- a/Sources/Pelmet/Settings/GeneralPaneView.swift
+++ b/Sources/Pelmet/Settings/GeneralPaneView.swift
@@ -10,6 +10,7 @@ struct GeneralPaneView: View {
     @ObservedObject private var updater = UpdaterController.shared
     @AppStorage(Preferences.Keys.autoRehide) private var autoRehide = true
     @AppStorage(Preferences.Keys.rehideDelay) private var rehideDelay = 10.0
+    @AppStorage(Preferences.Keys.showOnHover) private var showOnHover = false
     @State private var launchAtLogin = (SMAppService.mainApp.status == .enabled)
     @State private var launchAtLoginError: String?
     @State private var autoCheckUpdates = UpdaterController.shared.automaticallyChecksForUpdates
@@ -23,6 +24,11 @@ struct GeneralPaneView: View {
     var body: some View {
         Form {
             Section("Behavior") {
+                Toggle("Show hidden items on hover", isOn: $showOnHover)
+                Text("Move the pointer into the menu bar to reveal managed items.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+
                 Toggle("Automatically re-hide items", isOn: $autoRehide)
 
                 if autoRehide {

--- a/Sources/PelmetCore/MenuBarHoverPolicy.swift
+++ b/Sources/PelmetCore/MenuBarHoverPolicy.swift
@@ -1,0 +1,118 @@
+import CoreGraphics
+
+/// A pointer transition across the menu bar region that currently hosts
+/// Pelmet's toggle.
+public enum MenuBarHoverTransition: Equatable {
+    case entered
+    case exited
+}
+
+/// Pure geometry for turning Pelmet's live status-item frame into the full
+/// horizontal menu bar region on that display.
+public enum MenuBarHoverRegion {
+
+    public static func band(toggleFrame: CGRect?, screenFrame: CGRect?) -> CGRect? {
+        guard let toggleFrame, let screenFrame,
+              toggleFrame.width > 0, toggleFrame.height > 0,
+              screenFrame.width > 0, screenFrame.height > 0
+        else { return nil }
+
+        let minY = max(toggleFrame.minY, screenFrame.minY)
+        let maxY = min(toggleFrame.maxY, screenFrame.maxY)
+        guard maxY > minY, toggleFrame.maxX > screenFrame.minX,
+              toggleFrame.minX < screenFrame.maxX
+        else { return nil }
+
+        return CGRect(
+            x: screenFrame.minX,
+            y: minY,
+            width: screenFrame.width,
+            height: maxY - minY
+        )
+    }
+
+    public static func contains(
+        _ point: CGPoint,
+        toggleFrame: CGRect?,
+        screenFrame: CGRect?
+    ) -> Bool {
+        guard let band = band(toggleFrame: toggleFrame, screenFrame: screenFrame) else {
+            return false
+        }
+        return point.x >= band.minX && point.x < band.maxX
+            && point.y >= band.minY && point.y < band.maxY
+    }
+}
+
+/// Edge detector for a permission-free stream of pointer locations.
+public struct MenuBarHoverTracker {
+
+    public private(set) var isPointerInside = false
+
+    public init() {}
+
+    public mutating func update(
+        enabled: Bool,
+        buttonsDown: Bool,
+        point: CGPoint,
+        toggleFrame: CGRect?,
+        screenFrame: CGRect?
+    ) -> MenuBarHoverTransition? {
+        guard enabled else {
+            isPointerInside = false
+            return nil
+        }
+        guard !buttonsDown else { return nil }
+
+        let isInside = MenuBarHoverRegion.contains(
+            point,
+            toggleFrame: toggleFrame,
+            screenFrame: screenFrame
+        )
+        guard isInside != isPointerInside else { return nil }
+        isPointerInside = isInside
+        return isInside ? .entered : .exited
+    }
+
+    public mutating func reset() {
+        isPointerInside = false
+    }
+}
+
+/// Pure decisions for coordinating hover transitions with the existing
+/// expand and auto-rehide behavior.
+public enum MenuBarHoverPolicy {
+
+    public struct Decision: Equatable {
+        public let cancelRehide: Bool
+        public let reveal: Bool
+        public let scheduleRehide: Bool
+
+        public init(cancelRehide: Bool, reveal: Bool, scheduleRehide: Bool) {
+            self.cancelRehide = cancelRehide
+            self.reveal = reveal
+            self.scheduleRehide = scheduleRehide
+        }
+    }
+
+    public static func decide(
+        transition: MenuBarHoverTransition,
+        isCollapsed: Bool,
+        autoRehide: Bool
+    ) -> Decision {
+        switch transition {
+        case .entered:
+            return Decision(
+                cancelRehide: true,
+                reveal: isCollapsed,
+                scheduleRehide: false
+            )
+        case .exited:
+            return Decision(
+                cancelRehide: false,
+                reveal: false,
+                scheduleRehide: !isCollapsed && autoRehide
+            )
+        }
+    }
+}

--- a/Tests/PelmetCoreTests/MenuBarHoverPolicyTests.swift
+++ b/Tests/PelmetCoreTests/MenuBarHoverPolicyTests.swift
@@ -1,0 +1,204 @@
+import CoreGraphics
+import Testing
+@testable import PelmetCore
+
+struct MenuBarHoverPolicyTests {
+
+    private let screen = CGRect(x: 0, y: 0, width: 1512, height: 982)
+    private let toggle = CGRect(x: 1430, y: 949, width: 32, height: 33)
+
+    @Test func testBandUsesFullScreenWidthAndToggleHeight() {
+        let band = MenuBarHoverRegion.band(toggleFrame: toggle, screenFrame: screen)
+
+        #expect(band == CGRect(x: 0, y: 949, width: 1512, height: 33))
+        #expect(MenuBarHoverRegion.contains(
+            CGPoint(x: 20, y: 960),
+            toggleFrame: toggle,
+            screenFrame: screen
+        ))
+        #expect(MenuBarHoverRegion.contains(
+            CGPoint(x: 750, y: 960),
+            toggleFrame: toggle,
+            screenFrame: screen
+        ))
+    }
+
+    @Test func testBandBoundariesExcludePointsOutsideTheMenuBar() {
+        #expect(MenuBarHoverRegion.contains(
+            CGPoint(x: 0, y: 949),
+            toggleFrame: toggle,
+            screenFrame: screen
+        ))
+        #expect(!MenuBarHoverRegion.contains(
+            CGPoint(x: 0, y: 948.9),
+            toggleFrame: toggle,
+            screenFrame: screen
+        ))
+        #expect(!MenuBarHoverRegion.contains(
+            CGPoint(x: 1512, y: 960),
+            toggleFrame: toggle,
+            screenFrame: screen
+        ))
+        #expect(!MenuBarHoverRegion.contains(
+            CGPoint(x: 400, y: 982),
+            toggleFrame: toggle,
+            screenFrame: screen
+        ))
+    }
+
+    @Test func testNotchDoesNotCreateAHoleInTheTriggerBand() {
+        #expect(MenuBarHoverRegion.contains(
+            CGPoint(x: 755, y: 960),
+            toggleFrame: toggle,
+            screenFrame: screen
+        ))
+    }
+
+    @Test func testNegativeCoordinateDisplayIsHandled() {
+        let secondary = CGRect(x: -1920, y: 120, width: 1920, height: 1080)
+        let secondaryToggle = CGRect(x: -60, y: 1176, width: 32, height: 24)
+
+        #expect(MenuBarHoverRegion.band(
+            toggleFrame: secondaryToggle,
+            screenFrame: secondary
+        ) == CGRect(x: -1920, y: 1176, width: 1920, height: 24))
+        #expect(MenuBarHoverRegion.contains(
+            CGPoint(x: -1800, y: 1185),
+            toggleFrame: secondaryToggle,
+            screenFrame: secondary
+        ))
+        #expect(!MenuBarHoverRegion.contains(
+            CGPoint(x: 200, y: 1185),
+            toggleFrame: secondaryToggle,
+            screenFrame: secondary
+        ))
+    }
+
+    @Test func testMissingInvalidOrOffscreenFramesHaveNoRegion() {
+        #expect(MenuBarHoverRegion.band(toggleFrame: nil, screenFrame: screen) == nil)
+        #expect(MenuBarHoverRegion.band(toggleFrame: toggle, screenFrame: nil) == nil)
+        #expect(MenuBarHoverRegion.band(
+            toggleFrame: .zero,
+            screenFrame: screen
+        ) == nil)
+        #expect(MenuBarHoverRegion.band(
+            toggleFrame: CGRect(x: 1430, y: 1100, width: 32, height: 24),
+            screenFrame: screen
+        ) == nil)
+    }
+
+    @Test func testTrackerEmitsOnlyEdgeTransitions() {
+        var tracker = MenuBarHoverTracker()
+        let inside = CGPoint(x: 500, y: 960)
+        let outside = CGPoint(x: 500, y: 900)
+
+        #expect(tracker.update(
+            enabled: true,
+            buttonsDown: false,
+            point: outside,
+            toggleFrame: toggle,
+            screenFrame: screen
+        ) == nil)
+        #expect(tracker.update(
+            enabled: true,
+            buttonsDown: false,
+            point: inside,
+            toggleFrame: toggle,
+            screenFrame: screen
+        ) == .entered)
+        #expect(tracker.update(
+            enabled: true,
+            buttonsDown: false,
+            point: inside,
+            toggleFrame: toggle,
+            screenFrame: screen
+        ) == nil)
+        #expect(tracker.update(
+            enabled: true,
+            buttonsDown: false,
+            point: outside,
+            toggleFrame: toggle,
+            screenFrame: screen
+        ) == .exited)
+    }
+
+    @Test func testTrackerIgnoresDragUntilButtonsAreReleased() {
+        var tracker = MenuBarHoverTracker()
+        let inside = CGPoint(x: 500, y: 960)
+
+        #expect(tracker.update(
+            enabled: true,
+            buttonsDown: true,
+            point: inside,
+            toggleFrame: toggle,
+            screenFrame: screen
+        ) == nil)
+        #expect(!tracker.isPointerInside)
+        #expect(tracker.update(
+            enabled: true,
+            buttonsDown: false,
+            point: inside,
+            toggleFrame: toggle,
+            screenFrame: screen
+        ) == .entered)
+    }
+
+    @Test func testDisablingResetsTrackerWithoutExitSideEffects() {
+        var tracker = MenuBarHoverTracker()
+        let inside = CGPoint(x: 500, y: 960)
+
+        #expect(tracker.update(
+            enabled: true,
+            buttonsDown: false,
+            point: inside,
+            toggleFrame: toggle,
+            screenFrame: screen
+        ) == .entered)
+        #expect(tracker.update(
+            enabled: false,
+            buttonsDown: false,
+            point: inside,
+            toggleFrame: toggle,
+            screenFrame: screen
+        ) == nil)
+        #expect(!tracker.isPointerInside)
+        #expect(tracker.update(
+            enabled: true,
+            buttonsDown: false,
+            point: inside,
+            toggleFrame: toggle,
+            screenFrame: screen
+        ) == .entered)
+    }
+
+    @Test func testEntryCancelsRehideAndRevealsOnlyWhenCollapsed() {
+        #expect(MenuBarHoverPolicy.decide(
+            transition: .entered,
+            isCollapsed: true,
+            autoRehide: true
+        ) == .init(cancelRehide: true, reveal: true, scheduleRehide: false))
+        #expect(MenuBarHoverPolicy.decide(
+            transition: .entered,
+            isCollapsed: false,
+            autoRehide: true
+        ) == .init(cancelRehide: true, reveal: false, scheduleRehide: false))
+    }
+
+    @Test func testExitFollowsAutoRehidePreference() {
+        #expect(MenuBarHoverPolicy.decide(
+            transition: .exited,
+            isCollapsed: false,
+            autoRehide: true
+        ) == .init(cancelRehide: false, reveal: false, scheduleRehide: true))
+        #expect(MenuBarHoverPolicy.decide(
+            transition: .exited,
+            isCollapsed: false,
+            autoRehide: false
+        ) == .init(cancelRehide: false, reveal: false, scheduleRehide: false))
+        #expect(MenuBarHoverPolicy.decide(
+            transition: .exited,
+            isCollapsed: true,
+            autoRehide: true
+        ) == .init(cancelRehide: false, reveal: false, scheduleRehide: false))
+    }
+}


### PR DESCRIPTION
## Summary

- add an opt-in Show hidden items on hover setting
- monitor the active menu bar with permission-free local and global mouse events
- keep hover expansion temporary while preserving click, hotkey, Shelf, and saved-state behavior
- coordinate pointer entry and exit with auto-rehide and open Pelmet surfaces
- add pure hover geometry and transition policy coverage in PelmetCore
- update the README, project roadmap, changelog, and development startup banner

## Why

The roadmap calls for managed icons to become available when the pointer reaches the menu bar. This implementation adds that accelerator without changing Pelmet's zero-permission core or making hover the only access path.

## User impact

The feature is disabled by default and can be enabled in General settings. When enabled, entering Pelmet's active menu-bar band reveals managed icons immediately. Auto-rehide waits until the pointer leaves, and explicit chevron or hotkey actions retain their existing behavior.

## Validation

- `swiftformat .`
- `git diff --check`
- `swift test` (175 tests passed)
- `xcodegen generate`
- `xcodebuild build -project Pelmet.xcodeproj -scheme Pelmet -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`
