### PR TITLE
chore(packaging): point the cask homepage at pelmet.xyz

### DIFF
--- a/packaging/homebrew/pelmet.rb
+++ b/packaging/homebrew/pelmet.rb
@@ -14,7 +14,7 @@ cask "pelmet" do
       verified: "github.com/ismatBabirli/pelmet/"
   name "Pelmet"
   desc "Menu bar organizer that reclaims the icons a MacBook notch hides"
-  homepage "https://github.com/ismatBabirli/pelmet"
+  homepage "https://pelmet.xyz/"
 
   livecheck do
     url :url


### PR DESCRIPTION
Pairs with ismatBabirli/homebrew-pelmet#1. Merge this one first.

## What & why

`homepage` in the cask is what `brew info pelmet` prints and what Homebrew links from the generated formula page. It currently points at the source repository; it should point at the product site now that one exists.

`packaging/homebrew/pelmet.rb` is the canonical copy, seeded into the tap by `scripts/bootstrap-tap.sh`. The release workflow only rewrites `version` and `sha256` in the tap, so changing the tap alone would silently revert the next time the bootstrap script ran. Both are changed, in paired PRs.

The `verified:` stanza stays as is and is still required: the download host (`github.com`) no longer matches the homepage host, which is precisely the case that stanza covers.

No website change needed. The site quotes the `brew install` command, which is unchanged, and never surfaces the cask homepage.

## How I tested it

`ruby -c` parses clean, and `brew style` reports the same 4 pre-existing, autocorrectable offences before and after the change (Sorbet sigils and a frozen-string-literal comment, which are artefacts of linting a cask outside a tap, plus an unrelated `zap trash:` ordering nit). No new offences introduced.