### PR TITLE
feat: support software-drawn menu bar islands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Detect permission-free top-center software-island candidates from local window
+  geometry. Vibe Island works automatically through the built-in compatibility
+  registry; unknown apps stay disabled until enabled and calibrated in Menu Bar
+  Space settings.
+- Model a stable resting width for software-island detection so transient
+  hover expansion does not make the covered-icon count jump. Calibration
+  changes reclassify icons live while the Settings slider moves.
+
+### Changed
+
+- The hidden-icon count, Shelf, one-click access, and make-room guidance now work
+  for both physical camera notches and enabled software islands.
+- Software-island app identities and bundle identifiers remain local and are not
+  added to anonymous telemetry.
+
+### Fixed
+
+- Enabling a software island no longer triggers Pelmet's physical-notch control
+  rescue path, which could repack menu items and move a neighboring icon under
+  the island.
+- Covered-icon and update badges now render inside Pelmet's fixed-width toggle,
+  so appearing or disappearing badge text cannot shift neighboring menu items.
+- Software-island launch and quit events now update Settings even when the
+  covered-icon count itself does not change, such as while Pelmet is collapsed.
+- One-Click Access remains available in Settings while enabled after its island
+  app quits, preserving the in-app path to turn the feature off.
+- Software-island discovery now retains every detected display for an app and
+  scans Window Server only once per layout measurement.
+
 ## [0.7.0] - 2026-08-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This one hides your menu bar clutter, so nothing disappears behind the MacBook n
 
 > [!NOTE]
 > **Status: shipping.** Hide/show works with zero special permissions, and the
-> notch-aware Shelf panel, opt-in one-click access, and opt-in show-on-hover
+> notch-aware Shelf panel, software-island support, opt-in one-click access, and opt-in show-on-hover
 > have shipped. One-click access uses advertised macOS Accessibility actions
 > only and never creates mouse events or moves the pointer.
 
@@ -35,9 +35,15 @@ On notched MacBooks, macOS silently hides menu bar items that don't fit next to
 the camera housing — no overflow indicator, the icons are just *gone*. Pelmet
 gives you back control: park rarely-used icons behind a divider and summon them
 when you need them. And when icons *still* don't fit, Pelmet is the only tool
-that tells you — a small **+3** appears next to its chevron, with tips one
+that tells you: a small **+3** appears above its chevron, with tips one
 right-click away. No other utility detects this, and Pelmet does it with zero
 permissions.
+
+Pelmet also recognizes software-drawn islands on displays without a physical
+notch. Vibe Island has a built-in compatibility profile. Other persistent,
+top-center accessory windows are detected locally and can be enabled and
+calibrated in Settings. Pelmet models the resting width for coverage detection,
+so hover expansion does not make the covered-icon count jump.
 
 ## How it works — no private APIs, no permissions
 
@@ -57,9 +63,10 @@ Pelmet places two items in your menu bar:
 - This is the same battle-tested technique used by Hidden Bar and Dozer. It
   needs **no** Screen Recording or Accessibility permission.
 - If the expanded icons don't all fit beside the notch, the toggle shows a
-  count (e.g. **› +3**) instead of letting them vanish without a trace.
+  compact count above its chevron instead of letting them vanish without a trace.
   Right-click it for ways to make room. Detection uses only public
-  window-geometry metadata — nothing that prompts for permissions or lights
+  window-geometry metadata. Software-island detection uses the same public
+  metadata, with unknown apps disabled until you opt in. Nothing prompts for permissions or lights
   the screen-recording indicator.
 
 ## Privacy
@@ -75,7 +82,7 @@ SDKs. It makes two kinds of network calls, both under your control:
 - **Anonymous usage ping**: one tiny event per day (app version, macOS version,
   chip type, which Pelmet features are on) so we know how many people use Pelmet
   and what to prioritize. No personal data, no menu bar contents, never anything
-  about the other apps you run; IP addresses are discarded on arrival. An in-app
+  about the other apps you run, including software-island candidates; IP addresses are discarded on arrival. An in-app
   notice appears before the first ping is ever sent. Turn it off in Settings,
   with `defaults write com.ismatbabirli.Pelmet telemetryEnabled -bool NO`, or
   with `DO_NOT_TRACK=1`.

