### PR TITLE
Add star-on-GitHub nudge and refresh the About pane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- A gentle prompt to star Pelmet on GitHub, shown a few days after first use
+  once you have hidden icons at least once. It opens the repo in your browser,
+  sends nothing, and can be dismissed for good.
+
 ## [0.4.1] - 2026-07-24
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2] - 2026-07-27
+
 ### Added
 
 - A gentle prompt to star Pelmet on GitHub, shown a few days after first use
@@ -166,7 +168,9 @@ First public release — the working MVP.
 - Requires **macOS 13 Ventura** or later.
 - The core hide/show experience needs **zero special permissions**.
 
-[Unreleased]: https://github.com/ismatBabirli/pelmet/compare/v0.4.0...HEAD
+[Unreleased]: https://github.com/ismatBabirli/pelmet/compare/v0.4.2...HEAD
+[0.4.2]: https://github.com/ismatBabirli/pelmet/compare/v0.4.1...v0.4.2
+[0.4.1]: https://github.com/ismatBabirli/pelmet/compare/v0.4.0...v0.4.1
 [0.4.0]: https://github.com/ismatBabirli/pelmet/compare/v0.3.3...v0.4.0
 [0.3.3]: https://github.com/ismatBabirli/pelmet/compare/v0.3.2...v0.3.3
 [0.3.2]: https://github.com/ismatBabirli/pelmet/compare/v0.3.1...v0.3.2

--- a/Sources/Pelmet/AppDelegate.swift
+++ b/Sources/Pelmet/AppDelegate.swift
@@ -25,6 +25,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             hadExistingPreferences: hadExistingPreferences
         )
 
+        // Start the "after some time" clock for the star-on-GitHub nudge exactly
+        // once. Existing users begin counting from their first launch of this
+        // build; they have already shown engagement, so that is acceptable.
+        if Preferences.firstLaunchAt == nil {
+            Preferences.firstLaunchAt = Date()
+        }
+
         MenuBarManager.shared.setUp()
 
         // Start Sparkle (bundled .app only). Sparkle asks the user once on

--- a/Sources/Pelmet/MenuBarManager.swift
+++ b/Sources/Pelmet/MenuBarManager.swift
@@ -435,6 +435,10 @@ final class MenuBarManager: NSObject {
         if plan.attemptOneClickOffer {
             OnboardingController.shared.maybeOfferOneClick(toggle: toggleItem)
         }
+        // Last in the serialized chain: the star nudge is layout-independent and
+        // self-gates on its policy, so it only appears days into real use and
+        // never covers a tip or the release-notes window.
+        StarNudgeWindowController.shared.maybePresent()
     }
 
     /// The toggle is the escape hatch — if it ever gets swallowed the user

--- a/Sources/Pelmet/Preferences.swift
+++ b/Sources/Pelmet/Preferences.swift
@@ -34,6 +34,10 @@ enum Preferences {
         static let lastAcknowledgedWhatsNewVersion = "lastAcknowledgedWhatsNewVersion"
         static let updateRetrySnapshot = "updateRetrySnapshot"
         static let lastSuccessfulUpdateCheck = "lastSuccessfulUpdateCheck"
+        static let firstLaunchAt = "firstLaunchAt"
+        static let starNudgeLastShownAt = "starNudgeLastShownAt"
+        static let starNudgeShowCount = "starNudgeShowCount"
+        static let starNudgeDismissed = "starNudgeDismissed"
     }
 
     /// Last collapse state, restored at launch. Defaults to expanded so a
@@ -216,6 +220,36 @@ enum Preferences {
     static var lastAcknowledgedWhatsNewVersion: String? {
         get { UserDefaults.standard.string(forKey: Keys.lastAcknowledgedWhatsNewVersion) }
         set { UserDefaults.standard.set(newValue, forKey: Keys.lastAcknowledgedWhatsNewVersion) }
+    }
+
+    // MARK: - Star-on-GitHub nudge
+
+    /// When the app first launched, seeded once at startup. Anchors the "after
+    /// some time" delay before the star nudge may appear. A usage fact, not an
+    /// onboarding tip, so `resetOnboardingFlags()` leaves it be.
+    static var firstLaunchAt: Date? {
+        get { UserDefaults.standard.object(forKey: Keys.firstLaunchAt) as? Date }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.firstLaunchAt) }
+    }
+
+    /// When the star nudge was last shown; nil until the first show. Drives the
+    /// snooze interval between reminders.
+    static var starNudgeLastShownAt: Date? {
+        get { UserDefaults.standard.object(forKey: Keys.starNudgeLastShownAt) as? Date }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.starNudgeLastShownAt) }
+    }
+
+    /// How many times the star nudge has been shown, for the hard cap.
+    static var starNudgeShowCount: Int {
+        get { UserDefaults.standard.integer(forKey: Keys.starNudgeShowCount) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.starNudgeShowCount) }
+    }
+
+    /// Set once the user stars, opts out ("Don't ask again"), or the show cap is
+    /// reached. A true value stops the nudge forever.
+    static var starNudgeDismissed: Bool {
+        get { UserDefaults.standard.bool(forKey: Keys.starNudgeDismissed) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.starNudgeDismissed) }
     }
 
     /// Must be sampled before menu setup writes status-item positions. A real

