### PR TITLE
Prepare Pelmet 0.4.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-07-24
+
 ### Changed
 
 - Automatic update checks now run every 6 hours after opt-in instead of daily.


### PR DESCRIPTION
Prepare the versioned changelog entry required by the release workflow for v0.4.1.

The release contains the merged six-hour automatic update check change from PR #29.