--- a/Sources/Pelmet/Activation/StatusItemActivationEngine.swift
+++ b/Sources/Pelmet/Activation/StatusItemActivationEngine.swift
@@ -94,7 +94,7 @@ final class StatusItemActivationEngine: StatusItemActivating {
     var activatableDescriptors: [EngineItemDescriptor] {
         guard canActivate else { return [] }
         return directory.records
-            .filter { $0.visibility == .swallowedByNotch }
+            .filter { $0.visibility.isObstructed }
             .map { record in
                 EngineItemDescriptor(
                     token: record.id,
@@ -445,7 +445,7 @@ final class StatusItemActivationEngine: StatusItemActivating {
         // failure ("Hidden item N", no logo). When it's a transient (element
         // positions read mid-animation), a re-read moments later fixes it.
         let unidentifiedSwallowed = records.contains {
-            $0.visibility == .swallowedByNotch && $0.identity == nil
+            $0.visibility.isObstructed && $0.identity == nil
         }
         if canActivate, unidentifiedSwallowed,
            !axCache.isEmpty, healAttempts < 2 {

--- a/Sources/Pelmet/LayoutStatus.swift
+++ b/Sources/Pelmet/LayoutStatus.swift
@@ -10,20 +10,43 @@ final class LayoutStatus: ObservableObject {
 
     @Published var swallowedCount = 0
     @Published var hasNotchedDisplay: Bool
+    @Published var hasMenuBarObstruction: Bool
     @Published var spacingProfile: MenuBarSpacing.Profile
     /// One row per icon the notch hid — same source of truth as
     /// `swallowedCount` (badge parity).
     @Published var shelfEntries: [ShelfEntryModel] = []
+    private var softwareIslandObservation: AnyCancellable?
 
     private init() {
-        hasNotchedDisplay = NSScreen.screens.contains { $0.safeAreaInsets.top > 0 }
+        let softwareIslands = SoftwareIslandMonitor.shared
+        softwareIslands.refresh()
+        let hasPhysicalNotch = NSScreen.screens.contains { $0.safeAreaInsets.top > 0 }
+        hasNotchedDisplay = hasPhysicalNotch
+        hasMenuBarObstruction = hasPhysicalNotch
+            || softwareIslands.hasEnabledCandidate
         spacingProfile = MenuBarSpacing.currentProfile()
+
+        // Candidate lifecycle is independent of the layout digest. In
+        // particular, launching or quitting an island while Pelmet is
+        // collapsed can leave the icon count unchanged, so observe discovery
+        // directly instead of waiting for MenuBarManager.apply().
+        softwareIslandObservation = softwareIslands.$candidates
+            .map { candidates in
+                NSScreen.screens.contains { $0.safeAreaInsets.top > 0 }
+                    || candidates.contains(where: \.enabled)
+            }
+            .removeDuplicates()
+            .sink { [weak self] hasObstruction in
+                self?.hasMenuBarObstruction = hasObstruction
+            }
     }
 
     func refresh(swallowedCount: Int, shelfEntries: [ShelfEntryModel]) {
         self.swallowedCount = swallowedCount
         self.shelfEntries = shelfEntries
         hasNotchedDisplay = NSScreen.screens.contains { $0.safeAreaInsets.top > 0 }
+        hasMenuBarObstruction = hasNotchedDisplay
+            || SoftwareIslandMonitor.shared.hasEnabledCandidate
     }
 
     func refreshSpacing() {

--- a/Sources/Pelmet/MakeRoom/MakeRoomWindowController.swift
+++ b/Sources/Pelmet/MakeRoom/MakeRoomWindowController.swift
@@ -2,7 +2,7 @@ import AppKit
 import SwiftUI
 
 /// The remedies hub: everything a user can actually do about a menu bar
-/// that doesn't fit beside the notch. Non-modal, reachable from the
+/// that doesn't fit around an obstruction. Non-modal, reachable from the
 /// right-click menu, the count education popover's advice, and Settings.
 final class MakeRoomWindowController: NSWindowController, NSWindowDelegate {
 
@@ -47,8 +47,8 @@ struct MakeRoomView: View {
             if status.swallowedCount > 0 {
                 Label(
                     status.swallowedCount == 1
-                        ? "1 icon doesn't fit beside the notch right now."
-                        : "\(status.swallowedCount) icons don't fit beside the notch right now.",
+                        ? "1 icon is covered in the menu bar right now."
+                        : "\(status.swallowedCount) icons are covered in the menu bar right now.",
                     systemImage: "info.circle"
                 )
                 .font(.callout)
@@ -66,7 +66,7 @@ struct MakeRoomView: View {
                 symbol: "arrow.left.and.right",
                 title: "Tighten icon spacing",
                 text: "macOS spaces menu bar icons generously. Reducing the spacing fits more icons "
-                    + "beside the notch. No permissions involved; the change takes effect the next "
+                    + "around the notch or software island. No permissions involved; the change takes effect the next "
                     + "time you log in."
             ) {
                 VStack(alignment: .leading, spacing: 6) {

--- a/Sources/Pelmet/MenuBarManager.swift
+++ b/Sources/Pelmet/MenuBarManager.swift
@@ -25,6 +25,12 @@ final class MenuBarManager: NSObject {
     // MARK: - Configuration
 
     private let expandedSeparatorLength: CGFloat = 10
+    /// The toggle never changes width when a covered-icon or update badge
+    /// appears. A variable-length title repacks every item to its left, which
+    /// can itself move an otherwise safe icon underneath a software island.
+    // AppKit adds 16 pt of status-item chrome, so a 10 pt content length
+    // preserves the original 26 pt window footprint.
+    private let toggleItemLength: CGFloat = 10
 
     /// Collapse works by inflating the separator so items left of it are
     /// pushed past the screen edge. Bounded because huge lengths misbehave:
@@ -73,9 +79,7 @@ final class MenuBarManager: NSObject {
     func setUp() {
         seedFirstLaunchPositionsIfNeeded()
 
-        // variableLength so the "+N" overflow count fits next to the chevron;
-        // with an empty title the width matches the old square item.
-        toggleItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
+        toggleItem = NSStatusBar.system.statusItem(withLength: toggleItemLength)
         toggleItem.autosaveName = toggleAutosaveName
         toggleItem.behavior = []
         // Assigning autosaveName adopts persisted state, so un-hide AFTER it —
@@ -473,7 +477,7 @@ final class MenuBarManager: NSObject {
         toggleItem = StatusItemRescuer.recreate(
             toggleItem,
             autosaveName: toggleAutosaveName,
-            length: NSStatusItem.variableLength,
+            length: toggleItemLength,
             preferredPosition: 0,
             configure: { [weak self] item in self?.configureToggleButton(item) }
         )
@@ -548,25 +552,19 @@ final class MenuBarManager: NSObject {
         guard let button = toggleItem.button else { return }
 
         let symbol = isCollapsed ? "chevron.left" : "chevron.right"
-        button.image = NSImage(
-            systemSymbolName: symbol,
-            accessibilityDescription: isCollapsed ? "Show hidden icons" : "Hide icons"
-        )
-
         let showCount = !isCollapsed && swallowedCount > 0 && Preferences.showSwallowedCount
         let updatePresentation = MenuBarUpdatePresentation(
             swallowedCount: swallowedCount,
             showsSwallowedCount: showCount,
             availableVersion: updateAvailableVersion
         )
-        if !updatePresentation.badgeText.isEmpty {
-            button.attributedTitle = NSAttributedString(
-                string: updatePresentation.badgeText,
-                attributes: [.font: NSFont.monospacedDigitSystemFont(ofSize: 12, weight: .medium)]
-            )
-        } else {
-            button.attributedTitle = NSAttributedString(string: "")
-        }
+        button.image = toggleImage(
+            symbolName: symbol,
+            badgeText: updatePresentation.compactBadgeText,
+            accessibilityDescription: isCollapsed ? "Show hidden icons" : "Hide icons"
+        )
+        button.imagePosition = .imageOnly
+        button.attributedTitle = NSAttributedString(string: "")
 
         var tooltip: String
         var accessibilityValue: String
@@ -575,17 +573,17 @@ final class MenuBarManager: NSObject {
             tooltip = "Pelmet: show hidden icons\(toggleHint)"
             accessibilityValue = "Icons hidden"
         } else if separatorSwallowed {
-            tooltip = "The menu bar is full. Pelmet's divider is hidden by the notch. Right-click for options."
+            tooltip = "The menu bar is full. Pelmet's divider is covered. Right-click for options."
             accessibilityValue = "Icons shown. The divider is hidden; the menu bar is full."
         } else if swallowedCount > 0 {
             // "Click to see them" only when a click actually opens the Shelf
             // — i.e. the badge is visible (showCount) and the Shelf is on.
             if showCount && Preferences.shelfEnabled {
-                tooltip = "\(countPhrase(swallowedCount)) by the notch. Click to see them; right-click for options."
-                accessibilityValue = "Icons shown. \(countPhrase(swallowedCount)) by the notch. Click to open the Shelf."
+                tooltip = "\(countPhrase(swallowedCount)). Click to see them; right-click for options."
+                accessibilityValue = "Icons shown. \(countPhrase(swallowedCount)). Click to open the Shelf."
             } else {
-                tooltip = "\(countPhrase(swallowedCount)) by the notch. Right-click for ways to make room."
-                accessibilityValue = "Icons shown. \(countPhrase(swallowedCount)) by the notch."
+                tooltip = "\(countPhrase(swallowedCount)). Right-click for ways to make room."
+                accessibilityValue = "Icons shown. \(countPhrase(swallowedCount))."
             }
         } else {
             tooltip = "Pelmet: hide icons\(toggleHint)"
@@ -601,10 +599,61 @@ final class MenuBarManager: NSObject {
         button.setAccessibilityValue(accessibilityValue)
     }
 
+    /// Draws the state chevron and a compact badge inside one fixed-width
+    /// template image. Putting badge text beside the chevron would widen the
+    /// item and alter the layout Pelmet is observing.
+    private func toggleImage(
+        symbolName: String,
+        badgeText: String,
+        accessibilityDescription: String
+    ) -> NSImage? {
+        guard !badgeText.isEmpty else {
+            return NSImage(
+                systemSymbolName: symbolName,
+                accessibilityDescription: accessibilityDescription
+            )
+        }
+
+        let imageSize = NSSize(width: 10, height: 18)
+        let image = NSImage(size: imageSize, flipped: false) { bounds in
+            let symbolRect = NSRect(x: 2, y: 0, width: 6, height: 8)
+            let configuration = NSImage.SymbolConfiguration(pointSize: 7, weight: .semibold)
+            NSImage(systemSymbolName: symbolName, accessibilityDescription: nil)?
+                .withSymbolConfiguration(configuration)?
+                .draw(in: symbolRect)
+
+            let badgeRect = NSRect(x: 0, y: 8, width: bounds.width, height: 10)
+            let measuringFont = NSFont.monospacedDigitSystemFont(ofSize: 7, weight: .medium)
+            let measuringAttributes: [NSAttributedString.Key: Any] = [.font: measuringFont]
+            let measuredWidth = (badgeText as NSString).size(
+                withAttributes: measuringAttributes
+            ).width
+            let scale = measuredWidth > 0 ? min(1, badgeRect.width / measuredWidth) : 1
+            let font = NSFont.monospacedDigitSystemFont(
+                ofSize: max(4, 7 * scale),
+                weight: .medium
+            )
+            let attributes: [NSAttributedString.Key: Any] = [
+                .font: font,
+                .foregroundColor: NSColor.labelColor,
+            ]
+            let textSize = (badgeText as NSString).size(withAttributes: attributes)
+            let point = NSPoint(
+                x: badgeRect.midX - textSize.width / 2,
+                y: badgeRect.midY - textSize.height / 2
+            )
+            (badgeText as NSString).draw(at: point, withAttributes: attributes)
+            return true
+        }
+        image.isTemplate = true
+        image.accessibilityDescription = accessibilityDescription
+        return image
+    }
+
     private func countPhrase(_ count: Int) -> String {
         count == 1
-            ? "1 icon doesn't fit and is hidden"
-            : "\(count) icons don't fit and are hidden"
+            ? "1 icon is covered and unavailable"
+            : "\(count) icons are covered and unavailable"
     }
 
     private func separatorImage() -> NSImage? {
@@ -626,7 +675,7 @@ final class MenuBarManager: NSObject {
             statusLines.append(
                 isCollapsed
                     ? "\(fitPhrase) even while collapsed"
-                    : "\(fitPhrase), hidden by the notch"
+                    : "\(fitPhrase), covered by the notch or a software island"
             )
         }
         if !statusLines.isEmpty {
@@ -699,7 +748,7 @@ final class MenuBarManager: NSObject {
         // A permanent path to enable one-click open — survives a dismissed or
         // never-seen onboarding popover. Only where it's relevant (notched Mac,
         // not yet granted).
-        if LayoutStatus.shared.hasNotchedDisplay, shelfEngine.availability != .granted {
+        if LayoutStatus.shared.hasMenuBarObstruction, shelfEngine.availability != .granted {
             let oneClickEntry = NSMenuItem(
                 title: "Open Hidden Icons with One Click…",
                 action: #selector(enableOneClickFromMenu),

--- a/Sources/Pelmet/NotchLayoutMonitor.swift
+++ b/Sources/Pelmet/NotchLayoutMonitor.swift
@@ -2,7 +2,7 @@ import AppKit
 import PelmetCore
 
 /// Watches menu bar layout and reports, with zero permissions, how many
-/// icons macOS is silently hiding at the notch — plus whether Pelmet's own
+/// icons are hidden by a physical notch or software island, plus whether Pelmet's own
 /// divider and toggle are visible.
 ///
 /// Event-driven only (no polling): measurements run after expand/collapse
@@ -63,10 +63,12 @@ final class NotchLayoutMonitor {
     private var candidate: MeasurementDigest?
     private var confirmedMeasurement: MeasurementDigest?
     private var deferredRetries = 0
+    private var hasPendingSoftwareIslandConfiguration = false
     private var observers: [NSObjectProtocol] = []
 
-    enum MeasurementReason {
-        case launch, expandSettled, collapseSettled, screenChanged, workspaceChanged, menuOpened, itemRecreated
+    enum MeasurementReason: Equatable {
+        case launch, expandSettled, collapseSettled, screenChanged, workspaceChanged
+        case menuOpened, itemRecreated, softwareIslandConfigurationChanged
 
         var settleDelay: TimeInterval {
             switch self {
@@ -75,6 +77,7 @@ final class NotchLayoutMonitor {
             case .screenChanged: return 1.0
             case .workspaceChanged: return 1.0
             case .menuOpened: return 0
+            case .softwareIslandConfigurationChanged: return 0.03
             case .itemRecreated: return 0.5
             }
         }
@@ -93,9 +96,17 @@ final class NotchLayoutMonitor {
         }
         observers = [
             observe(.default, NSApplication.didChangeScreenParametersNotification, .screenChanged),
+            observe(
+                .default,
+                .pelmetSoftwareIslandConfigurationDidChange,
+                .softwareIslandConfigurationChanged
+            ),
             observe(NSWorkspace.shared.notificationCenter, NSWorkspace.activeSpaceDidChangeNotification, .workspaceChanged),
             observe(NSWorkspace.shared.notificationCenter, NSWorkspace.didWakeNotification, .workspaceChanged),
+            observe(NSWorkspace.shared.notificationCenter, NSWorkspace.didLaunchApplicationNotification, .workspaceChanged),
             observe(NSWorkspace.shared.notificationCenter, NSWorkspace.didTerminateApplicationNotification, .workspaceChanged),
+            observe(NSWorkspace.shared.notificationCenter, NSWorkspace.didHideApplicationNotification, .workspaceChanged),
+            observe(NSWorkspace.shared.notificationCenter, NSWorkspace.didUnhideApplicationNotification, .workspaceChanged),
         ]
     }
 
@@ -110,22 +121,35 @@ final class NotchLayoutMonitor {
     // MARK: - Measurement
 
     func requestMeasurement(reason: MeasurementReason) {
+        if case .softwareIslandConfigurationChanged = reason {
+            // Slider and toggle changes are deterministic user input. They do
+            // not need the two-snapshot guard used for Window Server churn.
+            hasPendingSoftwareIslandConfiguration = true
+        }
         // Coalesce: the soonest requested measurement wins.
         let delay = reason.settleDelay
         if let pending = pendingMeasurement, pending.isValid,
            pending.fireDate.timeIntervalSinceNow < delay { return }
         pendingMeasurement?.invalidate()
         deferredRetries = 0
-        pendingMeasurement = Timer.scheduledTimer(withTimeInterval: max(delay, 0.01), repeats: false) { [weak self] _ in
+        let timer = Timer(timeInterval: max(delay, 0.01), repeats: false) { [weak self] _ in
             self?.measureNow()
         }
+        pendingMeasurement = timer
+        RunLoop.main.add(
+            timer,
+            forMode: reason == .softwareIslandConfigurationChanged ? .common : .default
+        )
     }
 
     private func measureNow() {
         pendingMeasurement = nil
+        let confirmsImmediately = hasPendingSoftwareIslandConfiguration
+        hasPendingSoftwareIslandConfiguration = false
 
         // Mid-drag (⌘-drag of a status item) layouts are transient garbage.
-        if NSEvent.pressedMouseButtons != 0, deferredRetries < 6 {
+        // A Settings slider drag is safe and must update while the mouse is down.
+        if !confirmsImmediately, NSEvent.pressedMouseButtons != 0, deferredRetries < 6 {
             deferredRetries += 1
             pendingMeasurement = Timer.scheduledTimer(withTimeInterval: 0.5, repeats: false) { [weak self] _ in
                 self?.measureNow()
@@ -146,16 +170,19 @@ final class NotchLayoutMonitor {
             geometry: geometry
         )
 
-        publish(classification)
+        publish(classification, confirmsImmediately: confirmsImmediately)
     }
 
-    private func publish(_ classification: LayoutClassification) {
+    private func publish(
+        _ classification: LayoutClassification,
+        confirmsImmediately: Bool = false
+    ) {
         let digest = MeasurementDigest(classification: classification)
         if digest == confirmedMeasurement {
             candidate = nil
             return
         }
-        if digest == candidate {
+        if confirmsImmediately || digest == candidate {
             candidate = nil
             confirmedMeasurement = digest
             confirmed = classification
@@ -187,10 +214,20 @@ final class NotchLayoutMonitor {
     }
 
     func currentGeometry() -> MenuBarGeometry? {
-        // Warn only about the notched (built-in) display; on every other
-        // display the full bar fits and there is nothing to say. Fall back
-        // to the toggle's screen so collapse bookkeeping still works.
-        let screen = NSScreen.screens.first { $0.safeAreaInsets.top > 0 }
+        let softwareIslands = SoftwareIslandMonitor.shared
+        softwareIslands.refresh()
+
+        // Prefer a display with an enabled software island, then preserve the
+        // existing physical-notch behavior. The toggle screen remains the
+        // fallback for ordinary displays and collapse bookkeeping.
+        let toggleScreenFrame = toggleItem?.button?.window?.screen?.frame
+        let softwareIslandScreen = softwareIslands
+            .preferredScreenFrame(preferred: toggleScreenFrame)
+            .flatMap { frame in
+            NSScreen.screens.first { $0.frame == frame }
+        }
+        let screen = softwareIslandScreen
+            ?? NSScreen.screens.first { $0.safeAreaInsets.top > 0 }
             ?? toggleItem?.button?.window?.screen
             ?? NSScreen.main
         guard let screen else { return nil }
@@ -209,11 +246,16 @@ final class NotchLayoutMonitor {
 
         let menuBarHeight = toggleItem?.button?.window?.frame.height
             ?? max(NSStatusBar.system.thickness, screen.safeAreaInsets.top)
+        let softwareOverlayRect = softwareIslands.obstruction(
+            on: screen,
+            menuBarHeight: menuBarHeight
+        )
 
         return MenuBarGeometry(
             screenFrame: screen.frame,
             notchRect: notchRect,
-            menuBarHeight: menuBarHeight
+            menuBarHeight: menuBarHeight,
+            softwareOverlayRect: softwareOverlayRect
         )
     }
 }

--- a/Sources/Pelmet/Onboarding/OnboardingController.swift
+++ b/Sources/Pelmet/Onboarding/OnboardingController.swift
@@ -69,7 +69,7 @@ final class OnboardingController: NSObject, NSPopoverDelegate {
         }
     }
 
-    /// The first time icons are detected hidden by the notch: explain the
+    /// The first time icons are detected covered in the menu bar: explain the
     /// count once, quietly. New users learn the Shelf here too — no second
     /// popover for them.
     func maybeShowSwallowedEducation(count: Int, toggle: NSStatusItem) {
@@ -81,7 +81,7 @@ final class OnboardingController: NSObject, NSPopoverDelegate {
         let phrase = count == 1 ? "1 icon doesn't fit" : "\(count) icons don't fit"
         guard show(
             title: phrase,
-            message: "The notch hides menu bar icons that run out of room, and macOS gives no warning. "
+            message: "A camera notch or software island can cover menu bar icons, and macOS gives no warning. "
                 + "Pelmet shows a count beside its chevron whenever that happens. "
                 + "Click the chevron to open the Shelf and see exactly what's hidden; "
                 + "right-click for ways to make room.",
@@ -106,7 +106,7 @@ final class OnboardingController: NSObject, NSPopoverDelegate {
         guard show(
             title: "See what's hidden",
             message: "New: when the chevron shows +\(count), click it to open the Shelf, "
-                + "a panel listing the icons the notch hid.\(shelfHint)",
+                + "a panel listing the covered icons.\(shelfHint)",
             buttonTitle: "Got It",
             on: button
         ) else { return }
@@ -121,7 +121,7 @@ final class OnboardingController: NSObject, NSPopoverDelegate {
     func maybeOfferOneClick(toggle: NSStatusItem) {
         guard activePopover == nil,
               !Preferences.didOfferOneClick,
-              LayoutStatus.shared.hasNotchedDisplay,
+              LayoutStatus.shared.hasMenuBarObstruction,
               !Preferences.activationEngineEnabled,
               StatusItemActivationEngine.shared.availability != .granted,
               let button = toggle.button else { return }
@@ -130,7 +130,7 @@ final class OnboardingController: NSObject, NSPopoverDelegate {
 
         guard show(
             title: "Open hidden icons with one click",
-            message: "Turn on One-Click Access and Pelmet can open the icons the notch hides "
+            message: "Turn on One-Click Access and Pelmet can open covered menu bar icons "
                 + "when they offer a macOS Accessibility action. It never creates mouse events, "
                 + "moves your pointer, or reads your screen, and you can turn it off any time in "
                 + "Settings → One-Click Access.",

--- a/Sources/Pelmet/Preferences.swift
+++ b/Sources/Pelmet/Preferences.swift
@@ -43,6 +43,7 @@ enum Preferences {
         static let supportNudgeLastShownAt = "supportNudgeLastShownAt"
         static let supportNudgeShowCount = "supportNudgeShowCount"
         static let supportNudgeDismissed = "supportNudgeDismissed"
+        static let softwareIslandRules = "softwareIslandRules"
 
         /// Which key holds an action's shortcut. Two keys rather than one blob, so
         /// a corrupt value costs one shortcut instead of both.
@@ -88,6 +89,37 @@ enum Preferences {
     /// menu and the Shelf shortcut open the Shelf regardless of this setting.
     static var shelfEnabled: Bool {
         UserDefaults.standard.object(forKey: Keys.shelfEnabled) as? Bool ?? true
+    }
+
+    struct SoftwareIslandRule: Codable, Equatable {
+        var enabled: Bool?
+        var restingWidth: Double?
+    }
+
+    static var softwareIslandRules: [String: SoftwareIslandRule] {
+        get {
+            guard let data = UserDefaults.standard.data(forKey: Keys.softwareIslandRules) else {
+                return [:]
+            }
+            return (try? JSONDecoder().decode([String: SoftwareIslandRule].self, from: data)) ?? [:]
+        }
+        set {
+            guard let data = try? JSONEncoder().encode(newValue) else { return }
+            UserDefaults.standard.set(data, forKey: Keys.softwareIslandRules)
+        }
+    }
+
+    static func updateSoftwareIslandRule(
+        bundleIdentifier: String,
+        enabled: Bool? = nil,
+        restingWidth: CGFloat? = nil
+    ) {
+        var rules = softwareIslandRules
+        var rule = rules[bundleIdentifier] ?? SoftwareIslandRule()
+        if let enabled { rule.enabled = enabled }
+        if let restingWidth { rule.restingWidth = Double(restingWidth) }
+        rules[bundleIdentifier] = rule
+        softwareIslandRules = rules
     }
 
     /// Opt-in for the Accessibility-gated activation engine (one-click

--- a/Sources/Pelmet/Settings/MenuBarSpacePaneView.swift
+++ b/Sources/Pelmet/Settings/MenuBarSpacePaneView.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-/// Menu Bar Space pane: what the notch is hiding right now, the chevron
+/// Menu Bar Space pane: what a notch or software island is hiding, the chevron
 /// count, the Shelf, and icon-spacing remedies. On Macs without a notch it
 /// collapses to an informational note.
 struct MenuBarSpacePaneView: View {
@@ -8,6 +8,7 @@ struct MenuBarSpacePaneView: View {
     @AppStorage(Preferences.Keys.showSwallowedCount) private var showSwallowedCount = true
     @AppStorage(Preferences.Keys.shelfEnabled) private var shelfEnabled = true
     @ObservedObject private var status = LayoutStatus.shared
+    @ObservedObject private var softwareIslands = SoftwareIslandMonitor.shared
     @ObservedObject private var hotkeys = HotkeyStatus.shared
 
     /// " (or ⌥⌘N)", or nothing when the user cleared the Shelf shortcut.
@@ -17,7 +18,55 @@ struct MenuBarSpacePaneView: View {
 
     var body: some View {
         Form {
-            if status.hasNotchedDisplay {
+            Section {
+                if softwareIslands.candidates.isEmpty {
+                    Text("No software island app is running. Vibe Island is supported automatically; other top-center overlay apps appear here for local calibration.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                } else {
+                    ForEach(softwareIslands.candidates) { candidate in
+                        VStack(alignment: .leading, spacing: 8) {
+                            HStack {
+                                VStack(alignment: .leading, spacing: 2) {
+                                    Text(candidate.displayName)
+                                    Text(candidate.isKnown ? "Known app" : "Detected locally")
+                                        .font(.caption)
+                                        .foregroundStyle(.secondary)
+                                }
+                                Spacer()
+                                Toggle("Include in coverage detection", isOn: Binding(
+                                    get: { candidate.enabled },
+                                    set: { softwareIslands.setEnabled($0, for: candidate) }
+                                ))
+                                .labelsHidden()
+                            }
+                            if candidate.enabled {
+                                HStack {
+                                    Text("Island width")
+                                    Slider(value: Binding(
+                                        get: { candidate.restingWidth },
+                                        set: { softwareIslands.setRestingWidth($0, for: candidate) }
+                                    ), in: 80...800, step: 2)
+                                    Text("\(Int(candidate.restingWidth)) pt")
+                                        .monospacedDigit()
+                                        .frame(width: 52, alignment: .trailing)
+                                }
+                                .font(.caption)
+                            }
+                        }
+                    }
+                }
+            } header: {
+                Text("Software Islands")
+            } footer: {
+                Text("Detection uses window position and app metadata without Screen Recording or Accessibility access. Width changes update the covered-icon count and Shelf live. Pelmet cannot move other apps' menu items around a centered overlay. Hover expansion is ignored, and unknown apps are never enabled automatically.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if status.hasMenuBarObstruction {
                 Section {
                     LabeledContent(
                         "Icons that don't fit",
@@ -29,7 +78,7 @@ struct MenuBarSpacePaneView: View {
                 Section {
                     Toggle("Open the Shelf when clicking the count", isOn: $shelfEnabled)
                 } footer: {
-                    Text("The Shelf is a panel under the notch listing the icons macOS hid. "
+                    Text("The Shelf is a panel below the obstruction listing covered icons. "
                         + "Turned off, a click always hides/shows icons instead; the Shelf stays "
                         + "one right-click\(shelfShortcutHint) away.")
                         .font(.caption)
@@ -54,7 +103,7 @@ struct MenuBarSpacePaneView: View {
             } else {
                 Section {
                     Label {
-                        Text("This Mac has no camera notch, so icons rarely run out of room.")
+                        Text("No physical notch or enabled software island is currently taking menu bar space.")
                     } icon: {
                         Image(systemName: "info.circle")
                     }
@@ -64,5 +113,16 @@ struct MenuBarSpacePaneView: View {
             }
         }
         .formStyle(.grouped)
+        .onAppear {
+            softwareIslands.refresh()
+        }
+        .onReceive(NotificationCenter.default.publisher(
+            for: .pelmetSoftwareIslandConfigurationDidChange
+        )) { _ in
+            status.refresh(
+                swallowedCount: status.swallowedCount,
+                shelfEntries: status.shelfEntries
+            )
+        }
     }
 }

--- a/Sources/Pelmet/Settings/SettingsPane.swift
+++ b/Sources/Pelmet/Settings/SettingsPane.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import PelmetCore
 
 /// The sidebar entries of the Settings window. Raw values are persisted
 /// (`Preferences.settingsPane`) — don't rename cases casually.
@@ -17,11 +18,16 @@ enum SettingsPane: String, CaseIterable, Identifiable {
     /// fits scroll-free; panes scroll if they ever outgrow it.
     static let contentHeight: CGFloat = 560
 
-    /// Panes offered for the current hardware — same gate as the
-    /// context-menu entry in MenuBarManager: One-Click Access only exists
-    /// where the notch makes it relevant.
-    static func available(hasNotchedDisplay: Bool) -> [SettingsPane] {
-        hasNotchedDisplay ? allCases : [.general, .menuBarSpace, .about]
+    /// One-Click Access appears when an obstruction makes it relevant and
+    /// remains available while enabled, even if that obstruction's app quits.
+    static func available(
+        hasMenuBarObstruction: Bool,
+        oneClickAccessEnabled: Bool
+    ) -> [SettingsPane] {
+        OneClickAccessPanePolicy.isAvailable(
+            hasMenuBarObstruction: hasMenuBarObstruction,
+            isEnabled: oneClickAccessEnabled
+        ) ? allCases : [.general, .menuBarSpace, .about]
     }
 
     var title: String {

--- a/Sources/Pelmet/Settings/SettingsRootView.swift
+++ b/Sources/Pelmet/Settings/SettingsRootView.swift
@@ -12,11 +12,16 @@ extension Notification.Name {
 struct SettingsRootView: View {
 
     @ObservedObject private var status = LayoutStatus.shared
+    @AppStorage(Preferences.Keys.activationEngineEnabled)
+    private var oneClickAccessEnabled = false
     @State private var selection: SettingsPane =
         SettingsPane(rawValue: Preferences.settingsPane) ?? .general
 
     var body: some View {
-        let available = SettingsPane.available(hasNotchedDisplay: status.hasNotchedDisplay)
+        let available = SettingsPane.available(
+            hasMenuBarObstruction: status.hasMenuBarObstruction,
+            oneClickAccessEnabled: oneClickAccessEnabled
+        )
         // Render a valid pane even before onReceive normalizes a stale
         // selection (e.g. "oneClickAccess" persisted on a non-notched Mac).
         let shown = available.contains(selection) ? selection : .general
@@ -72,10 +77,21 @@ struct SettingsRootView: View {
         .frame(height: SettingsPane.contentHeight)
         // If One-Click Access vanishes while selected (lid closed on a
         // notched MacBook driving an external display), fall back to General.
-        // removeDuplicates is mandatory: LayoutStatus re-assigns
-        // hasNotchedDisplay on every layout snapshot.
-        .onReceive(LayoutStatus.shared.$hasNotchedDisplay.removeDuplicates()) { hasNotch in
-            if !SettingsPane.available(hasNotchedDisplay: hasNotch).contains(selection) {
+        // removeDuplicates is mandatory: LayoutStatus re-assigns the value
+        // on every layout snapshot.
+        .onReceive(LayoutStatus.shared.$hasMenuBarObstruction.removeDuplicates()) { hasObstruction in
+            if !SettingsPane.available(
+                hasMenuBarObstruction: hasObstruction,
+                oneClickAccessEnabled: oneClickAccessEnabled
+            ).contains(selection) {
+                selection = .general
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(for: UserDefaults.didChangeNotification)) { _ in
+            if !SettingsPane.available(
+                hasMenuBarObstruction: status.hasMenuBarObstruction,
+                oneClickAccessEnabled: Preferences.activationEngineEnabled
+            ).contains(selection) {
                 selection = .general
             }
         }

--- a/Sources/Pelmet/Shelf/ShelfView.swift
+++ b/Sources/Pelmet/Shelf/ShelfView.swift
@@ -1,7 +1,7 @@
 import SwiftUI
 import PelmetCore
 
-/// The Shelf's content: a frosted card listing the icons the notch hid.
+/// The Shelf's content: a frosted card listing covered icons.
 /// Rows are real buttons (VoiceOver reads them for free); keyboard events
 /// arrive from the panel via the view model, not SwiftUI focus.
 struct ShelfView: View {
@@ -53,7 +53,7 @@ struct ShelfView: View {
                 .strokeBorder(Color.primary.opacity(0.12), lineWidth: 0.5)
         )
         .accessibilityElement(children: .contain)
-        .accessibilityLabel("Pelmet Shelf: icons hidden by the notch")
+        .accessibilityLabel("Pelmet Shelf: unavailable menu bar icons")
     }
 
     // MARK: - Sections
@@ -68,9 +68,9 @@ struct ShelfView: View {
     private var headerText: String {
         switch model.tier {
         case .owners, .engine:
-            return "Hidden by the notch"
+            return "Unavailable in the menu bar"
         case .anonymous:
-            return "Hidden by the notch. macOS 26 hides which apps these belong to"
+            return "Unavailable in the menu bar. macOS 26 hides which apps these belong to"
         }
     }
 
@@ -79,7 +79,7 @@ struct ShelfView: View {
             Image(systemName: "checkmark.circle")
                 .font(.title2)
                 .foregroundStyle(.secondary)
-            Text("Everything fits. Nothing is hidden by the notch.")
+            Text("Everything fits. No icons are unavailable.")
                 .font(.callout)
                 .foregroundStyle(.secondary)
                 .multilineTextAlignment(.center)

--- a/Sources/Pelmet/SoftwareIslandMonitor.swift
+++ b/Sources/Pelmet/SoftwareIslandMonitor.swift
@@ -1,0 +1,121 @@
+import AppKit
+import Combine
+import PelmetCore
+
+extension Notification.Name {
+    static let pelmetSoftwareIslandConfigurationDidChange = Notification.Name(
+        "PelmetSoftwareIslandConfigurationDidChange"
+    )
+}
+
+/// Permission-free discovery and local configuration for software-drawn
+/// menu bar islands. Known providers work automatically. Unknown candidates
+/// remain inert until the user enables a local rule in Settings.
+final class SoftwareIslandMonitor: ObservableObject {
+
+    struct Candidate: Equatable, Identifiable {
+        let bundleIdentifier: String
+        let displayName: String
+        let screenFrames: [CGRect]
+        let outerWindowFrame: CGRect
+        let provider: SoftwareIslandProvider?
+        let enabled: Bool
+        let restingWidth: CGFloat
+
+        var id: String { bundleIdentifier }
+        var isKnown: Bool { provider != nil }
+    }
+
+    static let shared = SoftwareIslandMonitor()
+
+    @Published private(set) var candidates: [Candidate] = []
+    private var detections: [SoftwareIslandDetection] = []
+
+    var hasEnabledCandidate: Bool {
+        candidates.contains(where: \.enabled)
+    }
+
+    private init() {}
+
+    /// Refreshes the Window Server snapshot exactly once. Callers that only
+    /// changed a local rule use rebuildCandidates() instead of rescanning.
+    func refresh() {
+        detections = WindowListSource.softwareIslandWindows()
+        rebuildCandidates()
+    }
+
+    private func rebuildCandidates() {
+        let rules = Preferences.softwareIslandRules
+
+        let next = SoftwareIslandDetectionGrouper.group(detections).map { group in
+            let bundleIdentifier = group.bundleIdentifier
+            let provider = SoftwareIslandRegistry.provider(for: bundleIdentifier)
+            let rule = rules[bundleIdentifier]
+            let defaultWidth = provider?.defaultRestingWidth
+                ?? min(group.widestOuterWindowFrame.width, 340)
+            return Candidate(
+                bundleIdentifier: bundleIdentifier,
+                displayName: provider?.displayName ?? group.displayName,
+                screenFrames: group.screenFrames,
+                outerWindowFrame: group.widestOuterWindowFrame,
+                provider: provider,
+                enabled: rule?.enabled ?? (provider != nil),
+                restingWidth: CGFloat(rule?.restingWidth ?? Double(defaultWidth))
+            )
+        }
+        .sorted {
+            if $0.isKnown != $1.isKnown { return $0.isKnown }
+            return $0.displayName.localizedCaseInsensitiveCompare($1.displayName) == .orderedAscending
+        }
+        if next != candidates {
+            candidates = next
+        }
+    }
+
+    func obstruction(on screen: NSScreen, menuBarHeight: CGFloat) -> CGRect? {
+        guard let candidate = candidates
+            .filter({ $0.enabled && $0.screenFrames.contains(screen.frame) })
+            .max(by: { $0.restingWidth < $1.restingWidth })
+        else { return nil }
+
+        return SoftwareIslandCandidateClassifier.restingRect(
+            width: candidate.restingWidth,
+            screenFrame: screen.frame,
+            menuBarHeight: menuBarHeight
+        )
+    }
+
+    func preferredScreenFrame(preferred preferredFrame: CGRect?) -> CGRect? {
+        let enabledFrames = candidates
+            .filter(\.enabled)
+            .flatMap(\.screenFrames)
+        if let preferredFrame, enabledFrames.contains(preferredFrame) {
+            return preferredFrame
+        }
+        return enabledFrames.first
+    }
+
+    func setEnabled(_ enabled: Bool, for candidate: Candidate) {
+        Preferences.updateSoftwareIslandRule(
+            bundleIdentifier: candidate.bundleIdentifier,
+            enabled: enabled
+        )
+        configurationChanged()
+    }
+
+    func setRestingWidth(_ restingWidth: CGFloat, for candidate: Candidate) {
+        Preferences.updateSoftwareIslandRule(
+            bundleIdentifier: candidate.bundleIdentifier,
+            restingWidth: restingWidth
+        )
+        configurationChanged()
+    }
+
+    private func configurationChanged() {
+        rebuildCandidates()
+        NotificationCenter.default.post(
+            name: .pelmetSoftwareIslandConfigurationDidChange,
+            object: self
+        )
+    }
+}

--- a/Sources/Pelmet/WindowListSource.swift
+++ b/Sources/Pelmet/WindowListSource.swift
@@ -45,4 +45,66 @@ enum WindowListSource {
             )
         }
     }
+
+    /// Top-center overlay candidates using the same permission-free metadata
+    /// as status-item discovery. App identity is resolved locally from the
+    /// owning PID and never leaves the Mac.
+    static func softwareIslandWindows() -> [SoftwareIslandDetection] {
+        guard
+            let primary = NSScreen.screens.first,
+            let list = CGWindowListCopyWindowInfo([.optionAll], kCGNullWindowID) as? [[String: Any]]
+        else { return [] }
+
+        let primaryMaxY = primary.frame.maxY
+        let ownPID = Int32(ProcessInfo.processInfo.processIdentifier)
+
+        return list.compactMap { info in
+            guard
+                let level = info[kCGWindowLayer as String] as? Int,
+                level > statusItemWindowLevel,
+                info[kCGWindowIsOnscreen as String] as? Bool == true,
+                let pid = info[kCGWindowOwnerPID as String] as? Int32,
+                pid != ownPID,
+                let bounds = info[kCGWindowBounds as String] as? [String: CGFloat],
+                let x = bounds["X"], let y = bounds["Y"],
+                let width = bounds["Width"], let height = bounds["Height"],
+                width > 0, height > 0,
+                let app = NSRunningApplication(processIdentifier: pid),
+                let bundleIdentifier = app.bundleIdentifier
+            else { return nil }
+
+            let frame = CGRect(
+                x: x,
+                y: primaryMaxY - y - height,
+                width: width,
+                height: height
+            )
+            guard let screen = NSScreen.screens.first(where: { candidate in
+                frame.intersects(candidate.frame)
+                    && abs(frame.maxY - candidate.frame.maxY)
+                        <= SoftwareIslandCandidateClassifier.topEdgeTolerance
+            }) else { return nil }
+
+            let isSystemOwner = bundleIdentifier.hasPrefix("com.apple.")
+            let observation = SoftwareIslandWindowObservation(
+                frame: frame,
+                layer: level,
+                bundleIdentifier: bundleIdentifier,
+                isAccessoryApplication: app.activationPolicy == .accessory,
+                isSystemOwner: isSystemOwner
+            )
+            guard SoftwareIslandCandidateClassifier.isCandidate(
+                observation,
+                screenFrame: screen.frame,
+                menuBarHeight: max(NSStatusBar.system.thickness, screen.safeAreaInsets.top)
+            ) else { return nil }
+
+            return SoftwareIslandDetection(
+                bundleIdentifier: bundleIdentifier,
+                displayName: app.localizedName ?? bundleIdentifier,
+                screenFrame: screen.frame,
+                outerWindowFrame: observation.frame
+            )
+        }
+    }
 }

--- a/Sources/PelmetCore/MenuBarLayoutClassifier.swift
+++ b/Sources/PelmetCore/MenuBarLayoutClassifier.swift
@@ -30,12 +30,19 @@ public enum ItemVisibility: Equatable {
     /// Frame in or left of the notch while the bar is full — macOS gives it
     /// no space and no indication. The user cannot see or reach it.
     case swallowedByNotch
+    /// Covered by a software-drawn island in the menu bar. Unlike a
+    /// physical notch, items to the island's left remain reachable.
+    case coveredBySoftwareIsland
     /// Pushed past the left screen edge by Pelmet's own inflated separator —
     /// expected and intentional while collapsed.
     case offscreenLeft
     /// Almost certainly a stale twin window, not a real icon (see below) —
     /// never counted.
     case suspectedGhost
+
+    public var isObstructed: Bool {
+        self == .swallowedByNotch || self == .coveredBySoftwareIsland
+    }
 }
 
 /// A status-item window as the window server reports it: a frame in AppKit
@@ -79,13 +86,22 @@ public struct MenuBarGeometry: Equatable {
     public let screenFrame: CGRect
     /// nil on screens without a camera housing.
     public let notchRect: CGRect?
+    /// A permission-free, locally detected software island reservation.
+    /// The rect describes its stable resting footprint, not hover expansion.
+    public let softwareOverlayRect: CGRect?
     /// Height of the menu bar band at the top of `screenFrame`.
     public let menuBarHeight: CGFloat
 
-    public init(screenFrame: CGRect, notchRect: CGRect?, menuBarHeight: CGFloat) {
+    public init(
+        screenFrame: CGRect,
+        notchRect: CGRect?,
+        menuBarHeight: CGFloat,
+        softwareOverlayRect: CGRect? = nil
+    ) {
         self.screenFrame = screenFrame
         self.notchRect = notchRect
         self.menuBarHeight = menuBarHeight
+        self.softwareOverlayRect = softwareOverlayRect
     }
 
     /// The horizontal strip status items live in on this screen.
@@ -105,7 +121,7 @@ public struct LayoutClassification: Equatable {
     public let toggleVisible: Bool
 
     public var swallowedCount: Int {
-        items.filter { $0.visibility == .swallowedByNotch }.count
+        items.filter { $0.visibility.isObstructed }.count
     }
 
     public var offscreenLeftCount: Int {
@@ -174,14 +190,20 @@ public enum MenuBarLayoutClassifier {
         if isCollapsed {
             separatorHealth = .unknown
         } else if let sep = ownSeparatorFrame {
-            separatorHealth = isSwallowed(sep, geometry: geometry) ? .swallowed : .visible
+            // Only a physical notch should trigger Pelmet's status-item rescue
+            // machinery. Treating a software overlay as a missing separator
+            // makes MenuBarManager recreate its controls, which repacks other
+            // apps' items and can move one underneath the overlay.
+            separatorHealth = isSwallowedByNotch(sep, geometry: geometry) ? .swallowed : .visible
         } else {
             separatorHealth = .unknown
         }
 
         let toggleVisible: Bool
         if let toggle = ownToggleFrame {
-            toggleVisible = !isSwallowed(toggle, geometry: geometry)
+            // Software-island coverage is observational. It must never feed
+            // back into rescueToggleIfNeeded and perturb the menu-bar layout.
+            toggleVisible = !isSwallowedByNotch(toggle, geometry: geometry)
                 && toggle.maxX <= geometry.screenFrame.maxX + frameMatchTolerance
         } else {
             toggleVisible = false
@@ -231,17 +253,27 @@ public enum MenuBarLayoutClassifier {
             // collapse's mirror windows lingering there).
             return isCollapsed ? .offscreenLeft : .suspectedGhost
         }
-        if isSwallowed(frame, geometry: geometry) {
+        if isSwallowedByNotch(frame, geometry: geometry) {
             return .swallowedByNotch
+        }
+        if isCoveredBySoftwareIsland(frame, geometry: geometry) {
+            return .coveredBySoftwareIsland
         }
         return .visible
     }
 
-    private static func isSwallowed(_ frame: CGRect, geometry: MenuBarGeometry) -> Bool {
+    private static func isSwallowedByNotch(_ frame: CGRect, geometry: MenuBarGeometry) -> Bool {
         guard let notch = geometry.notchRect else { return false }
         // Items never render in or left of the notch; a band frame there is
         // invisible. Small inset absorbs frames that merely kiss the edge.
         return frame.intersects(notch.insetBy(dx: 2, dy: 0)) || frame.maxX <= notch.minX + 2
+    }
+
+    private static func isCoveredBySoftwareIsland(_ frame: CGRect, geometry: MenuBarGeometry) -> Bool {
+        guard let island = geometry.softwareOverlayRect else { return false }
+        // Software islands cover only their own footprint. macOS can still
+        // draw and activate menu bar items on either side of that footprint.
+        return frame.intersects(island.insetBy(dx: 2, dy: 0))
     }
 
     private static func matches(_ a: CGRect, _ b: CGRect) -> Bool {

--- a/Sources/PelmetCore/MenuBarUpdatePresentation.swift
+++ b/Sources/PelmetCore/MenuBarUpdatePresentation.swift
@@ -2,6 +2,8 @@
 /// chevron, notch count, tooltip, and accessibility value.
 public struct MenuBarUpdatePresentation: Equatable, Sendable {
     public let badgeText: String
+    /// Space-constrained form drawn above the fixed-width state chevron.
+    public let compactBadgeText: String
     public let actionTitle: String
     public let tooltipNotice: String?
     public let accessibilityNotice: String?
@@ -14,8 +16,15 @@ public struct MenuBarUpdatePresentation: Equatable, Sendable {
         let countText = showsSwallowedCount && swallowedCount > 0
             ? "+\(swallowedCount)"
             : nil
+        let compactCountText: String?
+        if showsSwallowedCount && swallowedCount > 0 {
+            compactCountText = swallowedCount > 99 ? "99+" : "+\(swallowedCount)"
+        } else {
+            compactCountText = nil
+        }
         let updateText = availableVersion == nil ? nil : "↑"
         badgeText = [countText, updateText].compactMap { $0 }.joined(separator: " ")
+        compactBadgeText = [compactCountText, updateText].compactMap { $0 }.joined()
 
         if let availableVersion {
             actionTitle = "Update Pelmet to \(availableVersion)…"

--- a/Sources/PelmetCore/OneClickAccessPanePolicy.swift
+++ b/Sources/PelmetCore/OneClickAccessPanePolicy.swift
@@ -1,0 +1,12 @@
+/// One-Click Access must remain manageable after the obstruction that made it
+/// relevant disappears. Otherwise an enabled Accessibility-backed engine can
+/// persist while its only in-app off switch is hidden.
+public enum OneClickAccessPanePolicy {
+
+    public static func isAvailable(
+        hasMenuBarObstruction: Bool,
+        isEnabled: Bool
+    ) -> Bool {
+        hasMenuBarObstruction || isEnabled
+    }
+}

--- a/Sources/PelmetCore/ShelfContent.swift
+++ b/Sources/PelmetCore/ShelfContent.swift
@@ -66,7 +66,7 @@ public struct ShelfEntryModel: Equatable, Identifiable {
 /// Pure derivation of Shelf rows from a layout classification.
 ///
 /// Source-of-truth rule (badge parity): the rows are exactly the
-/// classification's `.swallowedByNotch` items — the same set the "+N" badge
+/// classification's obstructed items, the same set the "+N" badge
 /// counts. Engine items only ENRICH rows (title, activation token); they
 /// never add or remove any.
 public enum ShelfContentDeriver {
@@ -83,7 +83,7 @@ public enum ShelfContentDeriver {
         engineItems: [EngineItemDescriptor]
     ) -> [ShelfEntryModel] {
         let swallowed = classification.items
-            .filter { $0.visibility == .swallowedByNotch }
+            .filter { $0.visibility.isObstructed }
             // Defensively drop Pelmet's own windows if frame exclusion ever
             // slips — better a missing row than Pelmet listing itself.
             .filter { !$0.ownerPIDs.contains(ownPID) }

--- a/Sources/PelmetCore/ShelfPlacement.swift
+++ b/Sources/PelmetCore/ShelfPlacement.swift
@@ -18,6 +18,7 @@ public enum ShelfPlacement {
         let top = screen.maxY - geometry.menuBarHeight - gap
 
         let preferredCenterX = anchorFrame?.midX
+            ?? geometry.softwareOverlayRect?.midX
             ?? geometry.notchRect?.midX
             ?? screen.midX
 

--- a/Sources/PelmetCore/SoftwareIsland.swift
+++ b/Sources/PelmetCore/SoftwareIsland.swift
@@ -1,0 +1,206 @@
+import CoreGraphics
+import Foundation
+
+/// How Pelmet treats a known software island when its host window grows.
+/// Resting-only providers keep a stable menu bar reservation while transient
+/// hover panels are open, so status items do not jump under the pointer.
+public enum SoftwareIslandExpansionPolicy: Equatable {
+    case restingWidthOnly
+}
+
+/// A source-controlled compatibility hint for a known top-center overlay.
+/// Geometry remains user-adjustable because display scaling and app settings
+/// can change the visible resting width independently of the outer window.
+public struct SoftwareIslandProvider: Equatable {
+    public let id: String
+    public let displayName: String
+    public let bundleIdentifiers: Set<String>
+    public let defaultRestingWidth: CGFloat
+    public let expansionPolicy: SoftwareIslandExpansionPolicy
+
+    public init(
+        id: String,
+        displayName: String,
+        bundleIdentifiers: Set<String>,
+        defaultRestingWidth: CGFloat,
+        expansionPolicy: SoftwareIslandExpansionPolicy
+    ) {
+        self.id = id
+        self.displayName = displayName
+        self.bundleIdentifiers = bundleIdentifiers
+        self.defaultRestingWidth = defaultRestingWidth
+        self.expansionPolicy = expansionPolicy
+    }
+}
+
+public enum SoftwareIslandRegistry {
+
+    public static let providers: [SoftwareIslandProvider] = [
+        SoftwareIslandProvider(
+            id: "vibe-island",
+            displayName: "Vibe Island",
+            bundleIdentifiers: ["app.vibeisland.macos"],
+            // Vibe Island uses a 680 pt transparent envelope. Its resting
+            // pill is much narrower and is user-tunable, so this is only the
+            // first-run calibration value.
+            defaultRestingWidth: 340,
+            expansionPolicy: .restingWidthOnly
+        ),
+    ]
+
+    public static func provider(for bundleIdentifier: String) -> SoftwareIslandProvider? {
+        providers.first { $0.bundleIdentifiers.contains(bundleIdentifier) }
+    }
+}
+
+/// Permission-free facts about a foreign window, normalized to AppKit screen
+/// coordinates before they enter the pure candidate classifier.
+public struct SoftwareIslandWindowObservation: Equatable {
+    public let frame: CGRect
+    public let layer: Int
+    public let bundleIdentifier: String
+    public let isAccessoryApplication: Bool
+    public let isSystemOwner: Bool
+
+    public init(
+        frame: CGRect,
+        layer: Int,
+        bundleIdentifier: String,
+        isAccessoryApplication: Bool,
+        isSystemOwner: Bool
+    ) {
+        self.frame = frame
+        self.layer = layer
+        self.bundleIdentifier = bundleIdentifier
+        self.isAccessoryApplication = isAccessoryApplication
+        self.isSystemOwner = isSystemOwner
+    }
+}
+
+/// One locally detected candidate window after the app layer has resolved its
+/// display name and screen. Keeping this value pure makes multi-display
+/// grouping testable without querying Window Server in tests.
+public struct SoftwareIslandDetection: Equatable {
+    public let bundleIdentifier: String
+    public let displayName: String
+    public let screenFrame: CGRect
+    public let outerWindowFrame: CGRect
+
+    public init(
+        bundleIdentifier: String,
+        displayName: String,
+        screenFrame: CGRect,
+        outerWindowFrame: CGRect
+    ) {
+        self.bundleIdentifier = bundleIdentifier
+        self.displayName = displayName
+        self.screenFrame = screenFrame
+        self.outerWindowFrame = outerWindowFrame
+    }
+}
+
+/// Every detected screen for one app, plus a representative outer envelope
+/// used only to choose the initial resting-width calibration.
+public struct SoftwareIslandDetectionGroup: Equatable {
+    public let bundleIdentifier: String
+    public let displayName: String
+    public let screenFrames: [CGRect]
+    public let widestOuterWindowFrame: CGRect
+}
+
+public enum SoftwareIslandDetectionGrouper {
+
+    public static func group(
+        _ detections: [SoftwareIslandDetection]
+    ) -> [SoftwareIslandDetectionGroup] {
+        var byBundleIdentifier: [String: [SoftwareIslandDetection]] = [:]
+        for detection in detections {
+            byBundleIdentifier[detection.bundleIdentifier, default: []].append(detection)
+        }
+
+        return byBundleIdentifier.map { bundleIdentifier, members in
+            let representative = members.max(by: representativeSort)!
+            let screenFrames = members
+                .map(\.screenFrame)
+                .reduce(into: [CGRect]()) { result, frame in
+                    if !result.contains(frame) { result.append(frame) }
+                }
+                .sorted(by: screenSort)
+            return SoftwareIslandDetectionGroup(
+                bundleIdentifier: bundleIdentifier,
+                displayName: representative.displayName,
+                screenFrames: screenFrames,
+                widestOuterWindowFrame: representative.outerWindowFrame
+            )
+        }
+        .sorted { $0.bundleIdentifier < $1.bundleIdentifier }
+    }
+
+    private static func representativeSort(
+        _ lhs: SoftwareIslandDetection,
+        _ rhs: SoftwareIslandDetection
+    ) -> Bool {
+        let left = lhs.outerWindowFrame
+        let right = rhs.outerWindowFrame
+        if left.width != right.width { return left.width < right.width }
+        if left.height != right.height { return left.height < right.height }
+        if left.minX != right.minX { return left.minX > right.minX }
+        return left.minY > right.minY
+    }
+
+    private static func screenSort(_ lhs: CGRect, _ rhs: CGRect) -> Bool {
+        if lhs.minX != rhs.minX { return lhs.minX < rhs.minX }
+        if lhs.minY != rhs.minY { return lhs.minY < rhs.minY }
+        if lhs.width != rhs.width { return lhs.width < rhs.width }
+        return lhs.height < rhs.height
+    }
+}
+
+/// Conservative generic discovery for persistent notch-style overlays.
+/// This identifies candidates, not their opaque pixel shape. Unknown apps
+/// still require a local user rule before Pelmet reserves space for them.
+public enum SoftwareIslandCandidateClassifier {
+
+    public static let statusItemWindowLevel = 25
+    public static let minimumWidth: CGFloat = 80
+    public static let maximumScreenWidthFraction: CGFloat = 0.65
+    public static let topEdgeTolerance: CGFloat = 2
+    public static let centerToleranceFraction: CGFloat = 0.03
+
+    public static func isCandidate(
+        _ observation: SoftwareIslandWindowObservation,
+        screenFrame: CGRect,
+        menuBarHeight: CGFloat
+    ) -> Bool {
+        let frame = observation.frame
+        let centerTolerance = max(4, screenFrame.width * centerToleranceFraction)
+        let isKnownProvider = SoftwareIslandRegistry.provider(
+            for: observation.bundleIdentifier
+        ) != nil
+
+        return observation.layer > statusItemWindowLevel
+            && observation.isAccessoryApplication
+            && !observation.isSystemOwner
+            && frame.intersects(screenFrame)
+            && abs(frame.maxY - screenFrame.maxY) <= topEdgeTolerance
+            && abs(frame.midX - screenFrame.midX) <= centerTolerance
+            && frame.width >= minimumWidth
+            && (isKnownProvider
+                || frame.width <= screenFrame.width * maximumScreenWidthFraction)
+            && frame.height >= max(8, menuBarHeight * 0.8)
+    }
+
+    public static func restingRect(
+        width requestedWidth: CGFloat,
+        screenFrame: CGRect,
+        menuBarHeight: CGFloat
+    ) -> CGRect {
+        let width = min(max(requestedWidth, minimumWidth), screenFrame.width)
+        return CGRect(
+            x: screenFrame.midX - width / 2,
+            y: screenFrame.maxY - menuBarHeight,
+            width: width,
+            height: menuBarHeight
+        )
+    }
+}

--- a/Tests/PelmetCoreTests/MenuBarLayoutClassifierTests.swift
+++ b/Tests/PelmetCoreTests/MenuBarLayoutClassifierTests.swift
@@ -325,4 +325,60 @@ struct MenuBarLayoutClassifierTests {
         #expect(result.separatorHealth == .visible)
         #expect(result.toggleVisible)
     }
+
+    @Test func testSoftwareIslandCoversIntersectingItemWithoutPhysicalNotch() {
+        let flat = MenuBarGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1920, height: 1080),
+            notchRect: nil,
+            menuBarHeight: 30,
+            softwareOverlayRect: CGRect(x: 790, y: 1050, width: 340, height: 30)
+        )
+        let result = MenuBarLayoutClassifier.classify(
+            rawItems: [RawStatusWindow(frame: CGRect(x: 800, y: 1050, width: 40, height: 30))],
+            ownSeparatorFrame: CGRect(x: 1500, y: 1050, width: 26, height: 30),
+            ownToggleFrame: CGRect(x: 1530, y: 1050, width: 38, height: 30),
+            isCollapsed: false,
+            geometry: flat
+        )
+        #expect(result.swallowedCount == 1)
+        #expect(result.items[0].visibility == .coveredBySoftwareIsland)
+    }
+
+    @Test func testSoftwareIslandDoesNotHideItemsToItsLeft() {
+        let flat = MenuBarGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1920, height: 1080),
+            notchRect: nil,
+            menuBarHeight: 30,
+            softwareOverlayRect: CGRect(x: 790, y: 1050, width: 340, height: 30)
+        )
+        let result = MenuBarLayoutClassifier.classify(
+            rawItems: [RawStatusWindow(frame: CGRect(x: 700, y: 1050, width: 40, height: 30))],
+            ownSeparatorFrame: CGRect(x: 1500, y: 1050, width: 26, height: 30),
+            ownToggleFrame: CGRect(x: 1530, y: 1050, width: 38, height: 30),
+            isCollapsed: false,
+            geometry: flat
+        )
+        #expect(result.swallowedCount == 0)
+        #expect(result.items[0].visibility == .visible)
+    }
+
+    @Test func testSoftwareIslandDoesNotTriggerPelmetControlRescue() {
+        let flat = MenuBarGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1920, height: 1080),
+            notchRect: nil,
+            menuBarHeight: 30,
+            softwareOverlayRect: CGRect(x: 790, y: 1050, width: 340, height: 30)
+        )
+        let result = MenuBarLayoutClassifier.classify(
+            rawItems: [],
+            ownSeparatorFrame: CGRect(x: 800, y: 1050, width: 26, height: 30),
+            ownToggleFrame: CGRect(x: 830, y: 1050, width: 38, height: 30),
+            isCollapsed: false,
+            geometry: flat
+        )
+
+        #expect(result.separatorHealth == .visible)
+        #expect(result.toggleVisible)
+    }
+
 }

--- a/Tests/PelmetCoreTests/MenuBarUpdatePresentationTests.swift
+++ b/Tests/PelmetCoreTests/MenuBarUpdatePresentationTests.swift
@@ -10,6 +10,7 @@ struct MenuBarUpdatePresentationTests {
         )
 
         #expect(presentation.badgeText == "↑")
+        #expect(presentation.compactBadgeText == "↑")
         #expect(presentation.actionTitle == "Update Pelmet to 0.4.0…")
         #expect(presentation.tooltipNotice == "Pelmet 0.4.0 is available. Right-click to update.")
         #expect(presentation.accessibilityNotice == "Update 0.4.0 available. Right-click to update.")
@@ -23,6 +24,7 @@ struct MenuBarUpdatePresentationTests {
         )
 
         #expect(presentation.badgeText == "+3")
+        #expect(presentation.compactBadgeText == "+3")
         #expect(presentation.actionTitle == "Check for Updates…")
         #expect(presentation.tooltipNotice == nil)
         #expect(presentation.accessibilityNotice == nil)
@@ -36,6 +38,7 @@ struct MenuBarUpdatePresentationTests {
         )
 
         #expect(presentation.badgeText == "+2 ↑")
+        #expect(presentation.compactBadgeText == "+2↑")
     }
 
     @Test func hiddenNotchCountStillShowsUpdate() {
@@ -46,5 +49,17 @@ struct MenuBarUpdatePresentationTests {
         )
 
         #expect(presentation.badgeText == "↑")
+        #expect(presentation.compactBadgeText == "↑")
+    }
+
+    @Test func compactCountIsBoundedForTheFixedWidthToggle() {
+        let presentation = MenuBarUpdatePresentation(
+            swallowedCount: 142,
+            showsSwallowedCount: true,
+            availableVersion: "1.0.0"
+        )
+
+        #expect(presentation.badgeText == "+142 ↑")
+        #expect(presentation.compactBadgeText == "99+↑")
     }
 }

--- a/Tests/PelmetCoreTests/OneClickAccessPanePolicyTests.swift
+++ b/Tests/PelmetCoreTests/OneClickAccessPanePolicyTests.swift
@@ -1,0 +1,26 @@
+import Testing
+@testable import PelmetCore
+
+struct OneClickAccessPanePolicyTests {
+
+    @Test func obstructionMakesThePaneAvailable() {
+        #expect(OneClickAccessPanePolicy.isAvailable(
+            hasMenuBarObstruction: true,
+            isEnabled: false
+        ))
+    }
+
+    @Test func enabledEngineKeepsThePaneAvailableAfterTheObstructionExits() {
+        #expect(OneClickAccessPanePolicy.isAvailable(
+            hasMenuBarObstruction: false,
+            isEnabled: true
+        ))
+    }
+
+    @Test func irrelevantDisabledPaneStaysHidden() {
+        #expect(!OneClickAccessPanePolicy.isAvailable(
+            hasMenuBarObstruction: false,
+            isEnabled: false
+        ))
+    }
+}

--- a/Tests/PelmetCoreTests/ShelfPlacementTests.swift
+++ b/Tests/PelmetCoreTests/ShelfPlacementTests.swift
@@ -50,6 +50,18 @@ struct ShelfPlacementTests {
         #expect(frame.midX == 756)
     }
 
+    @Test func testNoAnchorPrefersSoftwareIslandCenter() {
+        let island = CGRect(x: 800, y: 950, width: 200, height: 32)
+        let geometry = MenuBarGeometry(
+            screenFrame: CGRect(x: 0, y: 0, width: 1512, height: 982),
+            notchRect: nil,
+            menuBarHeight: 32,
+            softwareOverlayRect: island
+        )
+        let frame = ShelfPlacement.panelFrame(panelSize: panelSize, anchorFrame: nil, geometry: geometry)
+        #expect(frame.midX == island.midX)
+    }
+
     @Test func testSecondaryDisplayOriginIsRespected() {
         // A display left of the primary: negative-x screen frame.
         let external = MenuBarGeometry(

--- a/Tests/PelmetCoreTests/SoftwareIslandTests.swift
+++ b/Tests/PelmetCoreTests/SoftwareIslandTests.swift
@@ -1,0 +1,137 @@
+import CoreGraphics
+import Testing
+@testable import PelmetCore
+
+struct SoftwareIslandTests {
+    private let screen = CGRect(x: 0, y: 0, width: 1920, height: 1080)
+
+    private func observation(
+        frame: CGRect = CGRect(x: 620, y: 500, width: 680, height: 580),
+        layer: Int = 27,
+        bundleIdentifier: String = "app.vibeisland.macos",
+        isAccessoryApplication: Bool = true,
+        isSystemOwner: Bool = false
+    ) -> SoftwareIslandWindowObservation {
+        SoftwareIslandWindowObservation(
+            frame: frame,
+            layer: layer,
+            bundleIdentifier: bundleIdentifier,
+            isAccessoryApplication: isAccessoryApplication,
+            isSystemOwner: isSystemOwner
+        )
+    }
+
+    @Test func registryRecognizesVibeIsland() {
+        let provider = SoftwareIslandRegistry.provider(for: "app.vibeisland.macos")
+        #expect(provider?.displayName == "Vibe Island")
+        #expect(provider?.defaultRestingWidth == 340)
+    }
+
+    @Test func registryLeavesUnknownAppsUnmatched() {
+        #expect(SoftwareIslandRegistry.provider(for: "example.unknown") == nil)
+    }
+
+    @Test func topCenteredAccessoryWindowIsCandidate() {
+        #expect(SoftwareIslandCandidateClassifier.isCandidate(
+            observation(), screenFrame: screen, menuBarHeight: 30
+        ))
+    }
+
+    @Test func systemAndOrdinaryAppsAreRejected() {
+        #expect(!SoftwareIslandCandidateClassifier.isCandidate(
+            observation(isAccessoryApplication: false), screenFrame: screen, menuBarHeight: 30
+        ))
+        #expect(!SoftwareIslandCandidateClassifier.isCandidate(
+            observation(isSystemOwner: true), screenFrame: screen, menuBarHeight: 30
+        ))
+    }
+
+    @Test func statusLevelAndOffCenterWindowsAreRejected() {
+        #expect(!SoftwareIslandCandidateClassifier.isCandidate(
+            observation(layer: 25), screenFrame: screen, menuBarHeight: 30
+        ))
+        #expect(!SoftwareIslandCandidateClassifier.isCandidate(
+            observation(frame: CGRect(x: 100, y: 500, width: 680, height: 580)),
+            screenFrame: screen,
+            menuBarHeight: 30
+        ))
+    }
+
+    @Test func knownProviderCanUseAWideTransparentEnvelope() {
+        let wideVibeWindow = observation(
+            frame: CGRect(x: 100, y: 500, width: 1720, height: 580)
+        )
+        #expect(SoftwareIslandCandidateClassifier.isCandidate(
+            wideVibeWindow, screenFrame: screen, menuBarHeight: 30
+        ))
+
+        let unknownWideWindow = observation(
+            frame: CGRect(x: 100, y: 500, width: 1720, height: 580),
+            bundleIdentifier: "example.unknown"
+        )
+        #expect(!SoftwareIslandCandidateClassifier.isCandidate(
+            unknownWideWindow, screenFrame: screen, menuBarHeight: 30
+        ))
+    }
+
+    @Test func restingRectUsesStableCalibratedWidth() {
+        let rect = SoftwareIslandCandidateClassifier.restingRect(
+            width: 340, screenFrame: screen, menuBarHeight: 30
+        )
+        #expect(rect == CGRect(x: 790, y: 1050, width: 340, height: 30))
+    }
+
+    @Test func restingRectClampsTooNarrowValues() {
+        let rect = SoftwareIslandCandidateClassifier.restingRect(
+            width: 20, screenFrame: screen, menuBarHeight: 30
+        )
+        #expect(rect.width == SoftwareIslandCandidateClassifier.minimumWidth)
+        #expect(rect.midX == screen.midX)
+    }
+
+    @Test func groupingPreservesEveryScreenForOneApp() {
+        let secondScreen = CGRect(x: 1920, y: 0, width: 1920, height: 1080)
+        let detections = [
+            SoftwareIslandDetection(
+                bundleIdentifier: "app.vibeisland.macos",
+                displayName: "Vibe Island",
+                screenFrame: screen,
+                outerWindowFrame: CGRect(x: 620, y: 500, width: 680, height: 580)
+            ),
+            SoftwareIslandDetection(
+                bundleIdentifier: "app.vibeisland.macos",
+                displayName: "Vibe Island",
+                screenFrame: secondScreen,
+                outerWindowFrame: CGRect(x: 2500, y: 480, width: 760, height: 600)
+            ),
+        ]
+
+        let groups = SoftwareIslandDetectionGrouper.group(detections)
+
+        #expect(groups.count == 1)
+        #expect(groups[0].screenFrames == [screen, secondScreen])
+        #expect(groups[0].widestOuterWindowFrame.width == 760)
+    }
+
+    @Test func groupingKeepsDifferentAppsSeparateAndDeterministic() {
+        let detections = [
+            SoftwareIslandDetection(
+                bundleIdentifier: "z.example.island",
+                displayName: "Z Island",
+                screenFrame: screen,
+                outerWindowFrame: CGRect(x: 700, y: 500, width: 520, height: 580)
+            ),
+            SoftwareIslandDetection(
+                bundleIdentifier: "a.example.island",
+                displayName: "A Island",
+                screenFrame: screen,
+                outerWindowFrame: CGRect(x: 760, y: 500, width: 400, height: 580)
+            ),
+        ]
+
+        let groups = SoftwareIslandDetectionGrouper.group(detections)
+
+        #expect(groups.map(\.bundleIdentifier) == ["a.example.island", "z.example.island"])
+    }
+
+}


### PR DESCRIPTION
## Problem

Pelmet currently learns how much menu-bar space is unavailable from the physical camera notch. That works on a notched MacBook because macOS exposes the notch through the screen safe area.

Software islands such as [Vibe Island](https://vibeisland.app/) create the same user-visible obstruction without changing that safe area. On a display with no physical notch, Pelmet therefore assumes the full menu bar is usable while macOS continues packing status items through the top-center overlay. The items still exist, but they can be hidden and unreachable underneath the island.

[![Vibe Island running as a top-center macOS overlay](https://vibeisland.app/images/og.jpg)](https://vibeisland.app/)

<sub>Vibe Island product image from its official website.</sub>

This is especially confusing because Vibe Island changes its visible size. Its resting pill can be user-configured, and hovering opens a much wider transient panel. Treating its outer window bounds as the reserved width makes Pelmet's layout jump during hover; ignoring it entirely leaves icons covered.

The first implementation also exposed a feedback loop: if Pelmet classified its own toggle or divider as covered by the software island, its physical-notch recovery path recreated that control. Recreating a status item makes macOS repack neighboring items, which could move another icon underneath the island and produce the apparently random behavior seen while adjusting the width.

## Solution

This PR introduces software islands as a separate kind of menu-bar obstruction rather than pretending they are physical notches.

- Discover persistent top-center overlay windows from Window Server coordinates, window level, process role, and application metadata. This does not require Screen Recording or Accessibility permission.
- Add a small source-controlled provider registry. Vibe Island is recognized and enabled automatically while running; conservatively detected unknown apps appear for explicit local opt-in instead of being enabled automatically.
- Model a stable, user-adjustable resting width. Pelmet intentionally ignores transient hover expansion so icons and Pelmet controls do not jump whenever the pointer enters the island.
- Classify status-item windows that intersect the resting rectangle as covered, then feed that result into the existing covered count, Shelf, onboarding, and one-click access behavior.
- Keep Pelmet's toggle at a fixed width and keep software-island coverage out of the physical-notch control-recovery path. Pelmet can observe its own control under an overlay without recreating it and perturbing the menu-bar layout.
- Apply width changes continuously during a slider drag, using one cached Window Server discovery snapshot per measurement.
- Track provider launch, quit, hide, unhide, and multi-display placement independently of whether the ordinary icon-count digest changed.
- Keep One-Click Access settings available while its engine is enabled, even if the island app temporarily quits.

## What this does and does not do

Pelmet cannot make macOS reserve the center of the menu bar for another app or reorder another app's status items around that overlay. It can accurately identify which items are covered, expose them through the Shelf, and make its own hide/show behavior obstruction-aware without destabilizing the surrounding layout.

The registry supplies compatibility defaults, not privileged handling. Geometry remains locally adjustable because display scale and provider settings can change the resting width. Candidate identities and local rules stay on the device; this PR does not add them to telemetry.

## Verification

- `swift test`: 225 tests passed across 26 suites.
- Tests cover software-overlay classification, exclusion of Pelmet's own controls from recovery, multi-display grouping, known and unknown candidates, stable resting rectangles, settings persistence, Shelf placement, and fixed-width badge presentation.
- The Release target builds successfully through `Pelmet.xcodeproj`.
- The installed Release bundle was launched on macOS and verified as the active single instance.

Pairs with ismatBabirli/pelmet.xyz#3
