### PR TITLE
docs: reference the website and add the cross-repo sync rule

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,68 @@
+<!-- Keep this file lean: pointers and rules, not prose. `CLAUDE.md` covers the
+     codebase itself (architecture, commands, gotchas, product invariants). This
+     file covers work that crosses repository boundaries. -->
+
+# Agent guide
+
+## Companion repository: the website
+
+Pelmet's marketing and documentation site lives in a separate repository.
+
+- Repo: `ismatBabirli/pelmet.xyz` (private)
+- Live: https://pelmet.xyz
+- Next.js, fully prerendered, self-hosted on Coolify. It redeploys itself on
+  every merge to its `main`, so there is no manual publish step.
+
+The site restates facts this repository owns: the current version, the
+changelog, the feature list, the permission model, the telemetry schema, the
+install commands, and the minimum macOS version. When those change here and not
+there, the site starts telling users and search engines something untrue.
+
+## Rule: every change here is also a website question
+
+Before opening a PR in this repo, check the table. If a row applies, the site
+needs a matching change and the two PRs ship together.
+
+| Change here | What to update on the site |
+|---|---|
+| New release tagged `vX.Y.Z` | Usually nothing by hand: `lib/github.ts` reads the GitHub API hourly. Refresh its pinned `FALLBACK` release when it drifts more than a release or two behind. |
+| `CHANGELOG.md` entry | `content/changelog.ts`. Transcribed by hand on purpose: release notes are prose that ships to an indexed page. |
+| Feature added, changed, or removed | `content/comparisons.ts` rows, `app/features/*`, the "Not yet" list on `/features`, and `featureList` in `lib/schema.ts` |
+| Permission model changes | `/privacy`, `/features/one-click`, `content/faq.ts`, and every "Works without ... permission" row in `content/comparisons.ts` |
+| `docs/TELEMETRY.md` schema change | The field table in `app/privacy/page.tsx`, which mirrors that doc field for field |
+| Minimum macOS version | `minMacOS` in `lib/site.ts`, which feeds both the pages and the structured data |
+| Install command or distribution change | `brewCommand` in `lib/site.ts`, and `/download` |
+| A roadmap item ships | The "Not yet" section of `/features`, plus any `content/comparisons.ts` row that currently says a rival has it and Pelmet does not |
+| A claim about a competitor goes stale | `content/comparisons.ts`. Only claims checkable against that project's own docs, site, or repository. No invented benchmarks. |
+
+If nothing applies, say so in one line in the PR description, so a reviewer can
+tell it was considered rather than forgotten.
+
+## Rule: cross-linked PRs, merged together
+
+1. Branch and open the PR here as usual.
+2. Branch `pelmet.xyz` and open the matching PR there.
+3. Link them in both directions. Add a line to each PR description:
+   `Pairs with ismatBabirli/pelmet.xyz#<n>` and, on the site PR,
+   `Pairs with ismatBabirli/pelmet#<n>`.
+4. Merge this repo's PR first, then the site's, so the site never documents a
+   feature that is not yet on `main`. For a release, merge the site PR straight
+   after the tag is pushed, so the changelog page is not left behind.
+5. Do not merge only one of the pair. A half-merged pair is exactly the state
+   this rule exists to prevent.
+
+## Working in the site repo
+
+Read its `README.md` first. Two things that catch people out:
+
+- Every page must set `alternates.canonical`, carry exactly one `<h1>`, and be
+  reachable from a hub page. `pnpm build` must show every route as static.
+- `/llms.txt` and `/llms-full.txt` are generated from the same content modules
+  as the pages, so editing content keeps them in sync automatically. Do not
+  hand-edit their output.
+
+## House style
+
+The rules in `CLAUDE.md` section "Etiquette" apply to every repo touched on
+Pelmet's behalf, including the site: no AI attribution in commits or PRs, and
+no em-dashes in prose you add.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,6 +59,13 @@ SwiftUI settings windows. Sandbox is intentionally OFF, hardened runtime ON, and
   reports stay local: Pelmet only opens a prefilled GitHub issue the user submits.
 - Rationale and full list: `PROJECT.md` § "5. Non-Goals" and § "6. Technical Foundation".
 
+## Cross-repo
+
+- The website (`ismatBabirli/pelmet.xyz`, live at https://pelmet.xyz) restates the
+  version, changelog, features, permission model and telemetry schema this repo
+  owns. Changing any of those here usually needs a paired site PR: read
+  `AGENTS.md` for the trigger table and the cross-linking rule.
+
 ## Etiquette
 
 - User-visible changes get a `CHANGELOG.md` entry under `[Unreleased]` (Keep a Changelog).

--- a/README.md
+++ b/README.md
@@ -14,9 +14,12 @@ This one hides your menu bar clutter, so nothing disappears behind the MacBook n
 ![macOS 13+](https://img.shields.io/badge/macOS-13%2B-black?logo=apple)
 ![Swift 6](https://img.shields.io/badge/Swift-6-F05138?logo=swift&logoColor=white)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue)](LICENSE)
+[![Website](https://img.shields.io/badge/website-pelmet.xyz-C8A272)](https://pelmet.xyz)
 
 <img src="Resources/pelmet-shelf.png" width="450"
      alt="Pelmet showing +4 beside its chevron and a frosted Shelf listing Screen Studio, ChatGPT, Docker Desktop, and Wispr Flow as four menu bar items hidden by the MacBook notch.">
+
+**[pelmet.xyz](https://pelmet.xyz)** &nbsp;·&nbsp; [Download](https://pelmet.xyz/download) &nbsp;·&nbsp; [Guides](https://pelmet.xyz/guides) &nbsp;·&nbsp; [FAQ](https://pelmet.xyz/faq)
 
 </div>
 


### PR DESCRIPTION
Pairs with ismatBabirli/pelmet.xyz#1. Merge this one first, then that one.

## What & why

The marketing and documentation site is now live at [pelmet.xyz](https://pelmet.xyz), in the separate `ismatBabirli/pelmet.xyz` repository. That site restates facts this repo owns: the current version, the changelog, the feature list, the permission model, the telemetry schema, the install commands and the minimum macOS version. Nothing currently stops the two drifting apart, and a stale site tells users and search engines something untrue.

Three changes:

- **README**: a website badge, and a link row under the screenshot pointing at the site, Download, Guides and FAQ.
- **AGENTS.md** (new): a trigger table mapping "this changed here" to "update these files on the site", plus the rule that the paired PRs are cross-linked and merged together, app first. Kept out of `CLAUDE.md` so that file stays lean, as its header asks.
- **CLAUDE.md**: a short pointer to the new rule under a `## Cross-repo` heading.

Docs only. No source, build or packaging changes.

## How I tested it

Verified every link in the added README row returns 200 on the live site (`/`, `/download`, `/guides`, `/faq`), and checked the diff adds no em-dashes, per the house style in `CLAUDE.md`.