### PR TITLE
Add menu bar profiles for 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Profiles**: save identifiable menu bar arrangements, including divider
+  membership and left-to-right order, then apply them from Settings or the
+  chevron menu. Items that cannot be identified or are ambiguous remain
+  unchanged and are reported. Applying a profile uses the existing opt-in
+  Accessibility path; ordinary startup never prompts for permission.
+
 ## [0.4.2] - 2026-07-27
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -53,8 +53,9 @@ geometry lives in `Sources/PelmetCore/`.
 | `Preferences.swift` | UserDefaults keys shared between AppKit and SwiftUI |
 | `Settings/SettingsRootView.swift` | System Settings-style sidebar + detail layout |
 | `Settings/SettingsPane.swift` | Pane descriptors: titles, icons, notch-gated availability |
-| `Settings/*PaneView.swift` | The panes: General, Menu Bar Space, One-Click Access |
+| `Settings/*PaneView.swift` | The panes: General, Menu Bar Space, One-Click Access, Profiles |
 | `Settings/SettingsWindowController.swift` | Hosts the settings window from an accessory app |
+| `Profiles/ProfileController.swift` | Profile persistence, capture, matching, and best-effort command drags |
 | `Shelf/` | The blurred "+N hidden icons" panel: panel, controller, SwiftUI rows, owner resolution |
 | `Activation/` | Opt-in Accessibility engine: one-click activation of real status items (AX reader, synthetic events, permission monitor) |
 | `Updates/UpdaterController.swift` | Sparkle facade — real under `#if canImport(Sparkle)` (XcodeGen build), inert stub in plain SPM |

--- a/PROJECT.md
+++ b/PROJECT.md
@@ -113,7 +113,7 @@ gracefully:
 *Goal: from tidy to fast.*
 
 - **Quick Search (⌘ space-style):** type to find and activate any menu bar item, hidden or not
-- **Profiles:** named icon arrangements — "Work", "Presentation", "Travel" — switchable manually or by hotkey
+- **Profiles (0.5.0):** named icon arrangements such as "Work", "Presentation", and "Travel", switchable from Settings or the chevron menu, with optional default application at launch
 - **Triggers:** auto-switch profiles based on Focus mode, connected display, battery state, or active app
 - **Per-item rules:** always show, always hide, show only when updating
 - **Presentation mode:** one action hides everything sensitive before screen sharing

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ This one hides your menu bar clutter, so nothing disappears behind the MacBook n
 > [!NOTE]
 > **Status: shipping.** Hide/show works with zero special permissions, and the
 > notch-aware Shelf panel, opt-in one-click access, and opt-in show-on-hover
