### PR TITLE
Check for updates every 6 hours

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,7 @@ jobs:
           test "$(/usr/libexec/PlistBuddy -c 'Print :SUFeedURL' "$INFO_PLIST")" = \
             "https://ismatbabirli.github.io/pelmet/appcast.xml"
           test -n "$(/usr/libexec/PlistBuddy -c 'Print :SUPublicEDKey' "$INFO_PLIST")"
-          test "$(/usr/libexec/PlistBuddy -c 'Print :SUScheduledCheckInterval' "$INFO_PLIST")" = "86400"
+          test "$(/usr/libexec/PlistBuddy -c 'Print :SUScheduledCheckInterval' "$INFO_PLIST")" = "21600"
           test "$(/usr/libexec/PlistBuddy -c 'Print :SUAllowsAutomaticUpdates' "$INFO_PLIST")" = "false"
           if /usr/libexec/PlistBuddy -c 'Print :SUEnableAutomaticChecks' "$INFO_PLIST" >/dev/null 2>&1; then
             echo "SUEnableAutomaticChecks must stay unset so Sparkle asks for consent."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Automatic update checks now run every 6 hours after opt-in instead of daily.
+
 ## [0.4.0] - 2026-07-24
 
 ### Added
@@ -31,7 +35,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- Automatic update checks remain opt-in and run daily, while installing an
+- Automatic update checks remain opt-in and run every 6 hours, while installing an
   update always requires approval in Sparkle's standard Install and Relaunch
   dialog. The release workflow now validates the app's update configuration,
   appcast XML, increasing build number, signed enclosure, downloadable ZIP,

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Pelmet places two items in your menu bar:
 Pelmet needs zero special permissions, has no accounts, and embeds no tracking
 SDKs. It makes two kinds of network calls, both under your control:
 
-- **Update checks** (Sparkle): asks you once before enabling daily checks.
+- **Update checks** (Sparkle): asks you once before enabling checks every 6 hours.
   If a scheduled check meets a temporary network failure, Pelmet performs at
   most three recovery checks and shows the retry state in Settings. An **↑** in
   the menu bar means an update is ready to review; Pelmet never installs it
@@ -167,7 +167,7 @@ open Pelmet.xcodeproj   # then build & run with ⌘R
 - [ ] Profiles and per-item rules (e.g. "presentation mode")
 - [ ] Custom hotkey recorder (replace the hardcoded ⌥⌘B)
 - [x] **Notarized releases + Homebrew cask** — a signed, notarized `.dmg` on every tagged release; `brew install --cask ismatBabirli/pelmet/pelmet`
-- [x] **Reliable Sparkle updates** — opt-in daily checks, bounded retry after temporary network failures, an **↑** menu-bar reminder, EdDSA-signed downloads, and explicit approval before Install and Relaunch
+- [x] **Reliable Sparkle updates** — opt-in checks every 6 hours, bounded retry after temporary network failures, an **↑** menu-bar reminder, EdDSA-signed downloads, and explicit approval before Install and Relaunch
 
 The full vision and phased plan live in [PROJECT.md](PROJECT.md); release history
 is in [CHANGELOG.md](CHANGELOG.md).

--- a/Sources/Pelmet/Updates/UpdaterController.swift
+++ b/Sources/Pelmet/Updates/UpdaterController.swift
@@ -23,7 +23,7 @@ enum UpdaterStatus: Equatable {
             return "Software Update is available in the bundled app."
         case let .idle(lastSuccessfulCheck):
             guard let lastSuccessfulCheck else {
-                return "Updates are checked daily after you opt in."
+                return "Updates are checked every 6 hours after you opt in."
             }
             let formatter = RelativeDateTimeFormatter()
             formatter.dateTimeStyle = .named

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -8,7 +8,7 @@ Releases are automated. Pushing a `vX.Y.Z` tag triggers
 3. **notarizes** the app and the DMG with Apple and staples the tickets,
 4. packages `Pelmet-<version>.dmg` + `Pelmet-<version>.zip`,
 5. creates the GitHub Release with generated notes + checksums,
-6. verifies the bundled Sparkle consent, daily-check, and user-approved install
+6. verifies the bundled Sparkle consent, six-hour check, and user-approved install
    configuration,
 7. EdDSA-signs the `.zip`, validates the appcast and enclosure, appends the item
    to the `gh-pages` branch, and waits until GitHub Pages serves that exact
@@ -192,4 +192,4 @@ update path end to end:
 4. Disable automatic checks and verify background requests and pending retries
    stop, while **Check for Updates…** still performs a manual check.
 5. Repeat offline failures and confirm only three recovery checks occur before
-   Pelmet falls back to Sparkle's next daily check.
+   Pelmet falls back to Sparkle's next six-hour check.

--- a/project.yml
+++ b/project.yml
@@ -58,9 +58,9 @@ targets:
         SUPublicEDKey: "PNXQ+qmeChvGLPr2kXxFLXC6U9mwjbQTlJo5RHA3eSU="
         # SUEnableAutomaticChecks is intentionally unset: Sparkle asks the user
         # once during early use whether to check automatically (trust-first).
-        # Opted-in scheduled checks run once per day. Network-only recovery is
+        # Opted-in scheduled checks run every six hours. Network-only recovery is
         # bounded separately by UpdaterController and never changes this cadence.
-        SUScheduledCheckInterval: 86400
+        SUScheduledCheckInterval: 21600
         # Never inherit Sparkle's legacy SUAutomaticallyUpdate preference. Pelmet
         # always presents Sparkle's standard approval UI before installation.
         SUAllowsAutomaticUpdates: false


### PR DESCRIPTION
## Summary
- change opted-in Sparkle checks from every 24 hours to every 6 hours
- keep installation approval, retry backoff, and telemetry cadence unchanged
- update release validation and user-facing documentation

## Validation
- `swift test` — 175 tests passed
- Xcode Debug app build succeeded
- generated Info.plist verified with `SUScheduledCheckInterval = 21600`
- `git diff --check` passed