### PR TITLE
Add Polar support nudge for v0.6.0

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,3 +1,3 @@
-# If you'd like to support Pelmet, GitHub Sponsors is the way. Add or remove
-# platforms as you set them up (ko_fi, buy_me_a_coffee, custom URLs, etc.).
-github: [ismatBabirli]
+# Pelmet is free and open source. Contributions help fund maintenance and
+# continued macOS compatibility work.
+custom: [https://buy.polar.sh/polar_cl_dmIB7LsoFtTdEnqBk5PBbK5OgB2v5Nw4Udw5d13Pi99]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.6.0] - 2026-08-05
+
+### Added
+
+- **Support Pelmet**: a Polar support link is available in the About pane and
+  chevron menu, with a gentle in-app prompt after the GitHub star prompt. The
+  prompt opens hosted Polar checkout, is rate-limited, and can be dismissed
+  permanently.
+
 ## [0.5.0] - 2026-08-04
 
 ### Added

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,7 @@ deliberately lightweight — no forms, no committees.
 ## The short version
 
 - **Found a bug or have an idea?** [Open an issue](https://github.com/ismatBabirli/pelmet/issues).
+- **Want to support Pelmet?** Make a [one-time or monthly contribution through Polar](https://buy.polar.sh/polar_cl_dmIB7LsoFtTdEnqBk5PBbK5OgB2v5Nw4Udw5d13Pi99).
 - **Small fix** (typo, small bug, doc tweak)? Send a PR directly.
 - **Bigger change** (new feature, refactor)? Open an issue first so we can talk
   it through — and skim [PROJECT.md](PROJECT.md), it may already be on the roadmap.

--- a/README.md
+++ b/README.md
@@ -188,6 +188,12 @@ Bug reports, ideas, and small PRs are very welcome — see
 [CONTRIBUTING.md](CONTRIBUTING.md) for a two-minute guide and a map of the
 codebase.
 
+## Support
+
+Pelmet is free and open source. If it helps keep your menu bar tidy, you can
+support maintenance, macOS compatibility work, and new features with a
+[one-time or monthly contribution through Polar](https://buy.polar.sh/polar_cl_dmIB7LsoFtTdEnqBk5PBbK5OgB2v5Nw4Udw5d13Pi99).
+
 ## License
 
 [MIT](LICENSE) © 2026 Ismat Babirli

--- a/Sources/Pelmet/AppDelegate.swift
+++ b/Sources/Pelmet/AppDelegate.swift
@@ -25,7 +25,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             hadExistingPreferences: hadExistingPreferences
         )
 
-        // Start the "after some time" clock for the star-on-GitHub nudge exactly
+        // Start the "after some time" clock for the community nudges exactly
         // once. Existing users begin counting from their first launch of this
         // build; they have already shown engagement, so that is acceptable.
         if Preferences.firstLaunchAt == nil {

--- a/Sources/Pelmet/AppVersionInfo.swift
+++ b/Sources/Pelmet/AppVersionInfo.swift
@@ -32,6 +32,7 @@ enum AppLinks {
     static let repo = URL(string: "https://github.com/ismatBabirli/pelmet")!
     static let changelog = URL(string: "https://github.com/ismatBabirli/pelmet/blob/main/CHANGELOG.md")!
     static let issues = URL(string: "https://github.com/ismatBabirli/pelmet/issues/new")!
+    static let support = URL(string: "https://buy.polar.sh/polar_cl_dmIB7LsoFtTdEnqBk5PBbK5OgB2v5Nw4Udw5d13Pi99")!
     /// Full field-by-field telemetry disclosure. Linked from the first-run
     /// notice and the Settings Privacy section.
     static let telemetryDoc = URL(string: "https://github.com/ismatBabirli/pelmet/blob/main/docs/TELEMETRY.md")!

--- a/Sources/Pelmet/MenuBarManager.swift
+++ b/Sources/Pelmet/MenuBarManager.swift
@@ -560,10 +560,12 @@ final class MenuBarManager: NSObject {
         if plan.attemptOneClickOffer {
             OnboardingController.shared.maybeOfferOneClick(toggle: toggleItem)
         }
-        // Last in the serialized chain: the star nudge is layout-independent and
-        // self-gates on its policy, so it only appears days into real use and
-        // never covers a tip or the release-notes window.
+        // Last in the serialized chain: the community nudges are
+        // layout-independent and self-gate on their policies, so they only
+        // appear after real use and never cover a tip or release notes. The
+        // support nudge also waits for the star nudge to finish and cools down.
         StarNudgeWindowController.shared.maybePresent()
+        SupportNudgeWindowController.shared.maybePresent()
     }
 
     /// The toggle is the escape hatch — if it ever gets swallowed the user
@@ -871,6 +873,14 @@ final class MenuBarManager: NSObject {
             menu.addItem(updatesEntry)
         }
 
+        let supportEntry = NSMenuItem(
+            title: "Support Pelmet…",
+            action: #selector(openSupport),
+            keyEquivalent: ""
+        )
+        supportEntry.target = self
+        menu.addItem(supportEntry)
+
         let settingsEntry = NSMenuItem(title: "Settings…", action: #selector(openSettings), keyEquivalent: ",")
         settingsEntry.target = self
         menu.addItem(settingsEntry)
@@ -967,6 +977,10 @@ final class MenuBarManager: NSObject {
 
     @objc private func openSettings() {
         SettingsWindowController.shared.show()
+    }
+
+    @objc private func openSupport() {
+        NSWorkspace.shared.open(AppLinks.support)
     }
 
     @objc private func openMakeRoom() {

--- a/Sources/Pelmet/Preferences.swift
+++ b/Sources/Pelmet/Preferences.swift
@@ -38,6 +38,9 @@ enum Preferences {
         static let starNudgeLastShownAt = "starNudgeLastShownAt"
         static let starNudgeShowCount = "starNudgeShowCount"
         static let starNudgeDismissed = "starNudgeDismissed"
+        static let supportNudgeLastShownAt = "supportNudgeLastShownAt"
+        static let supportNudgeShowCount = "supportNudgeShowCount"
+        static let supportNudgeDismissed = "supportNudgeDismissed"
         static let menuBarProfiles = "menuBarProfiles"
         static let activeProfileID = "activeProfileID"
         static let defaultProfileID = "defaultProfileID"
@@ -285,11 +288,11 @@ enum Preferences {
         set { UserDefaults.standard.set(newValue, forKey: Keys.lastAcknowledgedWhatsNewVersion) }
     }
 
-    // MARK: - Star-on-GitHub nudge
+    // MARK: - Community nudges
 
     /// When the app first launched, seeded once at startup. Anchors the "after
-    /// some time" delay before the star nudge may appear. A usage fact, not an
-    /// onboarding tip, so `resetOnboardingFlags()` leaves it be.
+    /// some time" delay before the community nudges may appear. A usage fact,
+    /// not an onboarding tip, so `resetOnboardingFlags()` leaves it be.
     static var firstLaunchAt: Date? {
         get { UserDefaults.standard.object(forKey: Keys.firstLaunchAt) as? Date }
         set { UserDefaults.standard.set(newValue, forKey: Keys.firstLaunchAt) }
@@ -313,6 +316,24 @@ enum Preferences {
     static var starNudgeDismissed: Bool {
         get { UserDefaults.standard.bool(forKey: Keys.starNudgeDismissed) }
         set { UserDefaults.standard.set(newValue, forKey: Keys.starNudgeDismissed) }
+    }
+
+    /// When the support nudge was last shown; nil until the first show.
+    static var supportNudgeLastShownAt: Date? {
+        get { UserDefaults.standard.object(forKey: Keys.supportNudgeLastShownAt) as? Date }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.supportNudgeLastShownAt) }
+    }
+
+    /// How many times the support nudge has been shown, for the hard cap.
+    static var supportNudgeShowCount: Int {
+        get { UserDefaults.standard.integer(forKey: Keys.supportNudgeShowCount) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.supportNudgeShowCount) }
+    }
+
+    /// Set once the user supports Pelmet, opts out, or the show cap is reached.
+    static var supportNudgeDismissed: Bool {
+        get { UserDefaults.standard.bool(forKey: Keys.supportNudgeDismissed) }
+        set { UserDefaults.standard.set(newValue, forKey: Keys.supportNudgeDismissed) }
     }
 
     /// Must be sampled before menu setup writes status-item positions. A real

--- a/Sources/Pelmet/Settings/AboutPaneView.swift
+++ b/Sources/Pelmet/Settings/AboutPaneView.swift
@@ -47,7 +47,7 @@ struct AboutPaneView: View {
 
             // Uniform, System-Settings-style rows: a tinted glyph, a title, and
             // a trailing hint (an up-right arrow leaves for the browser, a
-            // chevron opens an in-app window). One GitHub link, not two.
+            // chevron opens an in-app window).
             Section {
                 AboutRow(
                     title: "Star on GitHub",
@@ -56,6 +56,14 @@ struct AboutPaneView: View {
                     tint: .yellow,
                     opensExternally: true
                 ) { openURL(AppLinks.repo) }
+
+                AboutRow(
+                    title: "Support Pelmet",
+                    subtitle: "Help keep Pelmet free and open source.",
+                    systemImage: "heart.fill",
+                    tint: .pink,
+                    opensExternally: true
+                ) { openURL(AppLinks.support) }
 
                 AboutRow(title: "What's New", systemImage: "sparkles", tint: .accentColor) {
                     WhatsNewWindowController.shared.showManually()

--- a/Sources/Pelmet/SupportNudge/SupportNudgeView.swift
+++ b/Sources/Pelmet/SupportNudge/SupportNudgeView.swift
@@ -1,0 +1,49 @@
+import SwiftUI
+
+/// The support nudge card. It keeps the same lightweight, dismissible shape as
+/// the star prompt while making the financial ask explicit and optional.
+struct SupportNudgeView: View {
+
+    let onSupport: () -> Void
+    let onLater: () -> Void
+    let onDontAsk: () -> Void
+
+    var body: some View {
+        VStack(spacing: 14) {
+            Image(nsImage: NSApp.applicationIconImage)
+                .resizable()
+                .frame(width: 56, height: 56)
+
+            Text("Keep Pelmet free")
+                .font(.title3.bold())
+
+            Text("Pelmet is free and open source. If it helps keep your menu bar tidy, "
+                + "a one-time or monthly contribution helps fund maintenance, macOS "
+                + "compatibility work, and new features.")
+                .font(.callout)
+                .multilineTextAlignment(.center)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            VStack(spacing: 8) {
+                Button(action: onSupport) {
+                    Text("Support Pelmet")
+                        .frame(maxWidth: .infinity)
+                }
+                .keyboardShortcut(.defaultAction)
+
+                Button("Maybe Later", action: onLater)
+                    .keyboardShortcut(.cancelAction)
+                    .buttonStyle(.plain)
+                    .foregroundStyle(.secondary)
+
+                Button("Don't ask again", action: onDontAsk)
+                    .buttonStyle(.plain)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .padding(24)
+        .frame(width: 360)
+    }
+}

--- a/Sources/Pelmet/SupportNudge/SupportNudgeWindowController.swift
+++ b/Sources/Pelmet/SupportNudge/SupportNudgeWindowController.swift
@@ -2,11 +2,12 @@ import AppKit
 import PelmetCore
 import SwiftUI
 
-/// Owns Pelmet's single, reusable "star us on GitHub" nudge window and the gate
-/// that keeps it timed, rate-limited, and never stacked on another surface.
-final class StarNudgeWindowController: NSWindowController, NSWindowDelegate {
+/// Owns Pelmet's single, reusable support nudge window and its gentle gate.
+/// The nudge only follows a completed star ask, so the two requests never
+/// appear together or back-to-back for a new user.
+final class SupportNudgeWindowController: NSWindowController, NSWindowDelegate {
 
-    static let shared = StarNudgeWindowController()
+    static let shared = SupportNudgeWindowController()
 
     private var isTrackedAsOpen = false
     private var hasCenteredWindow = false
@@ -15,33 +16,34 @@ final class StarNudgeWindowController: NSWindowController, NSWindowDelegate {
         self.init(window: nil)
     }
 
-    var isVisible: Bool { window?.isVisible == true }
-
     /// True when the QA override is set: shows the nudge immediately, bypassing
-    /// the time/usage gate, and without advancing the counters or the cap.
+    /// timing and usage gates without advancing the counters or cap.
     private var isForced: Bool {
-        ProcessInfo.processInfo.environment["PELMET_FORCE_STAR_NUDGE"] != nil
+        ProcessInfo.processInfo.environment["PELMET_FORCE_SUPPORT_NUDGE"] != nil
     }
 
-    /// The single entry point. Presents the nudge only when the policy allows it
-    /// (or the QA override is set) and no other launch surface is up. Safe to
-    /// call on every onboarding pass; it self-gates.
+    /// Presents the support nudge when its policy allows it and no other launch
+    /// surface is active. Safe to call on every onboarding pass.
     func maybePresent() {
         guard window?.isVisible != true else { return }
 
         if !isForced {
-            guard StarNudgePolicy.shouldShow(
+            guard SupportNudgePolicy.shouldShow(
                 firstLaunchAt: Preferences.firstLaunchAt,
                 hasManagedItems: Preferences.hasEverManagedItems,
-                dismissedPermanently: Preferences.starNudgeDismissed,
-                lastShownAt: Preferences.starNudgeLastShownAt,
-                showCount: Preferences.starNudgeShowCount,
+                starNudgeDismissed: Preferences.starNudgeDismissed,
+                starNudgeLastShownAt: Preferences.starNudgeLastShownAt,
+                dismissedPermanently: Preferences.supportNudgeDismissed,
+                lastShownAt: Preferences.supportNudgeLastShownAt,
+                showCount: Preferences.supportNudgeShowCount,
                 now: Date()
             ) else { return }
         }
 
-        // Never cover release notes, a crash alert, or an onboarding tip.
-        guard !WhatsNewWindowController.shared.isPendingOrVisible,
+        // Never cover the star prompt, release notes, a crash alert, or an
+        // onboarding tip. The star window re-runs this check after closing.
+        guard !StarNudgeWindowController.shared.isVisible,
+              !WhatsNewWindowController.shared.isPendingOrVisible,
               NSApp.modalWindow == nil,
               OnboardingController.shared.activeTipWindow == nil
         else { return }
@@ -53,8 +55,8 @@ final class StarNudgeWindowController: NSWindowController, NSWindowDelegate {
         configureWindowIfNeeded()
         guard let window else { return }
 
-        let hosting = NSHostingController(rootView: StarNudgeView(
-            onStar: { [weak self] in self?.handleStar() },
+        let hosting = NSHostingController(rootView: SupportNudgeView(
+            onSupport: { [weak self] in self?.handleSupport() },
             onLater: { [weak self] in self?.window?.performClose(nil) },
             onDontAsk: { [weak self] in self?.handleDontAsk() }
         ))
@@ -76,40 +78,37 @@ final class StarNudgeWindowController: NSWindowController, NSWindowDelegate {
             isTrackedAsOpen = true
             UIActivityTracker.shared.surfaceOpened()
         }
-        // The QA override never burns a real ask.
         if !isForced { recordShow() }
     }
 
-    /// Advances the rate-limit state once the nudge is actually on screen, then
-    /// retires it for good if this was the last allowed ask.
     private func recordShow() {
-        Preferences.starNudgeLastShownAt = Date()
-        Preferences.starNudgeShowCount += 1
-        if Preferences.starNudgeShowCount >= StarNudgePolicy.maxShows {
-            Preferences.starNudgeDismissed = true
+        Preferences.supportNudgeLastShownAt = Date()
+        Preferences.supportNudgeShowCount += 1
+        if Preferences.supportNudgeShowCount >= SupportNudgePolicy.maxShows {
+            Preferences.supportNudgeDismissed = true
         }
     }
 
-    private func handleStar() {
-        NSWorkspace.shared.open(AppLinks.repo)
-        Preferences.starNudgeDismissed = true
+    private func handleSupport() {
+        NSWorkspace.shared.open(AppLinks.support)
+        Preferences.supportNudgeDismissed = true
         window?.performClose(nil)
     }
 
     private func handleDontAsk() {
-        Preferences.starNudgeDismissed = true
+        Preferences.supportNudgeDismissed = true
         window?.performClose(nil)
     }
 
     private func configureWindowIfNeeded() {
         guard window == nil else { return }
-        let window = StarNudgeWindow(
-            contentRect: NSRect(x: 0, y: 0, width: 360, height: 240),
+        let window = SupportNudgeWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 360, height: 260),
             styleMask: [.titled, .closable],
             backing: .buffered,
             defer: false
         )
-        window.title = "Enjoying Pelmet?"
+        window.title = "Support Pelmet"
         window.isReleasedWhenClosed = false
         window.collectionBehavior = [.moveToActiveSpace]
         window.delegate = self
@@ -128,9 +127,9 @@ final class StarNudgeWindowController: NSWindowController, NSWindowDelegate {
     }
 }
 
-/// Escape closes the nudge (treated as "maybe later") without needing a hidden
-/// SwiftUI button just to own the cancel shortcut.
-private final class StarNudgeWindow: NSWindow {
+/// Escape closes the support nudge (treated as "maybe later") without needing
+/// a hidden SwiftUI button just to own the cancel shortcut.
+private final class SupportNudgeWindow: NSWindow {
     override func cancelOperation(_ sender: Any?) {
         performClose(sender)
     }

--- a/Sources/PelmetCore/SupportNudge.swift
+++ b/Sources/PelmetCore/SupportNudge.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+/// Pure policy for the "support Pelmet" nudge. It follows the star nudge so
+/// users are not asked for two things at once, then uses a longer reminder
+/// interval and a lower cap because financial asks should stay occasional.
+public enum SupportNudgePolicy {
+
+    /// The app must have had time to provide value before asking for support.
+    public static let initialDelay: TimeInterval = 3 * 24 * 3600
+
+    /// Breathing room after the star nudge reaches a permanent outcome.
+    public static let graceAfterStarNudge: TimeInterval = 7 * 24 * 3600
+
+    /// Minimum time between support reminders.
+    public static let reminderInterval: TimeInterval = 30 * 24 * 3600
+
+    /// Hard cap on how many times the support nudge is ever shown.
+    public static let maxShows = 2
+
+    /// Decides whether the support nudge may be shown right now.
+    public static func shouldShow(
+        firstLaunchAt: Date?,
+        hasManagedItems: Bool,
+        starNudgeDismissed: Bool,
+        starNudgeLastShownAt: Date?,
+        dismissedPermanently: Bool,
+        lastShownAt: Date?,
+        showCount: Int,
+        now: Date
+    ) -> Bool {
+        guard !dismissedPermanently,
+              hasManagedItems,
+              let firstLaunchAt,
+              starNudgeDismissed,
+              let starNudgeLastShownAt,
+              showCount < maxShows,
+              now.timeIntervalSince(starNudgeLastShownAt) >= graceAfterStarNudge
+        else { return false }
+
+        if showCount == 0 {
+            return now.timeIntervalSince(firstLaunchAt) >= initialDelay
+        }
+
+        guard let lastShownAt else { return false }
+        return now.timeIntervalSince(lastShownAt) >= reminderInterval
+    }
+}

--- a/Tests/PelmetCoreTests/SupportNudgePolicyTests.swift
+++ b/Tests/PelmetCoreTests/SupportNudgePolicyTests.swift
@@ -1,0 +1,118 @@
+import Foundation
+import Testing
+@testable import PelmetCore
+
+struct SupportNudgePolicyTests {
+
+    private let base = Date(timeIntervalSince1970: 1_700_000_000)
+
+    @Test func notShownUntilStarNudgeHasFinishedAndGracePeriodElapses() {
+        let now = base.addingTimeInterval(SupportNudgePolicy.initialDelay * 10)
+
+        #expect(SupportNudgePolicy.shouldShow(
+            firstLaunchAt: base,
+            hasManagedItems: true,
+            starNudgeDismissed: false,
+            starNudgeLastShownAt: base,
+            dismissedPermanently: false,
+            lastShownAt: nil,
+            showCount: 0,
+            now: now
+        ) == false)
+
+        let afterStarGrace = base.addingTimeInterval(SupportNudgePolicy.graceAfterStarNudge)
+        #expect(SupportNudgePolicy.shouldShow(
+            firstLaunchAt: base,
+            hasManagedItems: true,
+            starNudgeDismissed: true,
+            starNudgeLastShownAt: base,
+            dismissedPermanently: false,
+            lastShownAt: nil,
+            showCount: 0,
+            now: afterStarGrace
+        ))
+    }
+
+    @Test func notShownWithoutEngagement() {
+        let now = base.addingTimeInterval(SupportNudgePolicy.initialDelay * 10)
+        #expect(SupportNudgePolicy.shouldShow(
+            firstLaunchAt: base,
+            hasManagedItems: false,
+            starNudgeDismissed: true,
+            starNudgeLastShownAt: base,
+            dismissedPermanently: false,
+            lastShownAt: nil,
+            showCount: 0,
+            now: now
+        ) == false)
+    }
+
+    @Test func notShownWhenStarTimestampIsMissing() {
+        let now = base.addingTimeInterval(SupportNudgePolicy.initialDelay * 10)
+        #expect(SupportNudgePolicy.shouldShow(
+            firstLaunchAt: base,
+            hasManagedItems: true,
+            starNudgeDismissed: true,
+            starNudgeLastShownAt: nil,
+            dismissedPermanently: false,
+            lastShownAt: nil,
+            showCount: 0,
+            now: now
+        ) == false)
+    }
+
+    @Test func remindersWaitThirtyDays() {
+        let starFinishedAt = base.addingTimeInterval(SupportNudgePolicy.graceAfterStarNudge)
+        let shownAt = starFinishedAt.addingTimeInterval(SupportNudgePolicy.initialDelay)
+        let tooSoon = shownAt.addingTimeInterval(SupportNudgePolicy.reminderInterval - 1)
+
+        #expect(SupportNudgePolicy.shouldShow(
+            firstLaunchAt: base,
+            hasManagedItems: true,
+            starNudgeDismissed: true,
+            starNudgeLastShownAt: base,
+            dismissedPermanently: false,
+            lastShownAt: shownAt,
+            showCount: 1,
+            now: tooSoon
+        ) == false)
+
+        let due = shownAt.addingTimeInterval(SupportNudgePolicy.reminderInterval)
+        #expect(SupportNudgePolicy.shouldShow(
+            firstLaunchAt: base,
+            hasManagedItems: true,
+            starNudgeDismissed: true,
+            starNudgeLastShownAt: base,
+            dismissedPermanently: false,
+            lastShownAt: shownAt,
+            showCount: 1,
+            now: due
+        ))
+    }
+
+    @Test func notShownOnceCapReachedOrDismissed() {
+        let now = base.addingTimeInterval(SupportNudgePolicy.reminderInterval * 100)
+
+        #expect(SupportNudgePolicy.shouldShow(
+            firstLaunchAt: base,
+            hasManagedItems: true,
+            starNudgeDismissed: true,
+            starNudgeLastShownAt: base,
+            dismissedPermanently: false,
+            lastShownAt: base,
+            showCount: SupportNudgePolicy.maxShows,
+            now: now
+        ) == false)
+
+        #expect(SupportNudgePolicy.shouldShow(
+            firstLaunchAt: base,
+            hasManagedItems: true,
+            starNudgeDismissed: true,
+            starNudgeLastShownAt: base,
+            dismissedPermanently: true,
+            lastShownAt: nil,
+            showCount: 0,
+            now: now
+        ) == false)
+    }
+}


### PR DESCRIPTION
## Summary

- add a direct Support Pelmet action to the chevron menu and retain the About-pane link
- add a separate rate-limited Polar support prompt after the GitHub star prompt
- add deterministic support-nudge policy tests and document the v0.6.0 release

The support flow uses hosted Polar checkout only; no Polar SDK, credentials, or backend webhook is needed.

## Release

This is the next minor release, `v0.6.0`. The changelog includes the exact version heading required by the tag-driven release workflow.

## Validation

- `swift test` — 196 tests passed
- `CHANGELOG.md` v0.6.0 heading validation passed
- `git diff --check` passed