-> have shipped. Profiles are next on the [roadmap](#roadmap).
+> have shipped. Profiles are implemented for the upcoming 0.5.0 release.
 
 ## Why
 
@@ -91,6 +91,7 @@ that you review and submit yourself.
 | See why icons are missing | Hover or right-click the toggle when it shows **+N** |
 | Lost the divider? | Right-click the toggle → Reset Divider Position |
 | Fit more icons beside the notch | Settings → Make Room… (incl. tighter icon spacing) |
+| Save or switch icon arrangements | Settings → Profiles, or right-click the chevron → Profiles |
 | Settings (hover, auto-rehide, launch at login) | Right-click the toggle → Settings… |
 | Quit | Right-click the toggle → Quit Pelmet |
 
@@ -164,7 +165,8 @@ open Pelmet.xcodeproj   # then build & run with ⌘R
 - [x] **The Shelf** — a blurred, rounded panel below the notch listing the icons macOS hid, opened by clicking the count (or ⌥⌘N). Rows show each item's app icon and name — **never a screen capture**, so no Screen Recording permission and no purple recording dot.
 - [x] **One-click access** — an *opt-in* Accessibility toggle that opens hidden items with a single click (and identifies them on macOS 26 Tahoe). Off by default; everything else works without it.
 - [x] Show on hover: reveal when the pointer touches the menu bar (opt-in)
-- [ ] Profiles and per-item rules (e.g. "presentation mode")
+- [x] **Profiles**: save identifiable icon arrangements, switch them from Settings or the chevron menu, and optionally apply a default at launch (0.5.0)
+- [ ] Per-item rules and presentation mode (e.g. "always hide" or "hide sensitive items")
 - [ ] Custom hotkey recorder (replace the hardcoded ⌥⌘B)
 - [x] **Notarized releases + Homebrew cask** — a signed, notarized `.dmg` on every tagged release; `brew install --cask ismatBabirli/pelmet/pelmet`
 - [x] **Reliable Sparkle updates** — opt-in checks every 6 hours, bounded retry after temporary network failures, an **↑** menu-bar reminder, EdDSA-signed downloads, and explicit approval before Install and Relaunch

--- a/Sources/Pelmet/Activation/StatusItemActivationEngine.swift
+++ b/Sources/Pelmet/Activation/StatusItemActivationEngine.swift
@@ -23,6 +23,9 @@ protocol StatusItemActivating: AnyObject {
     var canIdentify: Bool { get }
     /// True only when activation can actually run (permission granted).
     var canActivate: Bool { get }
+    /// True when a user has already granted Accessibility. Profile moves use
+    /// the same synthetic-event gate but do not enable one-click activation.
+    var canArrangeProfiles: Bool { get }
 
     /// Descriptors the Shelf deriver uses to make rows one-click
     /// activatable — empty unless activation can actually run. Tokens are
@@ -38,6 +41,10 @@ protocol StatusItemActivating: AnyObject {
     /// lands); an explicit user tap passes `false` and enables immediately.
     func offerOneClick(proactive: Bool)
     func refreshDirectory(reason: String)
+    func requestProfileDirectory(
+        completion: @escaping (DirectorySnapshot) -> Void
+    )
+    func endProfileDirectoryAccess()
     func activate(recordID: String, completion: @escaping (ActivationResult) -> Void)
 }
 
@@ -90,6 +97,7 @@ final class StatusItemActivationEngine: StatusItemActivating {
 
     var canIdentify: Bool { directory.fidelity == .identified }
     var canActivate: Bool { availability == .granted }
+    var canArrangeProfiles: Bool { AXIsProcessTrusted() }
 
     var activatableDescriptors: [EngineItemDescriptor] {
         guard canActivate else { return [] }
@@ -130,6 +138,12 @@ final class StatusItemActivationEngine: StatusItemActivating {
     private var healAttempts = 0
     private var axCache: [pid_t: (observations: [AXExtraObservation], stamp: Date)] = [:]
     private var slowPIDs: Set<pid_t> = []
+    private var profileDirectoryAccess = false
+    private struct ProfileDirectoryWaiter {
+        let requiresIdentity: Bool
+        let completion: (DirectorySnapshot) -> Void
+    }
+    private var profileDirectoryWaiters: [UUID: ProfileDirectoryWaiter] = [:]
     /// Live AX elements for the current directory's records (AXPress path).
     private(set) var elementForRecordID: [String: AXUIElement] = [:]
 
@@ -234,6 +248,29 @@ final class StatusItemActivationEngine: StatusItemActivating {
         rebuildDirectory()
     }
 
+    func requestProfileDirectory(
+        completion: @escaping (DirectorySnapshot) -> Void
+    ) {
+        profileDirectoryAccess = canArrangeProfiles
+        let waiterID = UUID()
+        profileDirectoryWaiters[waiterID] = ProfileDirectoryWaiter(
+            requiresIdentity: profileDirectoryAccess,
+            completion: completion
+        )
+        rebuildDirectory()
+        DispatchQueue.main.asyncAfter(deadline: .now() + 3) { [weak self] in
+            guard let self,
+                  let waiter = self.profileDirectoryWaiters.removeValue(forKey: waiterID)
+            else { return }
+            waiter.completion(self.directory)
+        }
+    }
+
+    func endProfileDirectoryAccess() {
+        profileDirectoryAccess = false
+        profileDirectoryWaiters.removeAll()
+    }
+
     func activate(recordID: String, completion: @escaping (ActivationResult) -> Void) {
         ActivationExecutor.shared.activate(recordID: recordID, engine: self, completion: completion)
     }
@@ -288,7 +325,8 @@ final class StatusItemActivationEngine: StatusItemActivating {
         let reparented = Self.isReparented(items: items, controlCenterPID: controlCenterPID)
 
         let cached = freshCachedObservations()
-        if canActivate, !cached.isEmpty {
+        let canReadAccessibility = canActivate || profileDirectoryAccess
+        if canReadAccessibility, !cached.isEmpty {
             // Cached FRAMES rot the moment the layout moves (every
             // collapse/expand relocates every item) — re-read each cached
             // element's live position off-main, then publish.
@@ -307,7 +345,7 @@ final class StatusItemActivationEngine: StatusItemActivating {
             )
         }
 
-        if canActivate {
+        if canReadAccessibility {
             scheduleSweep(controlCenterPID: controlCenterPID, reparented: reparented)
         }
     }
@@ -446,7 +484,8 @@ final class StatusItemActivationEngine: StatusItemActivating {
         let unidentifiedSwallowed = records.contains {
             $0.visibility == .swallowedByNotch && $0.identity == nil
         }
-        if canActivate, unidentifiedSwallowed, !axCache.isEmpty, healAttempts < 2 {
+        if canActivate || profileDirectoryAccess, unidentifiedSwallowed,
+           !axCache.isEmpty, healAttempts < 2 {
             healAttempts += 1
             DispatchQueue.main.asyncAfter(deadline: .now() + 0.8) { [weak self] in
                 self?.rebuildDirectory()
@@ -457,6 +496,13 @@ final class StatusItemActivationEngine: StatusItemActivating {
     private func publish(_ snapshot: DirectorySnapshot) {
         directory = snapshot
         onDirectoryChange?(snapshot)
+        let ready = profileDirectoryWaiters.filter { _, waiter in
+            !waiter.requiresIdentity || snapshot.fidelity == .identified
+        }
+        for (id, waiter) in ready {
+            profileDirectoryWaiters.removeValue(forKey: id)
+            waiter.completion(snapshot)
+        }
     }
 
     // MARK: - AX sweep

--- a/Sources/Pelmet/AppDelegate.swift
+++ b/Sources/Pelmet/AppDelegate.swift
@@ -33,6 +33,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         }
 
         MenuBarManager.shared.setUp()
+        ProfileController.shared.scheduleDefaultProfileApplication()
 
         // Start Sparkle (bundled .app only). Sparkle asks the user once on
         // during early use whether to check automatically; nothing hits the network

--- a/Sources/Pelmet/MenuBarManager.swift
+++ b/Sources/Pelmet/MenuBarManager.swift
@@ -155,6 +155,131 @@ final class MenuBarManager: NSObject {
         hoverMonitor.stop()
     }
 
+    // MARK: - Profiles
+
+    /// Temporarily expands the bar and waits for a fresh layout before a
+    /// profile capture or apply. The context restores the user's prior state.
+    func beginProfileOperation(
+        completion: @escaping (ProfileOperationContext, LayoutClassification?) -> Void
+    ) {
+        let context = ProfileOperationContext(wasCollapsed: isCollapsed)
+        if context.wasCollapsed {
+            setExpanded(persistState: false, scheduleRehide: false)
+        }
+        NotchLayoutMonitor.shared.requestConfirmedLayout { [weak self] classification in
+            guard let self else { return completion(context, nil) }
+            completion(context, classification ?? self.latestClassification)
+        }
+    }
+
+    func endProfileOperation(_ context: ProfileOperationContext) {
+        shelfEngine.endProfileDirectoryAccess()
+        if context.wasCollapsed {
+            collapse()
+        } else {
+            setExpanded(persistState: false, scheduleRehide: false)
+        }
+    }
+
+    /// Converts the engine's latest identified directory into profile
+    /// candidates. The divider itself remains Pelmet-owned and is never part
+    /// of a profile.
+    func profileSnapshot(
+        using classification: LayoutClassification
+    ) -> ProfileBarSnapshot {
+        profileSnapshot(using: classification, directory: shelfEngine.directory)
+    }
+
+    func profileSnapshot(
+        using classification: LayoutClassification,
+        directory: DirectorySnapshot
+    ) -> ProfileBarSnapshot {
+        let separatorFrame = separatorItem?.button?.window?.frame ?? .zero
+        let records = directory.records
+            .filter { $0.visibility != .suspectedGhost }
+            .sorted { $0.frame.minX < $1.frame.minX }
+
+        var occurrencesByBundle: [String: Int] = [:]
+        var candidates: [ProfileItemCandidate] = []
+        for (order, record) in records.enumerated() {
+            guard let identity = record.identity,
+                  let bundleID = identity.bundleIdentifier
+            else { continue }
+
+            let title = identity.axTitle?.trimmingCharacters(in: .whitespacesAndNewlines)
+            let occurrence = occurrencesByBundle[bundleID, default: 0]
+            occurrencesByBundle[bundleID] = occurrence + 1
+            let key = ProfileItemKey(
+                bundleIdentifier: bundleID,
+                accessibilityTitle: title?.isEmpty == false ? title : nil,
+                occurrence: occurrence
+            )
+            let displayName = title?.isEmpty == false ? title! : identity.appName
+            let side: ProfileItemSide = record.frame.maxX <= separatorFrame.minX
+                ? .managed
+                : .alwaysVisible
+            candidates.append(ProfileItemCandidate(
+                key: key,
+                displayName: displayName,
+                side: side,
+                order: order,
+                frame: record.frame
+            ))
+        }
+
+        let identifiedCount = candidates.count
+        let visibleRecords = classification.items.filter {
+            $0.visibility != .suspectedGhost
+        }.count
+        return ProfileBarSnapshot(
+            candidates: candidates,
+            unidentifiedCount: max(0, visibleRecords - identifiedCount)
+        )
+    }
+
+    /// Returns an insertion point immediately to the left of the next item in
+    /// the desired side/order. With no right neighbor, the item is placed next
+    /// to Pelmet's divider or toggle, preserving the two-sided invariant.
+    func profileTargetPoint(
+        side: ProfileItemSide,
+        rightNeighbor: ProfileItemCandidate?
+    ) -> CGPoint? {
+        guard let separatorFrame = separatorItem?.button?.window?.frame else { return nil }
+        let toggleFrame = toggleItem?.button?.window?.frame
+        let x: CGFloat
+        let y: CGFloat
+        if let rightNeighbor {
+            x = rightNeighbor.frame.minX - 6
+            y = rightNeighbor.frame.midY
+        } else {
+            switch side {
+            case .managed:
+                x = separatorFrame.minX - 6
+                y = separatorFrame.midY
+            case .alwaysVisible:
+                guard let toggleFrame else { return nil }
+                x = toggleFrame.minX - 6
+                y = toggleFrame.midY
+            }
+        }
+        return CGPoint(x: x, y: y)
+    }
+
+    /// The profile coordinator owns sequencing and reporting; this helper
+    /// performs one guarded synthetic command-drag off the main thread.
+    func performProfileDrag(
+        from: CGPoint,
+        to: CGPoint,
+        completion: @escaping (Bool) -> Void
+    ) {
+        DispatchQueue.global(qos: .userInitiated).async {
+            let success = SyntheticEventPoster().commandDrag(fromAppKit: from, toAppKit: to)
+            DispatchQueue.main.async {
+                completion(success)
+            }
+        }
+    }
+
     /// Sparkle's scheduled update UI is deliberately replaced by a persistent
     /// menu-bar cue. Binding after both services initialize also replays the
     /// current value, so an update found during launch cannot be missed.
@@ -679,6 +804,43 @@ final class MenuBarManager: NSObject {
         resetEntry.target = self
         menu.addItem(resetEntry)
 
+        let profilesEntry = NSMenuItem(title: "Profiles", action: nil, keyEquivalent: "")
+        let profilesMenu = NSMenu()
+        profilesMenu.autoenablesItems = false
+        if ProfileController.shared.profiles.isEmpty {
+            let manage = NSMenuItem(
+                title: "Create Profile…",
+                action: #selector(openProfilesSettings),
+                keyEquivalent: ""
+            )
+            manage.target = self
+            profilesMenu.addItem(manage)
+        } else {
+            for profile in ProfileController.shared.profiles {
+                let profileItem = NSMenuItem(
+                    title: profile.name,
+                    action: #selector(applyProfileFromMenu(_:)),
+                    keyEquivalent: ""
+                )
+                profileItem.target = self
+                profileItem.representedObject = profile.id.uuidString
+                profileItem.state = ProfileController.shared.activeProfileID == profile.id
+                    ? .on
+                    : .off
+                profilesMenu.addItem(profileItem)
+            }
+            profilesMenu.addItem(.separator())
+            let manage = NSMenuItem(
+                title: "Manage Profiles…",
+                action: #selector(openProfilesSettings),
+                keyEquivalent: ""
+            )
+            manage.target = self
+            profilesMenu.addItem(manage)
+        }
+        profilesEntry.submenu = profilesMenu
+        menu.addItem(profilesEntry)
+
         // A permanent path to enable one-click open — survives a dismissed or
         // never-seen onboarding popover. Only where it's relevant (notched Mac,
         // not yet granted).
@@ -734,6 +896,17 @@ final class MenuBarManager: NSObject {
     }
 
     @objc private func menuToggle() { toggle() }
+
+    @objc private func applyProfileFromMenu(_ sender: NSMenuItem) {
+        guard let rawID = sender.representedObject as? String,
+              let profileID = UUID(uuidString: rawID)
+        else { return }
+        ProfileController.shared.apply(profileID) { _ in }
+    }
+
+    @objc private func openProfilesSettings() {
+        SettingsWindowController.shared.show(pane: .profiles)
+    }
 
     @objc private func enableOneClickFromMenu() {
         shelfEngine.offerOneClick(proactive: false)

--- a/Sources/Pelmet/NotchLayoutMonitor.swift
+++ b/Sources/Pelmet/NotchLayoutMonitor.swift
@@ -42,12 +42,32 @@ final class NotchLayoutMonitor {
     private var isCollapsed: () -> Bool = { false }
 
     private var pendingMeasurement: Timer?
-    private var candidate: LayoutClassification.Digest?
+    private struct ItemMeasurement: Equatable {
+        let frame: CGRect
+        let visibility: ItemVisibility
+    }
+
+    private struct MeasurementDigest: Equatable {
+        let items: [ItemMeasurement]
+        let separatorHealth: SeparatorHealth
+        let toggleVisible: Bool
+
+        init(classification: LayoutClassification) {
+            items = classification.items.map {
+                ItemMeasurement(frame: $0.frame, visibility: $0.visibility)
+            }
+            separatorHealth = classification.separatorHealth
+            toggleVisible = classification.toggleVisible
+        }
+    }
+    private var candidate: MeasurementDigest?
+    private var confirmedMeasurement: MeasurementDigest?
     private var deferredRetries = 0
     private var observers: [NSObjectProtocol] = []
 
     enum MeasurementReason {
         case launch, expandSettled, collapseSettled, screenChanged, workspaceChanged, menuOpened, itemRecreated
+        case profileOperation
 
         var settleDelay: TimeInterval {
             switch self {
@@ -57,6 +77,7 @@ final class NotchLayoutMonitor {
             case .workspaceChanged: return 1.0
             case .menuOpened: return 0
             case .itemRecreated: return 0.5
+            case .profileOperation: return 0.35
             }
         }
     }
@@ -102,6 +123,41 @@ final class NotchLayoutMonitor {
         }
     }
 
+    /// Waits for the next confirmed classification after a caller requests a
+    /// profile operation. The timeout returns the last confirmed snapshot so a
+    /// transiently quiet window server degrades to a report instead of
+    /// hanging the Settings UI.
+    func requestConfirmedLayout(
+        timeout: TimeInterval = 3,
+        completion: @escaping (LayoutClassification?) -> Void
+    ) {
+        var observer: NSObjectProtocol?
+        var timer: Timer?
+        var finished = false
+
+        func finish(_ classification: LayoutClassification?) {
+            guard !finished else { return }
+            finished = true
+            if let observer {
+                NotificationCenter.default.removeObserver(observer)
+            }
+            timer?.invalidate()
+            completion(classification)
+        }
+
+        observer = NotificationCenter.default.addObserver(
+            forName: .pelmetLayoutDidChange,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            finish(self?.confirmed)
+        }
+        timer = Timer.scheduledTimer(withTimeInterval: timeout, repeats: false) { [weak self] _ in
+            finish(self?.confirmed)
+        }
+        requestMeasurement(reason: .profileOperation)
+    }
+
     private func measureNow() {
         pendingMeasurement = nil
 
@@ -131,13 +187,14 @@ final class NotchLayoutMonitor {
     }
 
     private func publish(_ classification: LayoutClassification) {
-        let digest = classification.digest
-        if digest == confirmed?.digest {
+        let digest = MeasurementDigest(classification: classification)
+        if digest == confirmedMeasurement {
             candidate = nil
             return
         }
         if digest == candidate {
             candidate = nil
+            confirmedMeasurement = digest
             confirmed = classification
             if let flag = ProcessInfo.processInfo.environment["PELMET_DEBUG_LAYOUT"] {
                 print("Pelmet layout: swallowed=\(classification.swallowedCount) offscreenLeft=\(classification.offscreenLeftCount) separator=\(classification.separatorHealth) toggleVisible=\(classification.toggleVisible)")

--- a/Sources/Pelmet/Preferences.swift
+++ b/Sources/Pelmet/Preferences.swift
@@ -38,6 +38,10 @@ enum Preferences {
         static let starNudgeLastShownAt = "starNudgeLastShownAt"
         static let starNudgeShowCount = "starNudgeShowCount"
         static let starNudgeDismissed = "starNudgeDismissed"
+        static let menuBarProfiles = "menuBarProfiles"
+        static let activeProfileID = "activeProfileID"
+        static let defaultProfileID = "defaultProfileID"
+        static let applyDefaultProfileAtLaunch = "applyDefaultProfileAtLaunch"
     }
 
     /// Last collapse state, restored at launch. Defaults to expanded so a
@@ -90,6 +94,65 @@ enum Preferences {
     static var settingsPane: String {
         get { UserDefaults.standard.string(forKey: Keys.settingsPane) ?? "" }
         set { UserDefaults.standard.set(newValue, forKey: Keys.settingsPane) }
+    }
+
+    // MARK: - Profiles
+
+    /// Saved menu-bar arrangements. A missing or malformed value is treated
+    /// as an empty store so a bad profile never blocks Pelmet startup.
+    static var menuBarProfiles: [MenuBarProfile] {
+        get {
+            guard let data = UserDefaults.standard.data(forKey: Keys.menuBarProfiles),
+                  let profiles = try? JSONDecoder().decode([MenuBarProfile].self, from: data)
+            else { return [] }
+            return profiles
+        }
+        set {
+            guard let data = try? JSONEncoder().encode(newValue) else {
+                UserDefaults.standard.removeObject(forKey: Keys.menuBarProfiles)
+                return
+            }
+            UserDefaults.standard.set(data, forKey: Keys.menuBarProfiles)
+        }
+    }
+
+    static var activeProfileID: UUID? {
+        get {
+            guard let raw = UserDefaults.standard.string(forKey: Keys.activeProfileID) else {
+                return nil
+            }
+            return UUID(uuidString: raw)
+        }
+        set {
+            if let newValue {
+                UserDefaults.standard.set(newValue.uuidString, forKey: Keys.activeProfileID)
+            } else {
+                UserDefaults.standard.removeObject(forKey: Keys.activeProfileID)
+            }
+        }
+    }
+
+    static var defaultProfileID: UUID? {
+        get {
+            guard let raw = UserDefaults.standard.string(forKey: Keys.defaultProfileID) else {
+                return nil
+            }
+            return UUID(uuidString: raw)
+        }
+        set {
+            if let newValue {
+                UserDefaults.standard.set(newValue.uuidString, forKey: Keys.defaultProfileID)
+            } else {
+                UserDefaults.standard.removeObject(forKey: Keys.defaultProfileID)
+            }
+        }
+    }
+
+    /// Explicit opt-in. Launch never requests Accessibility; when the grant
+    /// is absent the default application is deferred and reported in Settings.
+    static var applyDefaultProfileAtLaunch: Bool {
+        get { UserDefaults.standard.bool(forKey: Keys.applyDefaultProfileAtLaunch) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.applyDefaultProfileAtLaunch) }
     }
 
     // MARK: - Software update recovery

--- a/Sources/Pelmet/Profiles/ProfileController.swift
+++ b/Sources/Pelmet/Profiles/ProfileController.swift
@@ -1,0 +1,471 @@
+import AppKit
+import Combine
+import PelmetCore
+
+struct ProfileOperationContext {
+    let wasCollapsed: Bool
+}
+
+struct ProfileBarSnapshot {
+    let candidates: [ProfileItemCandidate]
+    let unidentifiedCount: Int
+}
+
+/// Coordinates profile persistence, layout capture, and Accessibility-gated
+/// command drags. All public methods are main-thread operations; synthetic
+/// events are delegated to MenuBarManager and never run on the main thread.
+final class ProfileController: ObservableObject {
+
+    static let shared = ProfileController()
+
+    @Published private(set) var profiles: [MenuBarProfile]
+    @Published private(set) var activeProfileID: UUID?
+    @Published private(set) var defaultProfileID: UUID?
+    @Published private(set) var applyDefaultAtLaunch: Bool
+    @Published private(set) var isBusy = false
+    @Published private(set) var lastResult: ProfileApplyResult?
+    @Published private(set) var lastMessage: String?
+
+    private var observedDefaults: NSObjectProtocol?
+    private var isPersisting = false
+
+    private init() {
+        profiles = Preferences.menuBarProfiles
+        activeProfileID = Preferences.activeProfileID
+        defaultProfileID = Preferences.defaultProfileID
+        applyDefaultAtLaunch = Preferences.applyDefaultProfileAtLaunch
+        observedDefaults = NotificationCenter.default.addObserver(
+            forName: UserDefaults.didChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.reload()
+        }
+    }
+
+    deinit {
+        if let observedDefaults {
+            NotificationCenter.default.removeObserver(observedDefaults)
+        }
+    }
+
+    var activeProfile: MenuBarProfile? {
+        guard let activeProfileID else { return nil }
+        return profiles.first { $0.id == activeProfileID }
+    }
+
+    var defaultProfile: MenuBarProfile? {
+        guard let defaultProfileID else { return nil }
+        return profiles.first { $0.id == defaultProfileID }
+    }
+
+    func reload() {
+        guard !isPersisting else { return }
+        let savedProfiles = Preferences.menuBarProfiles
+        let validIDs = Set(savedProfiles.map(\.id))
+        profiles = savedProfiles
+        activeProfileID = Preferences.activeProfileID.flatMap { validIDs.contains($0) ? $0 : nil }
+        defaultProfileID = Preferences.defaultProfileID.flatMap { validIDs.contains($0) ? $0 : nil }
+        applyDefaultAtLaunch = Preferences.applyDefaultProfileAtLaunch && defaultProfileID != nil
+    }
+
+    func createFromCurrent(
+        name rawName: String,
+        completion: @escaping (String) -> Void
+    ) {
+        let name = normalizedName(rawName)
+        guard !name.isEmpty else {
+            return completion("Enter a name for this profile.")
+        }
+        guard !isBusy else {
+            return completion("Pelmet is already working on a profile.")
+        }
+
+        isBusy = true
+        MenuBarManager.shared.beginProfileOperation { [weak self] context, classification in
+            guard let self else { return }
+            guard let classification else {
+                MenuBarManager.shared.endProfileOperation(context)
+                self.finishBusy(message: "Pelmet could not confirm the current menu bar layout.")
+                return completion(self.lastMessage ?? "")
+            }
+
+            MenuBarManager.shared.shelfEngine.requestProfileDirectory { directory in
+                let snapshot = MenuBarManager.shared.profileSnapshot(
+                    using: classification,
+                    directory: directory
+                )
+                guard !snapshot.candidates.isEmpty else {
+                    MenuBarManager.shared.endProfileOperation(context)
+                    let message = snapshot.unidentifiedCount > 0
+                        ? "No identifiable menu bar items were available. Accessibility may be needed on this macOS version."
+                        : "No menu bar items were available to save."
+                    self.finishBusy(message: message)
+                    return completion(message)
+                }
+
+                let placements = snapshot.candidates.map {
+                    ProfileItemPlacement(
+                        key: $0.key,
+                        displayName: $0.displayName,
+                        side: $0.side,
+                        order: $0.order
+                    )
+                }
+                let profile = MenuBarProfile(name: name, placements: placements)
+                self.profiles.append(profile)
+                self.activeProfileID = profile.id
+                self.persist()
+                MenuBarManager.shared.endProfileOperation(context)
+
+                var message = "Saved \(profile.name)."
+                if snapshot.unidentifiedCount > 0 {
+                    message += " \(snapshot.unidentifiedCount) unidentified item"
+                        + (snapshot.unidentifiedCount == 1 ? " was" : "s were")
+                        + " left out."
+                }
+                self.finishBusy(message: message)
+                completion(message)
+            }
+        }
+    }
+
+    func rename(_ profileID: UUID, to rawName: String) -> Bool {
+        let name = normalizedName(rawName)
+        guard !name.isEmpty,
+              let index = profiles.firstIndex(where: { $0.id == profileID })
+        else { return false }
+        profiles[index].name = name
+        persist()
+        return true
+    }
+
+    func delete(_ profileID: UUID) {
+        profiles.removeAll { $0.id == profileID }
+        if activeProfileID == profileID {
+            activeProfileID = profiles.first?.id
+        }
+        if defaultProfileID == profileID {
+            defaultProfileID = nil
+            applyDefaultAtLaunch = false
+        }
+        persist()
+    }
+
+    func move(_ profileID: UUID, by offset: Int) {
+        guard let index = profiles.firstIndex(where: { $0.id == profileID }) else { return }
+        let destination = min(max(index + offset, 0), profiles.count - 1)
+        guard destination != index else { return }
+        let profile = profiles.remove(at: index)
+        profiles.insert(profile, at: destination)
+        persist()
+    }
+
+    func setActive(_ profileID: UUID?) {
+        guard profileID == nil || profiles.contains(where: { $0.id == profileID }) else { return }
+        activeProfileID = profileID
+        persist()
+    }
+
+    func setDefault(_ profileID: UUID?) {
+        guard profileID == nil || profiles.contains(where: { $0.id == profileID }) else { return }
+        defaultProfileID = profileID
+        if profileID == nil {
+            applyDefaultAtLaunch = false
+        }
+        persist()
+    }
+
+    func setApplyDefaultAtLaunch(_ enabled: Bool) {
+        applyDefaultAtLaunch = enabled && defaultProfileID != nil
+        persist()
+    }
+
+    /// Called after the menu bar and activation engine are initialized. This
+    /// never asks for Accessibility; the result is visible when Settings opens.
+    func scheduleDefaultProfileApplication() {
+        guard applyDefaultAtLaunch, let defaultProfileID else { return }
+        DispatchQueue.main.asyncAfter(deadline: .now() + 2.5) { [weak self] in
+            guard let self,
+                  self.applyDefaultAtLaunch,
+                  self.defaultProfileID == defaultProfileID
+            else { return }
+            self.apply(defaultProfileID, reason: .launch) { _ in }
+        }
+    }
+
+    func apply(
+        _ profileID: UUID,
+        reason: ProfileApplyReason = .user,
+        completion: @escaping (ProfileApplyResult) -> Void
+    ) {
+        guard let profile = profiles.first(where: { $0.id == profileID }) else {
+            let result = ProfileApplyResult(
+                profileID: profileID,
+                profileName: "Profile",
+                appliedCount: 0,
+                skippedCount: 0,
+                failed: true
+            )
+            lastResult = result
+            lastMessage = result.summary
+            return completion(result)
+        }
+        guard !isBusy else {
+            let result = ProfileApplyResult(
+                profileID: profile.id,
+                profileName: profile.name,
+                appliedCount: 0,
+                skippedCount: 0,
+                failed: true
+            )
+            lastResult = result
+            lastMessage = "Pelmet is already working on a profile."
+            return completion(result)
+        }
+
+        if ProcessInfo.processInfo.environment["PELMET_DISABLE_ACTIVATION"] == "1" {
+            let result = ProfileApplyResult(
+                profileID: profile.id,
+                profileName: profile.name,
+                appliedCount: 0,
+                skippedCount: 0,
+                failed: true
+            )
+            lastResult = result
+            lastMessage = result.summary
+            return completion(result)
+        }
+
+        guard StatusItemActivationEngine.shared.canArrangeProfiles else {
+            let result = ProfileApplyResult(
+                profileID: profile.id,
+                profileName: profile.name,
+                appliedCount: 0,
+                skippedCount: 0,
+                missing: profile.placements,
+                permissionRequired: true
+            )
+            lastResult = result
+            lastMessage = result.summary
+            return completion(result)
+        }
+
+        isBusy = true
+        MenuBarManager.shared.beginProfileOperation { [weak self] context, classification in
+            guard let self else { return }
+            guard let classification else {
+                MenuBarManager.shared.endProfileOperation(context)
+                let result = ProfileApplyResult(
+                    profileID: profile.id,
+                    profileName: profile.name,
+                    appliedCount: 0,
+                    skippedCount: 0,
+                    failed: true
+                )
+                self.finish(result: result)
+                completion(result)
+                return
+            }
+
+            MenuBarManager.shared.shelfEngine.requestProfileDirectory { directory in
+                let snapshot = MenuBarManager.shared.profileSnapshot(
+                    using: classification,
+                    directory: directory
+                )
+                let match = ProfileMatcher.match(profile: profile, candidates: snapshot.candidates)
+                guard !match.matches.isEmpty else {
+                    MenuBarManager.shared.endProfileOperation(context)
+                    let result = ProfileApplyResult(
+                        profileID: profile.id,
+                        profileName: profile.name,
+                        appliedCount: 0,
+                        skippedCount: snapshot.unidentifiedCount,
+                        missing: match.missing,
+                        ambiguous: match.ambiguous
+                    )
+                    self.finish(result: result)
+                    completion(result)
+                    return
+                }
+
+                self.applyMatches(
+                    profile: profile,
+                    context: context,
+                    initialMatch: match,
+                    initialSkipped: snapshot.unidentifiedCount,
+                    reason: reason,
+                    completion: completion
+                )
+            }
+        }
+    }
+
+    private func applyMatches(
+        profile: MenuBarProfile,
+        context: ProfileOperationContext,
+        initialMatch: ProfileMatchResult,
+        initialSkipped: Int,
+        reason: ProfileApplyReason,
+        completion: @escaping (ProfileApplyResult) -> Void
+    ) {
+        var pending = Set(initialMatch.matches.map { $0.placement.key })
+        var appliedCount = 0
+        var skippedCount = initialSkipped
+        var lastMatch = initialMatch
+
+        func finish(_ failed: Bool = false) {
+            MenuBarManager.shared.endProfileOperation(context)
+            let result = ProfileApplyResult(
+                profileID: profile.id,
+                profileName: profile.name,
+                appliedCount: appliedCount,
+                skippedCount: skippedCount,
+                missing: lastMatch.missing,
+                ambiguous: lastMatch.ambiguous,
+                failed: failed
+            )
+            if appliedCount > 0 || result.isComplete {
+                activeProfileID = profile.id
+                persist()
+            }
+            self.finish(result: result)
+            completion(result)
+        }
+
+        func step() {
+            guard let classification = NotchLayoutMonitor.shared.confirmed else {
+                return finish(true)
+            }
+            MenuBarManager.shared.shelfEngine.requestProfileDirectory { directory in
+                let current = MenuBarManager.shared.profileSnapshot(
+                    using: classification,
+                    directory: directory
+                )
+                let currentMatch = ProfileMatcher.match(profile: profile, candidates: current.candidates)
+                lastMatch = currentMatch
+
+                if self.arrangementMatches(profile: profile, match: currentMatch) {
+                    pending.removeAll()
+                    return finish()
+                }
+
+                guard !pending.isEmpty else { return finish(true) }
+
+                guard let nextPlacement = profile.placements
+                    .filter({ pending.contains($0.key) })
+                    .sorted(by: { $0.order > $1.order })
+                    .first
+                else { return finish() }
+
+                guard let match = currentMatch.matches.first(where: {
+                    $0.placement.key == nextPlacement.key
+                }) else {
+                    pending.remove(nextPlacement.key)
+                    skippedCount += 1
+                    return step()
+                }
+
+                let sameSide = match.candidate.side == nextPlacement.side
+                let rightNeighbor = profile.placements
+                    .filter { placement in
+                        placement.side == nextPlacement.side
+                            && placement.order > nextPlacement.order
+                            && currentMatch.matches.contains { match in
+                                match.placement.key == placement.key
+                            }
+                    }
+                    .sorted { $0.order < $1.order }
+                    .compactMap { placement in
+                        currentMatch.matches.first { $0.placement.key == placement.key }?.candidate
+                    }
+                    .first
+
+                guard let target = MenuBarManager.shared.profileTargetPoint(
+                    side: nextPlacement.side,
+                    rightNeighbor: rightNeighbor
+                ) else {
+                    pending.remove(nextPlacement.key)
+                    skippedCount += 1
+                    return step()
+                }
+
+                let source = CGPoint(x: match.candidate.frame.midX, y: match.candidate.frame.midY)
+                pending.remove(nextPlacement.key)
+
+                if sameSide, abs(source.x - target.x) < 4 {
+                    appliedCount += 1
+                    return step()
+                }
+
+                MenuBarManager.shared.performProfileDrag(from: source, to: target) { success in
+                    if success {
+                        appliedCount += 1
+                    } else {
+                        skippedCount += 1
+                    }
+                    NotchLayoutMonitor.shared.requestConfirmedLayout { classification in
+                        guard classification != nil else { return finish(true) }
+                        step()
+                    }
+                }
+            }
+        }
+
+        _ = reason
+        step()
+    }
+
+    private func arrangementMatches(
+        profile: MenuBarProfile,
+        match: ProfileMatchResult
+    ) -> Bool {
+        let matchedKeys = Set(match.matches.map { $0.placement.key })
+        guard match.matches.allSatisfy({ $0.candidate.side == $0.placement.side }) else {
+            return false
+        }
+
+        for side in ProfileItemSide.allCases {
+            let desired = profile.placements
+                .filter { $0.side == side && matchedKeys.contains($0.key) }
+                .sorted { $0.order < $1.order }
+                .map(\.key)
+            let current = match.matches
+                .filter { $0.candidate.side == side }
+                .sorted { $0.candidate.order < $1.candidate.order }
+                .map { $0.placement.key }
+            if desired != current { return false }
+        }
+        return true
+    }
+
+    private func finish(result: ProfileApplyResult) {
+        lastResult = result
+        lastMessage = result.summary
+        isBusy = false
+    }
+
+    private func finishBusy(message: String) {
+        lastResult = nil
+        lastMessage = message
+        isBusy = false
+    }
+
+    private func persist() {
+        isPersisting = true
+        defer { isPersisting = false }
+        Preferences.menuBarProfiles = profiles
+        Preferences.activeProfileID = activeProfileID
+        Preferences.defaultProfileID = defaultProfileID
+        Preferences.applyDefaultProfileAtLaunch = applyDefaultAtLaunch
+    }
+
+    private func normalizedName(_ rawName: String) -> String {
+        rawName.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+enum ProfileApplyReason {
+    case user
+    case launch
+}

--- a/Sources/Pelmet/Settings/ProfilesPaneView.swift
+++ b/Sources/Pelmet/Settings/ProfilesPaneView.swift
@@ -1,0 +1,298 @@
+import PelmetCore
+import SwiftUI
+
+/// Profile management stays opt-in: opening this pane never moves icons or
+/// requests Accessibility. Capture and apply are explicit user actions.
+struct ProfilesPaneView: View {
+
+    @ObservedObject private var controller = ProfileController.shared
+    @State private var newProfileName = ""
+    @State private var editingProfileID: UUID?
+    @State private var editingName = ""
+    @State private var profileToDelete: MenuBarProfile?
+
+    var body: some View {
+        Form {
+            Section {
+                if controller.profiles.isEmpty {
+                    Text("Save your current menu bar arrangement as a profile. "
+                        + "Profiles can remember which items stay visible and their order.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                } else {
+                    ForEach(Array(controller.profiles.enumerated()), id: \.element.id) { index, profile in
+                        profileRow(profile, index: index)
+                    }
+                }
+
+                LabeledContent("Profile name") {
+                    HStack(alignment: .center, spacing: 10) {
+                        TextField("", text: $newProfileName)
+                            .textFieldStyle(.roundedBorder)
+                            .frame(minWidth: 220)
+                            .overlay(alignment: .leading) {
+                                if newProfileName.isEmpty {
+                                    Text("e.g. Work")
+                                        .foregroundStyle(.secondary)
+                                        .padding(.leading, 6)
+                                        .allowsHitTesting(false)
+                                }
+                            }
+                            .onSubmit { saveCurrentProfile() }
+
+                        Button("Create Profile") {
+                            saveCurrentProfile()
+                        }
+                        .disabled(newProfileName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+                            || controller.isBusy)
+                    }
+                }
+            } header: {
+                Text("Saved Profiles")
+            } footer: {
+                Text("Capture records identifiable menu bar items. Items macOS does not expose "
+                    + "are left out and reported.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Section("Active Profile") {
+                Picker(
+                    "Current profile",
+                    selection: Binding<String>(
+                        get: { controller.activeProfileID?.uuidString ?? "" },
+                        set: { controller.setActive(UUID(uuidString: $0)) }
+                    )
+                ) {
+                    Text("None").tag("")
+                    ForEach(controller.profiles) { profile in
+                        Text(profile.name).tag(profile.id.uuidString)
+                    }
+                }
+                .pickerStyle(.menu)
+
+                Text("The current profile is shown in the chevron menu. Use Apply above to arrange menu bar items.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Section("Default Profile") {
+                Picker(
+                    "Profile used at launch",
+                    selection: Binding<String>(
+                        get: { controller.defaultProfileID?.uuidString ?? "" },
+                        set: { controller.setDefault(UUID(uuidString: $0)) }
+                    )
+                ) {
+                    Text("None").tag("")
+                    ForEach(controller.profiles) { profile in
+                        Text(profile.name).tag(profile.id.uuidString)
+                    }
+                }
+                .pickerStyle(.menu)
+
+                Toggle(
+                    "Apply the default profile at launch",
+                    isOn: Binding(
+                        get: { controller.applyDefaultAtLaunch },
+                        set: { controller.setApplyDefaultAtLaunch($0) }
+                    )
+                )
+                .disabled(controller.defaultProfileID == nil)
+
+                Text("Applying a profile uses Accessibility only when you explicitly "
+                    + "save, apply, or opt into launch application. Pelmet never prompts "
+                    + "during ordinary startup.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if controller.isBusy {
+                Section {
+                    ProgressView("Working with the menu bar…")
+                }
+            }
+
+            if let result = controller.lastResult {
+                Section("Last Result") {
+                    Text(result.summary)
+                        .fixedSize(horizontal: false, vertical: true)
+                    if !result.missing.isEmpty {
+                        unresolvedList(title: "Not found", placements: result.missing)
+                    }
+                    if !result.ambiguous.isEmpty {
+                        unresolvedList(title: "Ambiguous", placements: result.ambiguous)
+                    }
+                }
+            } else if let lastMessage = controller.lastMessage {
+                Section("Last Result") {
+                    Text(lastMessage)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+        .formStyle(.grouped)
+        .alert(
+            "Delete Profile?",
+            isPresented: Binding(
+                get: { profileToDelete != nil },
+                set: { if !$0 { profileToDelete = nil } }
+            ),
+            presenting: profileToDelete
+        ) { profile in
+            Button("Delete", role: .destructive) {
+                controller.delete(profile.id)
+                profileToDelete = nil
+            }
+            Button("Cancel", role: .cancel) {
+                profileToDelete = nil
+            }
+        } message: { profile in
+            Text("Delete \(profile.name)? Its saved arrangement will be removed.")
+        }
+    }
+
+    private func saveCurrentProfile() {
+        let name = newProfileName
+        ProfileController.shared.createFromCurrent(name: name) { message in
+            if message.hasPrefix("Saved ") {
+                newProfileName = ""
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func profileRow(_ profile: MenuBarProfile, index: Int) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .center, spacing: 12) {
+                VStack(alignment: .leading, spacing: 4) {
+                    if editingProfileID == profile.id {
+                        TextField("Profile name", text: $editingName)
+                            .textFieldStyle(.roundedBorder)
+                            .onSubmit { finishEditing(profile.id) }
+                    } else {
+                        Text(profile.name)
+                            .font(.headline)
+                    }
+
+                    Text("\(profile.placements.count) identifiable item"
+                        + (profile.placements.count == 1 ? "" : "s"))
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Spacer(minLength: 8)
+
+                if editingProfileID == profile.id {
+                    Button("Save") {
+                        finishEditing(profile.id)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .controlSize(.small)
+
+                    Button("Cancel") {
+                        cancelEditing()
+                    }
+                    .buttonStyle(.bordered)
+                    .controlSize(.small)
+                } else {
+                    let isCurrent = controller.activeProfileID == profile.id
+                    if isCurrent {
+                        Button {} label: {
+                            Label("Current", systemImage: "checkmark")
+                        }
+                        .buttonStyle(.bordered)
+                        .controlSize(.small)
+                        .disabled(true)
+                    } else {
+                        Button {
+                            controller.apply(profile.id) { _ in }
+                        } label: {
+                            Label("Apply", systemImage: "arrow.right.circle")
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .controlSize(.small)
+                        .disabled(controller.isBusy)
+                    }
+
+                    profileActionsMenu(profile, index: index)
+                }
+            }
+        }
+        .padding(.vertical, 6)
+    }
+
+    private func profileActionsMenu(
+        _ profile: MenuBarProfile,
+        index: Int
+    ) -> some View {
+        Menu {
+            Button {
+                controller.move(profile.id, by: -1)
+            } label: {
+                Label("Move Up", systemImage: "arrow.up")
+            }
+            .disabled(index == 0)
+
+            Button {
+                controller.move(profile.id, by: 1)
+            } label: {
+                Label("Move Down", systemImage: "arrow.down")
+            }
+            .disabled(index == controller.profiles.count - 1)
+
+            Divider()
+
+            Button {
+                beginEditing(profile)
+            } label: {
+                Label("Rename", systemImage: "pencil")
+            }
+
+            Button(role: .destructive) {
+                profileToDelete = profile
+            } label: {
+                Label("Delete", systemImage: "trash")
+            }
+        } label: {
+            Image(systemName: "ellipsis")
+                .frame(width: 20, height: 18)
+        }
+        .menuStyle(.borderedButton)
+        .controlSize(.small)
+        .help("More actions for \(profile.name)")
+        .accessibilityLabel("More actions for \(profile.name)")
+    }
+
+    @ViewBuilder
+    private func unresolvedList(
+        title: String,
+        placements: [ProfileItemPlacement]
+    ) -> some View {
+        DisclosureGroup("\(title) (\(placements.count))") {
+            ForEach(placements) { placement in
+                Text(placement.displayName)
+                    .font(.caption)
+            }
+        }
+    }
+
+    private func finishEditing(_ profileID: UUID) {
+        _ = controller.rename(profileID, to: editingName)
+        cancelEditing()
+    }
+
+    private func beginEditing(_ profile: MenuBarProfile) {
+        editingProfileID = profile.id
+        editingName = profile.name
+    }
+
+    private func cancelEditing() {
+        editingProfileID = nil
+        editingName = ""
+    }
+}

--- a/Sources/Pelmet/Settings/SettingsPane.swift
+++ b/Sources/Pelmet/Settings/SettingsPane.swift
@@ -6,6 +6,7 @@ enum SettingsPane: String, CaseIterable, Identifiable {
     case general
     case menuBarSpace
     case oneClickAccess
+    case profiles
     case about
 
     var id: String { rawValue }
@@ -21,7 +22,7 @@ enum SettingsPane: String, CaseIterable, Identifiable {
     /// context-menu entry in MenuBarManager: One-Click Access only exists
     /// where the notch makes it relevant.
     static func available(hasNotchedDisplay: Bool) -> [SettingsPane] {
-        hasNotchedDisplay ? allCases : [.general, .menuBarSpace, .about]
+        hasNotchedDisplay ? allCases : [.general, .menuBarSpace, .profiles, .about]
     }
 
     var title: String {
@@ -29,6 +30,7 @@ enum SettingsPane: String, CaseIterable, Identifiable {
         case .general: return "General"
         case .menuBarSpace: return "Menu Bar Space"
         case .oneClickAccess: return "One-Click Access"
+        case .profiles: return "Profiles"
         case .about: return "About"
         }
     }
@@ -38,6 +40,7 @@ enum SettingsPane: String, CaseIterable, Identifiable {
         case .general: return "gearshape"
         case .menuBarSpace: return "menubar.rectangle"
         case .oneClickAccess: return "cursorarrow.click"
+        case .profiles: return "square.stack.3d.up"
         case .about: return "info.circle"
         }
     }
@@ -48,6 +51,7 @@ enum SettingsPane: String, CaseIterable, Identifiable {
         case .general: return .gray
         case .menuBarSpace: return .blue
         case .oneClickAccess: return .purple
+        case .profiles: return .orange
         case .about: return .teal
         }
     }

--- a/Sources/Pelmet/Settings/SettingsRootView.swift
+++ b/Sources/Pelmet/Settings/SettingsRootView.swift
@@ -1,6 +1,10 @@
 import Combine
 import SwiftUI
 
+extension Notification.Name {
+    static let pelmetSettingsSelectPane = Notification.Name("PelmetSettingsSelectPane")
+}
+
 /// System Settings-style two-column layout: a sidebar of panes on the left,
 /// the selected pane's form on the right. The window uses a transparent
 /// full-size titlebar, so the sidebar material runs to the top edge and the
@@ -75,6 +79,13 @@ struct SettingsRootView: View {
                 selection = .general
             }
         }
+        .onReceive(NotificationCenter.default.publisher(for: .pelmetSettingsSelectPane)) { note in
+            guard let rawValue = note.userInfo?["pane"] as? String,
+                  let pane = SettingsPane(rawValue: rawValue)
+            else { return }
+            selection = pane
+            Preferences.settingsPane = pane.rawValue
+        }
     }
 
     @ViewBuilder
@@ -83,6 +94,7 @@ struct SettingsRootView: View {
         case .general: GeneralPaneView()
         case .menuBarSpace: MenuBarSpacePaneView()
         case .oneClickAccess: OneClickAccessPaneView()
+        case .profiles: ProfilesPaneView()
         case .about: AboutPaneView()
         }
     }

--- a/Sources/Pelmet/Settings/SettingsWindowController.swift
+++ b/Sources/Pelmet/Settings/SettingsWindowController.swift
@@ -20,7 +20,10 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         window.delegate = self
     }
 
-    func show() {
+    func show(pane: SettingsPane? = nil) {
+        if let pane {
+            Preferences.settingsPane = pane.rawValue
+        }
         // Accessory apps need explicit activation to bring windows forward.
         NSApp.activate(ignoringOtherApps: true)
         if window?.isVisible != true {
@@ -29,6 +32,13 @@ final class SettingsWindowController: NSWindowController, NSWindowDelegate {
         }
         showWindow(nil)
         window?.makeKeyAndOrderFront(nil)
+        if let pane {
+            NotificationCenter.default.post(
+                name: .pelmetSettingsSelectPane,
+                object: nil,
+                userInfo: ["pane": pane.rawValue]
+            )
+        }
     }
 
     func windowWillClose(_ notification: Notification) {

--- a/Sources/PelmetCore/MenuBarProfile.swift
+++ b/Sources/PelmetCore/MenuBarProfile.swift
@@ -1,0 +1,274 @@
+import CoreGraphics
+import Foundation
+
+/// The side of Pelmet's divider where an item belongs.
+public enum ProfileItemSide: String, Codable, CaseIterable, Equatable {
+    case managed
+    case alwaysVisible
+
+    public var label: String {
+        switch self {
+        case .managed: return "Hidden by Pelmet"
+        case .alwaysVisible: return "Always visible"
+        }
+    }
+}
+
+/// A persisted identity for a menu bar item.
+///
+/// Process IDs and frames are deliberately absent: both change during normal
+/// launches and layout reflows. An Accessibility title is the strongest
+/// discriminator when one exists. Titleless items use an occurrence within the
+/// owning application as a bounded fallback.
+public struct ProfileItemKey: Codable, Hashable, Equatable {
+    public let bundleIdentifier: String
+    public let accessibilityTitle: String?
+    public let occurrence: Int?
+
+    public init(
+        bundleIdentifier: String,
+        accessibilityTitle: String? = nil,
+        occurrence: Int? = nil
+    ) {
+        self.bundleIdentifier = bundleIdentifier
+        self.accessibilityTitle = accessibilityTitle
+        self.occurrence = occurrence
+    }
+
+    /// Whether this saved key can refer to the candidate. A missing saved
+    /// title is a deliberate fallback, not a wildcard for another bundle.
+    public func matches(_ candidate: ProfileItemKey) -> Bool {
+        guard bundleIdentifier == candidate.bundleIdentifier else { return false }
+        if let accessibilityTitle {
+            guard accessibilityTitle == candidate.accessibilityTitle else { return false }
+        }
+        if let occurrence {
+            guard occurrence == candidate.occurrence else { return false }
+        }
+        return true
+    }
+
+    public var stableDescription: String {
+        var parts = [bundleIdentifier]
+        if let accessibilityTitle, !accessibilityTitle.isEmpty {
+            parts.append(accessibilityTitle)
+        }
+        if let occurrence {
+            parts.append("#\(occurrence + 1)")
+        }
+        return parts.joined(separator: " · ")
+    }
+}
+
+/// One item and its desired side/order in a saved profile.
+public struct ProfileItemPlacement: Codable, Equatable, Identifiable {
+    public let key: ProfileItemKey
+    public var displayName: String
+    public var side: ProfileItemSide
+    /// Left-to-right order in the menu bar, starting at zero.
+    public var order: Int
+
+    public init(
+        key: ProfileItemKey,
+        displayName: String,
+        side: ProfileItemSide,
+        order: Int
+    ) {
+        self.key = key
+        self.displayName = displayName
+        self.side = side
+        self.order = order
+    }
+
+    public var id: String {
+        "\(key.stableDescription)|\(order)|\(displayName)"
+    }
+}
+
+/// A named arrangement. Profiles intentionally contain arrangement only;
+/// hover, auto-rehide, spacing, and collapse state remain global preferences.
+public struct MenuBarProfile: Codable, Equatable, Identifiable {
+    public let id: UUID
+    public var name: String
+    public var placements: [ProfileItemPlacement]
+    public let createdAt: Date
+
+    public init(
+        id: UUID = UUID(),
+        name: String,
+        placements: [ProfileItemPlacement],
+        createdAt: Date = Date()
+    ) {
+        self.id = id
+        self.name = name
+        self.placements = placements.sorted { lhs, rhs in
+            if lhs.order != rhs.order { return lhs.order < rhs.order }
+            return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
+        }
+        self.createdAt = createdAt
+    }
+}
+
+/// A currently observed item prepared for profile matching.
+public struct ProfileItemCandidate: Equatable {
+    public let key: ProfileItemKey
+    public let displayName: String
+    public let side: ProfileItemSide
+    public let order: Int
+    public let frame: CGRect
+
+    public init(
+        key: ProfileItemKey,
+        displayName: String,
+        side: ProfileItemSide,
+        order: Int,
+        frame: CGRect = .zero
+    ) {
+        self.key = key
+        self.displayName = displayName
+        self.side = side
+        self.order = order
+        self.frame = frame
+    }
+}
+
+/// A unique saved-to-current item pairing.
+public struct ProfileItemMatch: Equatable {
+    public let placement: ProfileItemPlacement
+    public let candidate: ProfileItemCandidate
+
+    public init(placement: ProfileItemPlacement, candidate: ProfileItemCandidate) {
+        self.placement = placement
+        self.candidate = candidate
+    }
+}
+
+/// Deterministic result of matching a saved profile against the current bar.
+public struct ProfileMatchResult: Equatable {
+    public let matches: [ProfileItemMatch]
+    public let missing: [ProfileItemPlacement]
+    public let ambiguous: [ProfileItemPlacement]
+
+    public init(
+        matches: [ProfileItemMatch],
+        missing: [ProfileItemPlacement],
+        ambiguous: [ProfileItemPlacement]
+    ) {
+        self.matches = matches
+        self.missing = missing
+        self.ambiguous = ambiguous
+    }
+}
+
+/// Matches saved identities without guessing when a fallback identity is not
+/// unique. A unique title match can survive a same-app reorder; occurrence is
+/// used to disambiguate an exact duplicate title when it is still available.
+/// An ambiguous placement is reported and its candidate is not consumed by
+/// another placement.
+public enum ProfileMatcher {
+
+    public static func match(
+        profile: MenuBarProfile,
+        candidates: [ProfileItemCandidate]
+    ) -> ProfileMatchResult {
+        let placements = profile.placements.sorted { lhs, rhs in
+            if lhs.order != rhs.order { return lhs.order < rhs.order }
+            return lhs.displayName.localizedCaseInsensitiveCompare(rhs.displayName) == .orderedAscending
+        }
+        var usedCandidateIndexes = Set<Int>()
+        var matches: [ProfileItemMatch] = []
+        var missing: [ProfileItemPlacement] = []
+        var ambiguous: [ProfileItemPlacement] = []
+
+        for placement in placements {
+            let exact = candidates.indices.filter { index in
+                !usedCandidateIndexes.contains(index)
+                    && placement.key.matches(candidates[index].key)
+            }
+            let possible: [Int]
+            if !exact.isEmpty {
+                possible = exact
+            } else if let title = placement.key.accessibilityTitle {
+                possible = candidates.indices.filter { index in
+                    !usedCandidateIndexes.contains(index)
+                        && candidates[index].key.bundleIdentifier == placement.key.bundleIdentifier
+                        && candidates[index].key.accessibilityTitle == title
+                }
+            } else {
+                possible = []
+            }
+            switch possible.count {
+            case 0:
+                missing.append(placement)
+            case 1:
+                let index = possible[0]
+                usedCandidateIndexes.insert(index)
+                matches.append(ProfileItemMatch(
+                    placement: placement,
+                    candidate: candidates[index]
+                ))
+            default:
+                ambiguous.append(placement)
+            }
+        }
+
+        return ProfileMatchResult(matches: matches, missing: missing, ambiguous: ambiguous)
+    }
+}
+
+/// User-facing summary of a profile application. The AppKit coordinator
+/// fills this after each safe drag attempt; the pure matcher supplies the
+/// missing and ambiguous lists.
+public struct ProfileApplyResult: Codable, Equatable {
+    public let profileID: UUID
+    public let profileName: String
+    public let appliedCount: Int
+    public let skippedCount: Int
+    public let missing: [ProfileItemPlacement]
+    public let ambiguous: [ProfileItemPlacement]
+    public let permissionRequired: Bool
+    public let failed: Bool
+
+    public init(
+        profileID: UUID,
+        profileName: String,
+        appliedCount: Int,
+        skippedCount: Int,
+        missing: [ProfileItemPlacement] = [],
+        ambiguous: [ProfileItemPlacement] = [],
+        permissionRequired: Bool = false,
+        failed: Bool = false
+    ) {
+        self.profileID = profileID
+        self.profileName = profileName
+        self.appliedCount = appliedCount
+        self.skippedCount = skippedCount
+        self.missing = missing
+        self.ambiguous = ambiguous
+        self.permissionRequired = permissionRequired
+        self.failed = failed
+    }
+
+    public var isComplete: Bool {
+        !failed && !permissionRequired && skippedCount == 0
+            && missing.isEmpty && ambiguous.isEmpty
+    }
+
+    public var summary: String {
+        if permissionRequired {
+            return "Accessibility permission is required to move menu bar icons."
+        }
+        if failed, appliedCount == 0, skippedCount == 0, missing.isEmpty, ambiguous.isEmpty {
+            return "The profile could not be applied completely."
+        }
+        if appliedCount == 0, skippedCount == 0, missing.isEmpty, ambiguous.isEmpty {
+            return "Profile already matches the current arrangement."
+        }
+        var text = "Applied \(appliedCount) item\(appliedCount == 1 ? "" : "s")"
+        let unresolved = missing.count + ambiguous.count + skippedCount
+        if unresolved > 0 {
+            text += "; left \(unresolved) item\(unresolved == 1 ? "" : "s") unchanged"
+        }
+        return text + (failed ? ". Some moves could not be confirmed." : ".")
+    }
+}

--- a/Tests/PelmetCoreTests/MenuBarProfileTests.swift
+++ b/Tests/PelmetCoreTests/MenuBarProfileTests.swift
@@ -1,0 +1,216 @@
+import Foundation
+import PelmetCore
+import Testing
+
+struct MenuBarProfileTests {
+
+    private let vpnKey = ProfileItemKey(
+        bundleIdentifier: "com.example.vpn",
+        accessibilityTitle: "VPN",
+        occurrence: nil
+    )
+
+    @Test func profileRoundTripsThroughCodable() throws {
+        let profile = MenuBarProfile(
+            id: UUID(uuidString: "AAAAAAAA-AAAA-AAAA-AAAA-AAAAAAAAAAAA")!,
+            name: "Work",
+            placements: [
+                ProfileItemPlacement(
+                    key: vpnKey,
+                    displayName: "VPN",
+                    side: .alwaysVisible,
+                    order: 1
+                ),
+            ],
+            createdAt: Date(timeIntervalSince1970: 123)
+        )
+
+        let data = try JSONEncoder().encode(profile)
+        let decoded = try JSONDecoder().decode(MenuBarProfile.self, from: data)
+
+        #expect(decoded == profile)
+        #expect(decoded.placements.map(\.order) == [1])
+    }
+
+    @Test func titleAndBundleMustMatch() {
+        let candidate = ProfileItemKey(
+            bundleIdentifier: "com.example.other",
+            accessibilityTitle: "VPN"
+        )
+
+        #expect(!vpnKey.matches(candidate))
+        #expect(vpnKey.matches(vpnKey))
+        let occurrenceKey = ProfileItemKey(
+            bundleIdentifier: "com.example.vpn",
+            accessibilityTitle: "VPN",
+            occurrence: 1
+        )
+        #expect(occurrenceKey.matches(ProfileItemKey(
+            bundleIdentifier: "com.example.vpn",
+            accessibilityTitle: "VPN",
+            occurrence: 2
+        )) == false)
+    }
+
+    @Test func titlelessKeyUsesOccurrenceAsFallback() {
+        let saved = ProfileItemKey(
+            bundleIdentifier: "com.example.tool",
+            occurrence: 1
+        )
+        let sameOccurrence = ProfileItemKey(
+            bundleIdentifier: "com.example.tool",
+            accessibilityTitle: "",
+            occurrence: 1
+        )
+        let differentOccurrence = ProfileItemKey(
+            bundleIdentifier: "com.example.tool",
+            occurrence: 0
+        )
+
+        #expect(saved.matches(sameOccurrence))
+        #expect(!saved.matches(differentOccurrence))
+    }
+
+    @Test func matcherReportsMissingAndMatchesKnownItems() {
+        let profile = MenuBarProfile(
+            name: "Work",
+            placements: [
+                ProfileItemPlacement(key: vpnKey, displayName: "VPN", side: .alwaysVisible, order: 0),
+                ProfileItemPlacement(
+                    key: ProfileItemKey(bundleIdentifier: "com.example.chat"),
+                    displayName: "Chat",
+                    side: .managed,
+                    order: 1
+                ),
+            ]
+        )
+        let candidates = [
+            ProfileItemCandidate(
+                key: vpnKey,
+                displayName: "VPN",
+                side: .managed,
+                order: 0
+            ),
+        ]
+
+        let result = ProfileMatcher.match(profile: profile, candidates: candidates)
+
+        #expect(result.matches.count == 1)
+        #expect(result.matches[0].placement.displayName == "VPN")
+        #expect(result.missing.map(\.displayName) == ["Chat"])
+        #expect(result.ambiguous.isEmpty)
+    }
+
+    @Test func uniqueTitleMatchSurvivesSameAppReorder() {
+        let profile = MenuBarProfile(
+            name: "Work",
+            placements: [
+                ProfileItemPlacement(
+                    key: ProfileItemKey(
+                        bundleIdentifier: "com.example.tool",
+                        accessibilityTitle: "VPN",
+                        occurrence: 0
+                    ),
+                    displayName: "VPN",
+                    side: .managed,
+                    order: 0
+                ),
+            ]
+        )
+        let candidate = ProfileItemCandidate(
+            key: ProfileItemKey(
+                bundleIdentifier: "com.example.tool",
+                accessibilityTitle: "VPN",
+                occurrence: 1
+            ),
+            displayName: "VPN",
+            side: .managed,
+            order: 0
+        )
+
+        let result = ProfileMatcher.match(profile: profile, candidates: [candidate])
+
+        #expect(result.matches.count == 1)
+        #expect(result.missing.isEmpty)
+        #expect(result.ambiguous.isEmpty)
+    }
+
+    @Test func matcherLeavesDuplicateFallbacksAmbiguous() {
+        let profile = MenuBarProfile(
+            name: "Travel",
+            placements: [
+                ProfileItemPlacement(
+                    key: ProfileItemKey(bundleIdentifier: "com.example.tool"),
+                    displayName: "Tool",
+                    side: .managed,
+                    order: 0
+                ),
+            ]
+        )
+        let candidates = [
+            ProfileItemCandidate(
+                key: ProfileItemKey(bundleIdentifier: "com.example.tool", accessibilityTitle: "One"),
+                displayName: "Tool",
+                side: .managed,
+                order: 0
+            ),
+            ProfileItemCandidate(
+                key: ProfileItemKey(bundleIdentifier: "com.example.tool", accessibilityTitle: "Two"),
+                displayName: "Tool",
+                side: .alwaysVisible,
+                order: 1
+            ),
+        ]
+
+        let result = ProfileMatcher.match(profile: profile, candidates: candidates)
+
+        #expect(result.matches.isEmpty)
+        #expect(result.missing.isEmpty)
+        #expect(result.ambiguous.count == 1)
+    }
+
+    @Test func applyResultSummarizesBestEffortOutcome() {
+        let result = ProfileApplyResult(
+            profileID: UUID(),
+            profileName: "Presentation",
+            appliedCount: 2,
+            skippedCount: 1,
+            missing: [
+                ProfileItemPlacement(key: vpnKey, displayName: "VPN", side: .managed, order: 0),
+            ]
+        )
+
+        #expect(result.summary == "Applied 2 items; left 2 items unchanged.")
+        #expect(!result.isComplete)
+        #expect(!ProfileApplyResult(
+            profileID: UUID(),
+            profileName: "Travel",
+            appliedCount: 1,
+            skippedCount: 1
+        ).isComplete)
+    }
+
+    @Test func applyResultRoundTripsThroughCodable() throws {
+        let result = ProfileApplyResult(
+            profileID: UUID(uuidString: "BBBBBBBB-BBBB-BBBB-BBBB-BBBBBBBBBBBB")!,
+            profileName: "Travel",
+            appliedCount: 1,
+            skippedCount: 2,
+            ambiguous: [
+                ProfileItemPlacement(
+                    key: ProfileItemKey(bundleIdentifier: "com.example.tool"),
+                    displayName: "Tool",
+                    side: .managed,
+                    order: 0
+                ),
+            ],
+            permissionRequired: false,
+            failed: true
+        )
+
+        let data = try JSONEncoder().encode(result)
+        let decoded = try JSONDecoder().decode(ProfileApplyResult.self, from: data)
+
+        #expect(decoded == result)
+    }
+}

--- a/docs/shelf-verification.md
+++ b/docs/shelf-verification.md
@@ -58,28 +58,48 @@ On a notched Mac:
     Settings → availability flips to "Not granted"; clicking a row reports the
     permission failure inline; the core hide/show is untouched.
 
+## Profiles
+
+16. **Permission-free management.** Open Settings → Profiles without an
+    Accessibility grant. Confirm the pane does not prompt, existing profiles
+    can be renamed, reordered, selected as default, or deleted.
+17. **Capture.** Expand the bar if needed, enter a name, and choose "Save
+    Current Arrangement". Confirm the profile records identifiable items and
+    restores the prior collapsed or expanded state after capture.
+18. **Apply with permission.** Grant Accessibility in a bundled Release build,
+    apply a profile from Settings and from the chevron → Profiles menu. Confirm
+    managed/always-visible membership and left-to-right order change, then the
+    original collapsed state returns.
+19. **Best effort.** Add an unidentified or ambiguous item, apply a profile,
+    and confirm controllable items move while unresolved items remain unchanged
+    and appear under Last Result.
+20. **Launch default.** Select a default profile and enable "Apply the default
+    profile at launch". With Accessibility unavailable, relaunch and confirm no
+    prompt appears and Settings reports the permission requirement. Grant it,
+    relaunch, and confirm the profile applies.
+
 ## Safety rails
 
-16. **Hung app.** `kill -STOP <pid>` a menu bar app, then open the Shelf → the
+21. **Hung app.** `kill -STOP <pid>` a menu bar app, then open the Shelf → the
     AX sweep finishes within ~3s, no beachball (`kill -CONT` afterwards).
-17. **User race.** Start an activation, then immediately move the physical
+22. **User race.** Start an activation, then immediately move the physical
     mouse / press a button → the session aborts cleanly, no stuck synthetic
     button (verify with a manual click afterwards).
-18. **Kill switch.** `PELMET_DISABLE_ACTIVATION=1 ./Pelmet` → clicks report the
+23. **Kill switch.** `PELMET_DISABLE_ACTIVATION=1 ./Pelmet` → clicks report the
     permission failure and never post synthetic events.
 
 ## Accessibility
 
-19. VoiceOver announces each row as a button with the app name; arrow keys
+24. VoiceOver announces each row as a button with the app name; arrow keys
     move the selection; Return activates; Esc closes.
-20. System Settings → Accessibility: Reduce Motion → the Shelf appears with no
+25. System Settings → Accessibility: Reduce Motion → the Shelf appears with no
     slide/fade. Reduce Transparency → the panel draws opaque.
-21. `PELMET_DEBUG_LAYOUT=verbose swift run` → no repeating republish loop from
+26. `PELMET_DEBUG_LAYOUT=verbose swift run` → no repeating republish loop from
     PID-only churn (the digest ignores owner changes).
 
 ## Telemetry (anonymous daily ping)
 
-22. **Dry run, nothing sent.** `PELMET_DEBUG_TELEMETRY=verbose swift run` → prints
+27. **Dry run, nothing sent.** `PELMET_DEBUG_TELEMETRY=verbose swift run` → prints
     the gate decision and the exact JSON payload to stdout, and `active=false`
     (a `swift run` dev build is inert). Confirms the payload shape without a send.
     To actually send one from local for an end-to-end check, add
@@ -87,15 +107,15 @@ On a notched Mac:
     only, never beats `DO_NOT_TRACK`, `PELMET_DISABLE_TELEMETRY`, or an off
     preference). The day is recorded on success, so re-sending the same day needs
     `defaults delete com.ismatbabirli.Pelmet telemetryLastHeartbeatDay` first.
-23. **Kill switch.** `PELMET_DISABLE_TELEMETRY=1` or `DO_NOT_TRACK=1` → the verbose
+28. **Kill switch.** `PELMET_DISABLE_TELEMETRY=1` or `DO_NOT_TRACK=1` → the verbose
     trace shows `active=false`; the Settings toggle renders off and disabled under
     `DO_NOT_TRACK`.
-24. **Inert Debug bundle.** In the XcodeGen Debug `.app`, telemetry stays off via
+29. **Inert Debug bundle.** In the XcodeGen Debug `.app`, telemetry stays off via
     `#if DEBUG` even though the bundle has a real version. Only a Release build with
     a real PostHog key (see `docs/TELEMETRY.md`) actually sends.
-25. **First-run notice.** On a fresh profile the "Anonymous usage statistics" notice
+30. **First-run notice.** On a fresh profile the "Anonymous usage statistics" notice
     appears once, after the welcome tip, and does not stack on Sparkle's prompt.
     "Turn Off" flips the Settings toggle; nothing sends during that session.
-26. **Crash follow-up (local only).** `kill -TRAP <pid>` a Release build, relaunch →
+31. **Crash follow-up (local only).** `kill -TRAP <pid>` a Release build, relaunch →
     the "Pelmet quit unexpectedly" alert offers a prefilled GitHub issue and reveals
     the newest `Pelmet-*.ips` in Finder. A normal quit or Ctrl-C does not trigger it.


### PR DESCRIPTION
## What changed

- Add persisted Codable menu bar profiles with stable Accessibility-aware item matching.
- Add best-effort capture and apply through the existing Accessibility-gated command-drag path.
- Add Profiles settings controls for create, apply, rename, delete, reorder, active/default selection, and opt-in launch application.
- Add the active profile to the chevron menu.
- Update project, README, changelog, contributing, and manual QA documentation.

## Why

Profiles are the next roadmap item after the 0.4.2 shipping pipeline. They let users save and restore menu bar arrangements without requesting permissions during ordinary startup.

The final UI pass also fixed a UserDefaults observer race that could restore the previous active profile after a picker selection, and keeps only the successfully applied profile marked Current.

## Validation

- `swift test`: 191 tests in 23 suites passed.
- `xcodegen generate`: passed.
- Unsigned Xcode Release build: passed.
- SwiftFormat lint and `git diff --check`: passed.
- Bundled-app visual QA: Profiles pane, picker selection, Current/Apply state, action menu, rename flow, and best-effort result state verified.

Release target: v0.5.0 after CI passes.
