### PR TITLE
Add Polar support links

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
-# If you'd like to support Pelmet, GitHub Sponsors is the way. Add or remove
-# platforms as you set them up (ko_fi, buy_me_a_coffee, custom URLs, etc.).
-github: [ismatBabirli]
+# Pelmet is free and open source. Contributions help fund maintenance and
+# continued macOS compatibility work.
+custom: [https://buy.polar.sh/polar_cl_dmIB7LsoFtTdEnqBk5PBbK5OgB2v5Nw4Udw5d13Pi99]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ deliberately lightweight — no forms, no committees.
 ## The short version
 
 - **Found a bug or have an idea?** [Open an issue](https://github.com/ismatBabirli/pelmet/issues).
+- **Want to support Pelmet?** Make a [one-time or monthly contribution through Polar](https://buy.polar.sh/polar_cl_dmIB7LsoFtTdEnqBk5PBbK5OgB2v5Nw4Udw5d13Pi99).
 - **Small fix** (typo, small bug, doc tweak)? Send a PR directly.
 - **Bigger change** (new feature, refactor)? Open an issue first so we can talk
   it through — and skim [PROJECT.md](PROJECT.md), it may already be on the roadmap.

--- a/README.md
+++ b/README.md
@@ -188,6 +188,12 @@ Bug reports, ideas, and small PRs are very welcome — see
 [CONTRIBUTING.md](CONTRIBUTING.md) for a two-minute guide and a map of the
 codebase.
 
+## Support
+
+Pelmet is free and open source. If it helps keep your menu bar tidy, you can
+support maintenance, macOS compatibility work, and new features with a
+[one-time or monthly contribution through Polar](https://buy.polar.sh/polar_cl_dmIB7LsoFtTdEnqBk5PBbK5OgB2v5Nw4Udw5d13Pi99).
+
 ## License
 
 [MIT](LICENSE) © 2026 Ismat Babirli

--- a/Sources/Pelmet/AppVersionInfo.swift
+++ b/Sources/Pelmet/AppVersionInfo.swift
@@ -32,6 +32,7 @@ enum AppLinks {
     static let repo = URL(string: "https://github.com/ismatBabirli/pelmet")!
     static let changelog = URL(string: "https://github.com/ismatBabirli/pelmet/blob/main/CHANGELOG.md")!
     static let issues = URL(string: "https://github.com/ismatBabirli/pelmet/issues/new")!
+    static let support = URL(string: "https://buy.polar.sh/polar_cl_dmIB7LsoFtTdEnqBk5PBbK5OgB2v5Nw4Udw5d13Pi99")!
     /// Full field-by-field telemetry disclosure. Linked from the first-run
     /// notice and the Settings Privacy section.
     static let telemetryDoc = URL(string: "https://github.com/ismatBabirli/pelmet/blob/main/docs/TELEMETRY.md")!

--- a/Sources/Pelmet/Settings/AboutPaneView.swift
+++ b/Sources/Pelmet/Settings/AboutPaneView.swift
@@ -47,7 +47,7 @@ struct AboutPaneView: View {
 
             // Uniform, System-Settings-style rows: a tinted glyph, a title, and
             // a trailing hint (an up-right arrow leaves for the browser, a
-            // chevron opens an in-app window). One GitHub link, not two.
+            // chevron opens an in-app window).
             Section {
                 AboutRow(
                     title: "Star on GitHub",
@@ -56,6 +56,14 @@ struct AboutPaneView: View {
                     tint: .yellow,
                     opensExternally: true
                 ) { openURL(AppLinks.repo) }
+
+                AboutRow(
+                    title: "Support Pelmet",
+                    subtitle: "Help keep Pelmet free and open source.",
+                    systemImage: "heart.fill",
+                    tint: .pink,
+                    opensExternally: true
+                ) { openURL(AppLinks.support) }
 
                 AboutRow(title: "What's New", systemImage: "sparkles", tint: .accentColor) {
                     WhatsNewWindowController.shared.showManually()


### PR DESCRIPTION
## Summary

- add Polar as Pelmet's funding destination
- expose one-time and monthly support messaging in the README and contribution guide
- add a native About-pane support link while keeping checkout hosted by Polar

## Validation

- `swift test` — 191 tests passed
- `FUNDING.yml` YAML validation passed
- `git diff --check` passed