--- a/Sources/Pelmet/Settings/AboutPaneView.swift
+++ b/Sources/Pelmet/Settings/AboutPaneView.swift
@@ -8,6 +8,7 @@ struct AboutPaneView: View {
 
     private let version = AppVersionInfo.current
     @State private var didCopy = false
+    @Environment(\.openURL) private var openURL
 
     var body: some View {
         Form {
@@ -44,15 +45,32 @@ struct AboutPaneView: View {
                 }
             }
 
+            // Uniform, System-Settings-style rows: a tinted glyph, a title, and
+            // a trailing hint (an up-right arrow leaves for the browser, a
+            // chevron opens an in-app window). One GitHub link, not two.
             Section {
-                Button("What's New…") {
+                AboutRow(
+                    title: "Star on GitHub",
+                    subtitle: "It is free and open source. A star helps others find it.",
+                    systemImage: "star.fill",
+                    tint: .yellow,
+                    opensExternally: true
+                ) { openURL(AppLinks.repo) }
+
+                AboutRow(title: "What's New", systemImage: "sparkles", tint: .accentColor) {
                     WhatsNewWindowController.shared.showManually()
                 }
-                Link("View on GitHub", destination: AppLinks.repo)
-                Link("Full Changelog", destination: AppLinks.changelog)
+
+                AboutRow(
+                    title: "Full Changelog",
+                    systemImage: "doc.plaintext",
+                    tint: .secondary,
+                    opensExternally: true
+                ) { openURL(AppLinks.changelog) }
+
                 // Opens a GitHub issue prefilled with the version and
                 // environment; the user writes and submits it themselves.
-                Button("Report a Problem…") {
+                AboutRow(title: "Report a Problem", systemImage: "ladybug", tint: .orange) {
                     CrashReportMonitor.shared.reportProblem()
                 }
             } footer: {
@@ -68,5 +86,46 @@ struct AboutPaneView: View {
         NSPasteboard.general.clearContents()
         NSPasteboard.general.setString(version.labeled(), forType: .string)
         didCopy = true
+    }
+}
+
+/// A single tappable About-pane row: leading tinted glyph, title (with an
+/// optional one-line subtitle), and a trailing affordance that distinguishes an
+/// external link from an in-app action. The whole row is the hit target.
+private struct AboutRow: View {
+    let title: String
+    var subtitle: String?
+    let systemImage: String
+    var tint: Color = .accentColor
+    var opensExternally = false
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            HStack(spacing: 12) {
+                Image(systemName: systemImage)
+                    .font(.body)
+                    .foregroundStyle(tint)
+                    .frame(width: 22)
+
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(title)
+                        .foregroundStyle(.primary)
+                    if let subtitle {
+                        Text(subtitle)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Spacer(minLength: 8)
+
+                Image(systemName: opensExternally ? "arrow.up.forward" : "chevron.forward")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.tertiary)
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/Sources/Pelmet/StarNudge/StarNudgeView.swift
+++ b/Sources/Pelmet/StarNudge/StarNudgeView.swift
@@ -1,0 +1,50 @@
+import SwiftUI
+
+/// The star-on-GitHub nudge card. Styled like the What's New window and the
+/// onboarding tips: app icon, a short honest ask, and three actions. The star
+/// button opens the repository in the user's browser (no in-app network call).
+struct StarNudgeView: View {
+
+    let onStar: () -> Void
+    let onLater: () -> Void
+    let onDontAsk: () -> Void
+
+    var body: some View {
+        VStack(spacing: 14) {
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .frame(width: 56, height: 56)
+
+            Text("Enjoying Pelmet?")
+                .font(.title3.bold())
+
+            Text("Pelmet is free and open source. If it has earned a spot in your "
+                + "menu bar, a star on GitHub helps other people find it. It takes "
+                + "a second and means a lot.")
+                .font(.callout)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(spacing: 8) {
+                Button(action: onStar) {
+                    Text("Star on GitHub")
+                        .frame(maxWidth: .infinity)
+                }
+                .keyboardShortcut(.defaultAction)
+
+                Button("Maybe Later", action: onLater)
+                    .keyboardShortcut(.cancelAction)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+
+                Button("Don't ask again", action: onDontAsk)
+                    .buttonStyle(.plain)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(24)
+        .frame(width: 360)
+    }
+}

--- a/Sources/Pelmet/StarNudge/StarNudgeWindowController.swift
+++ b/Sources/Pelmet/StarNudge/StarNudgeWindowController.swift
@@ -1,0 +1,135 @@
+import AppKit
+import PelmetCore
+import SwiftUI
+
+/// Owns Pelmet's single, reusable "star us on GitHub" nudge window and the gate
+/// that keeps it timed, rate-limited, and never stacked on another surface.
+final class StarNudgeWindowController: NSWindowController, NSWindowDelegate {
+
+    static let shared = StarNudgeWindowController()
+
+    private var isTrackedAsOpen = false
+    private var hasCenteredWindow = false
+
+    private convenience init() {
+        self.init(window: nil)
+    }
+
+    /// True when the QA override is set: shows the nudge immediately, bypassing
+    /// the time/usage gate, and without advancing the counters or the cap.
+    private var isForced: Bool {
+        ProcessInfo.processInfo.environment["PELMET_FORCE_STAR_NUDGE"] != nil
+    }
+
+    /// The single entry point. Presents the nudge only when the policy allows it
+    /// (or the QA override is set) and no other launch surface is up. Safe to
+    /// call on every onboarding pass; it self-gates.
+    func maybePresent() {
+        guard window?.isVisible != true else { return }
+
+        if !isForced {
+            guard StarNudgePolicy.shouldShow(
+                firstLaunchAt: Preferences.firstLaunchAt,
+                hasManagedItems: Preferences.hasEverManagedItems,
+                dismissedPermanently: Preferences.starNudgeDismissed,
+                lastShownAt: Preferences.starNudgeLastShownAt,
+                showCount: Preferences.starNudgeShowCount,
+                now: Date()
+            ) else { return }
+        }
+
+        // Never cover release notes, a crash alert, or an onboarding tip.
+        guard !WhatsNewWindowController.shared.isPendingOrVisible,
+              NSApp.modalWindow == nil,
+              OnboardingController.shared.activeTipWindow == nil
+        else { return }
+
+        show()
+    }
+
+    private func show() {
+        configureWindowIfNeeded()
+        guard let window else { return }
+
+        let hosting = NSHostingController(rootView: StarNudgeView(
+            onStar: { [weak self] in self?.handleStar() },
+            onLater: { [weak self] in self?.window?.performClose(nil) },
+            onDontAsk: { [weak self] in self?.handleDontAsk() }
+        ))
+        window.contentViewController = hosting
+        window.setContentSize(hosting.view.fittingSize)
+
+        // An accessory app must activate explicitly or the window won't come
+        // forward; the pattern matches Settings and What's New.
+        NSApp.activate(ignoringOtherApps: true)
+        if !hasCenteredWindow {
+            window.center()
+            hasCenteredWindow = true
+        }
+        showWindow(nil)
+        window.makeKeyAndOrderFront(nil)
+
+        guard window.isVisible else { return }
+        if !isTrackedAsOpen {
+            isTrackedAsOpen = true
+            UIActivityTracker.shared.surfaceOpened()
+        }
+        // The QA override never burns a real ask.
+        if !isForced { recordShow() }
+    }
+
+    /// Advances the rate-limit state once the nudge is actually on screen, then
+    /// retires it for good if this was the last allowed ask.
+    private func recordShow() {
+        Preferences.starNudgeLastShownAt = Date()
+        Preferences.starNudgeShowCount += 1
+        if Preferences.starNudgeShowCount >= StarNudgePolicy.maxShows {
+            Preferences.starNudgeDismissed = true
+        }
+    }
+
+    private func handleStar() {
+        NSWorkspace.shared.open(AppLinks.repo)
+        Preferences.starNudgeDismissed = true
+        window?.performClose(nil)
+    }
+
+    private func handleDontAsk() {
+        Preferences.starNudgeDismissed = true
+        window?.performClose(nil)
+    }
+
+    private func configureWindowIfNeeded() {
+        guard window == nil else { return }
+        let window = StarNudgeWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+            styleMask: [.titled, .closable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "Enjoying Pelmet?"
+        window.isReleasedWhenClosed = false
+        window.collectionBehavior = [.moveToActiveSpace]
+        window.delegate = self
+        self.window = window
+    }
+
+    func windowWillClose(_ notification: Notification) {
+        if isTrackedAsOpen {
+            isTrackedAsOpen = false
+            UIActivityTracker.shared.surfaceClosed()
+        }
+        // Let any surface queued behind this one get its turn.
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.4) {
+            MenuBarManager.shared.reapplyOnboardingChecks()
+        }
+    }
+}
+
+/// Escape closes the nudge (treated as "maybe later") without needing a hidden
+/// SwiftUI button just to own the cancel shortcut.
+private final class StarNudgeWindow: NSWindow {
+    override func cancelOperation(_ sender: Any?) {
+        performClose(sender)
+    }
+}

--- a/Sources/PelmetCore/StarNudge.swift
+++ b/Sources/PelmetCore/StarNudge.swift
@@ -1,0 +1,52 @@
+import Foundation
+
+/// Pure policy for the "star us on GitHub" nudge. Kept free of wall-clock reads
+/// so it is deterministic and unit-testable; the app layer supplies `now` and
+/// the persisted state. The nudge is a gentle, hard-rate-limited ask: it never
+/// appears on first launch, only after the user has gotten real value from the
+/// app, and it stops for good once accepted, declined, or shown a few times.
+public enum StarNudgePolicy {
+
+    /// Minimum time after the first launch before the first ask. Long enough
+    /// that the user has lived with Pelmet, never on day one.
+    public static let initialDelay: TimeInterval = 3 * 24 * 3600
+
+    /// Minimum time between reminders once the first ask has been shown.
+    public static let reminderInterval: TimeInterval = 14 * 24 * 3600
+
+    /// Hard cap on how many times the nudge is ever shown.
+    public static let maxShows = 3
+
+    /// Decides whether the nudge may be shown right now.
+    ///
+    /// - Parameters:
+    ///   - firstLaunchAt: when the app first launched; nil before it is seeded.
+    ///   - hasManagedItems: whether the user has actually hidden icons at least
+    ///     once (the satisfaction signal).
+    ///   - dismissedPermanently: set once the user stars, opts out, or the cap
+    ///     is reached; a true value stops the nudge forever.
+    ///   - lastShownAt: when the nudge was last shown; nil until the first show.
+    ///   - showCount: how many times it has already been shown.
+    ///   - now: the current time.
+    public static func shouldShow(
+        firstLaunchAt: Date?,
+        hasManagedItems: Bool,
+        dismissedPermanently: Bool,
+        lastShownAt: Date?,
+        showCount: Int,
+        now: Date
+    ) -> Bool {
+        guard !dismissedPermanently,
+              hasManagedItems,
+              let firstLaunchAt,
+              showCount < maxShows
+        else { return false }
+
+        if showCount == 0 {
+            return now.timeIntervalSince(firstLaunchAt) >= initialDelay
+        }
+
+        guard let lastShownAt else { return false }
+        return now.timeIntervalSince(lastShownAt) >= reminderInterval
+    }
+}

--- a/Tests/PelmetCoreTests/StarNudgePolicyTests.swift
+++ b/Tests/PelmetCoreTests/StarNudgePolicyTests.swift
@@ -1,0 +1,117 @@
+import Foundation
+import Testing
+@testable import PelmetCore
+
+struct StarNudgePolicyTests {
+
+    private let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+    @Test func notShownBeforeInitialDelay() {
+        let now = base.addingTimeInterval(StarNudgePolicy.initialDelay - 1)
+        #expect(StarNudgePolicy.shouldShow(
+            firstLaunchAt: base,
+            hasManagedItems: true,
+            dismissedPermanently: false,
+            lastShownAt: nil,
+            showCount: 0,
+            now: now
+        ) == false)
+    }
+
+    @Test func shownAtInitialDelayWhenEngaged() {
+        let now = base.addingTimeInterval(StarNudgePolicy.initialDelay)
+        #expect(StarNudgePolicy.shouldShow(
+            firstLaunchAt: base,
+            hasManagedItems: true,
+            dismissedPermanently: false,
+            lastShownAt: nil,
+            showCount: 0,
+            now: now
+        ))
+    }
+
+    @Test func notShownWithoutEngagement() {
+        let now = base.addingTimeInterval(StarNudgePolicy.initialDelay * 10)
+        #expect(StarNudgePolicy.shouldShow(
+            firstLaunchAt: base,
+            hasManagedItems: false,
+            dismissedPermanently: false,
+            lastShownAt: nil,
+            showCount: 0,
+            now: now
+        ) == false)
+    }
+
+    @Test func notShownWhenDismissedPermanently() {
+        let now = base.addingTimeInterval(StarNudgePolicy.initialDelay * 10)
+        #expect(StarNudgePolicy.shouldShow(
+            firstLaunchAt: base,
+            hasManagedItems: true,
+            dismissedPermanently: true,
+            lastShownAt: nil,
+            showCount: 0,
+            now: now
+        ) == false)
+    }
+
+    @Test func notShownWhenFirstLaunchUnknown() {
+        let now = base.addingTimeInterval(StarNudgePolicy.initialDelay * 10)
+        #expect(StarNudgePolicy.shouldShow(
+            firstLaunchAt: nil,
+            hasManagedItems: true,
+            dismissedPermanently: false,
+            lastShownAt: nil,
+            showCount: 0,
+            now: now
+        ) == false)
+    }
+
+    @Test func snoozedUntilReminderIntervalElapses() {
+        let shownAt = base.addingTimeInterval(StarNudgePolicy.initialDelay)
+        let tooSoon = shownAt.addingTimeInterval(StarNudgePolicy.reminderInterval - 1)
+        #expect(StarNudgePolicy.shouldShow(
+            firstLaunchAt: base,
+            hasManagedItems: true,
+            dismissedPermanently: false,
+            lastShownAt: shownAt,
+            showCount: 1,
+            now: tooSoon
+        ) == false)
+
+        let due = shownAt.addingTimeInterval(StarNudgePolicy.reminderInterval)
+        #expect(StarNudgePolicy.shouldShow(
+            firstLaunchAt: base,
+            hasManagedItems: true,
+            dismissedPermanently: false,
+            lastShownAt: shownAt,
+            showCount: 1,
+            now: due
+        ))
+    }
+
+    @Test func notShownOnceCapReached() {
+        let shownAt = base
+        let wayLater = base.addingTimeInterval(StarNudgePolicy.reminderInterval * 100)
+        #expect(StarNudgePolicy.shouldShow(
+            firstLaunchAt: base,
+            hasManagedItems: true,
+            dismissedPermanently: false,
+            lastShownAt: shownAt,
+            showCount: StarNudgePolicy.maxShows,
+            now: wayLater
+        ) == false)
+    }
+
+    @Test func reminderNeedsAPriorShowTimestamp() {
+        // showCount > 0 but no lastShownAt is inconsistent state: never show.
+        let now = base.addingTimeInterval(StarNudgePolicy.reminderInterval * 10)
+        #expect(StarNudgePolicy.shouldShow(
+            firstLaunchAt: base,
+            hasManagedItems: true,
+            dismissedPermanently: false,
+            lastShownAt: nil,
+            showCount: 1,
+            now: now
+        ) == false)
+    }
+}


### PR DESCRIPTION
## What & why

Add a gentle, hard-rate-limited prompt inviting users to star Pelmet on GitHub, shown a few days after first use and only once they have actually hidden icons (the satisfaction moment), capped at three asks and dismissible for good. The Star button opens the repo in the user's browser, so no new network endpoint, dependency, or telemetry is added, keeping the zero-permission and two-endpoint invariants intact; the decision is a pure, unit-tested policy in PelmetCore that slots into the existing serialized launch-surface chain so it never stacks on What's New, the crash prompt, or onboarding tips. This PR also tidies the Settings About pane into consistent System Settings-style rows and drops the duplicate GitHub link.

## How I tested it

`swift build` succeeds and `swift test` passes all 183 tests including the new StarNudgePolicyTests; `swiftformat` reports no changes. The GUI was not exercised in this environment: run `PELMET_FORCE_STAR_NUDGE=1 swift run` to force the window immediately and open Settings > About to check the refreshed rows.